### PR TITLE
chore(build): add openjdk11 to build and prevent javadoc modules issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,11 @@ jobs:
       after_success:
         - build/publishCodeCoverage.sh
 
+    - jdk: openjdk11
+      install: true
+      script:
+        - mvn verify -fae -DskipITs $MVN_ARGS
+
     - stage: Semantic-Release
       install:
         - sudo apt-get install python

--- a/pom.xml
+++ b/pom.xml
@@ -359,6 +359,8 @@
                     <show>public</show>
                     <doctitle>${project.name}, version ${project.version}</doctitle>
                     <footer>IBM Corporation</footer>
+                    <source>8</source>
+                    <detectJavaApiLink>false</detectJavaApiLink>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
## PR summary
This PR brings the following changes:
- OpenJDK 11 is added to the build
- maven-javadoc-plugin setup is modified to prevent failing doc generation while building jdk11

Packages still published compiled on JDK8.


## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## Current vs new behavior  
<!-- Please describe the current behavior that you are modifying and the new behavior. -->

## Does this PR introduce a breaking change?    
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->