### PR TITLE
fix(build): disable integration tests in tagged-release builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,14 +21,18 @@ env:
     - MVN_ARGS="--settings build/.travis.settings.xml"
 
 before_install:
+- env | grep TRAVIS
 - sudo apt-get update
 - sudo apt-get install python
 - nvm install 12
 - npm install -g npm@6.x
-- '[ "${TRAVIS_PULL_REQUEST}" == "false" ] && openssl aes-256-cbc -K $encrypted_3058bc69cb40_key -iv $encrypted_3058bc69cb40_iv -in ghost.env.enc -out ghost.env -d || true'
-- '[ "${TRAVIS_PULL_REQUEST}" == "false" ] && openssl aes-256-cbc -K $encrypted_66f264007c0d_key -iv $encrypted_66f264007c0d_iv -in iam_access_groups.env.enc -out iam_access_groups.env -d || true'
-- '[ "${TRAVIS_PULL_REQUEST}" == "false" ] && openssl aes-256-cbc -K $encrypted_94fa7fdf4df9_key -iv $encrypted_94fa7fdf4df9_iv -in global_catalog.env.enc -out global_catalog.env -d || true'
-- '[ "${TRAVIS_PULL_REQUEST}" == "false" ] && openssl aes-256-cbc -K $encrypted_acd9ca9788e3_key -iv $encrypted_acd9ca9788e3_iv -in resource_manager.env.enc -out resource_manager.env -d || true'
+- >-
+      [ -z "${TRAVIS_TAG}" ] && [ "${TRAVIS_PULL_REQUEST}" == "false" ]
+      && openssl aes-256-cbc -K $encrypted_3058bc69cb40_key -iv $encrypted_3058bc69cb40_iv -in ghost.env.enc -out ghost.env -d
+      && openssl aes-256-cbc -K $encrypted_66f264007c0d_key -iv $encrypted_66f264007c0d_iv -in iam_access_groups.env.enc -out iam_access_groups.env -d
+      && openssl aes-256-cbc -K $encrypted_94fa7fdf4df9_key -iv $encrypted_94fa7fdf4df9_iv -in global_catalog.env.enc -out global_catalog.env -d
+      && openssl aes-256-cbc -K $encrypted_acd9ca9788e3_key -iv $encrypted_acd9ca9788e3_iv -in resource_manager.env.enc -out resource_manager.env -d
+      || true
 
 install:
 - curl -s https://codecov.io/bash > $HOME/codecov-bash.sh && chmod +x $HOME/codecov-bash.sh
@@ -36,7 +40,6 @@ install:
 
 # For a tagged build, we'll set the maven artifact version #.
 before_script:
-- echo "TRAVIS_TAG = '${TRAVIS_TAG}'"
 - >-
       [ -n "${TRAVIS_TAG}" ]
       && mvn versions:set -DnewVersion=${TRAVIS_TAG} -DgenerateBackupPoms=false


### PR DESCRIPTION
## PR summary
This PR changes the travis build script so that integration tests will be skipped for
tagged-release builds.   This is reasonable given that our build CI process requires
a clean build/test run in master BEFORE a tag is added to the repo by semantic-release.

**Fixes:** n/a

## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [x] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?  
<!-- Please describe the current behavior that you are modifying. -->

## What is the new behavior?  
<!-- Please describe the new behavior after your change. -->

## Does this PR introduce a breaking change?    
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->