### PR TITLE
chore: use jvm system property for IBM_CREDENTIALS_FILE

### DIFF
--- a/modules/common/src/test/java/com/ibm/cloud/platform_services/test/SdkIntegrationTestBase.java
+++ b/modules/common/src/test/java/com/ibm/cloud/platform_services/test/SdkIntegrationTestBase.java
@@ -15,22 +15,14 @@ package com.ibm.cloud.platform_services.test;
 
 import java.io.File;
 
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.testng.PowerMockTestCase;
 import org.testng.SkipException;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 
-import com.ibm.cloud.sdk.core.util.EnvironmentUtils;
-
 /**
  * This class provides common functionality used by integration tests.
  */
-@PrepareForTest({ EnvironmentUtils.class })
-@PowerMockIgnore({"javax.net.ssl.*", "okhttp3.*", "okio.*"})
-public abstract class SdkIntegrationTestBase extends PowerMockTestCase {
+public abstract class SdkIntegrationTestBase {
 
     // Default behavior is to skip tests, unless we have a valid config file.
     protected boolean skipTests = true;
@@ -65,19 +57,19 @@ public abstract class SdkIntegrationTestBase extends PowerMockTestCase {
      */
     @BeforeClass
     public void setUpConfig() throws Exception, InterruptedException {
-        // Allow the java core to "see" the config file if/when the testcase asks the core to load it.
-        PowerMockito.spy(EnvironmentUtils.class);
-        PowerMockito.when(EnvironmentUtils.getenv("IBM_CREDENTIALS_FILE")).thenReturn(getConfigFilename());
-
-        // Next, determine if the tests within the subclass should be skipped,
+        // Determine if the tests within the subclass should be skipped,
         // based on whether or not the config file exists.
         configFile = new File(getConfigFilename());
         if (!configFile.exists()) {
             skipTests = true;
             System.out.println(
-                    String.format(">>> Configuration file %s not found, skipping tests.", configFile.getCanonicalPath()));
+                    String.format(">>> Configuration file %s not found, skipping tests.",
+                            configFile.getCanonicalPath()));
         } else {
             skipTests = false;
+
+            // Set the system property to point to the config file.
+            System.setProperty("IBM_CREDENTIALS_FILE", getConfigFilename());
         }
     }
 


### PR DESCRIPTION
## PR summary
This PR changes the integration test base class so that it uses System.setProperty() to
set the IBM_CREDENTIALS_FILE variable instead of mocking the EnvironmentUtils class to use
environment variables.

**Fixes:** n/a

## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [x] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?  
<!-- Please describe the current behavior that you are modifying. -->

## What is the new behavior?  
<!-- Please describe the new behavior after your change. -->

## Does this PR introduce a breaking change?    
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->