### PR TITLE
 feat(Context based Restrictions): add support for the X-Correlation-Id header

### DIFF
--- a/modules/context-based-restrictions/src/main/java/com/ibm/cloud/platform_services/context_based_restrictions/v1/ContextBasedRestrictions.java
+++ b/modules/context-based-restrictions/src/main/java/com/ibm/cloud/platform_services/context_based_restrictions/v1/ContextBasedRestrictions.java
@@ -50,8 +50,8 @@ import java.util.Map.Entry;
 
 /**
  * With the Context Based Restrictions API, you can:
- * * Create, list, get, update, and delete network zones
- * * Create, list, get, update, and delete context-based restriction rules
+ * * Create, list, get, replace, and delete network zones
+ * * Create, list, get, replace, and delete context-based restriction rules
  * * Get account settings
  * .
  *
@@ -100,7 +100,7 @@ public class ContextBasedRestrictions extends BaseService {
   }
 
   /**
-   * Create a zone.
+   * Create a network zone.
    *
    * This operation creates a network zone for the specified account.
    *
@@ -119,6 +119,9 @@ public class ContextBasedRestrictions extends BaseService {
       builder.header(header.getKey(), header.getValue());
     }
     builder.header("Accept", "application/json");
+    if (createZoneOptions.xCorrelationId() != null) {
+      builder.header("X-Correlation-Id", createZoneOptions.xCorrelationId());
+    }
     if (createZoneOptions.transactionId() != null) {
       builder.header("Transaction-Id", createZoneOptions.transactionId());
     }
@@ -147,7 +150,7 @@ public class ContextBasedRestrictions extends BaseService {
   }
 
   /**
-   * Create a zone.
+   * Create a network zone.
    *
    * This operation creates a network zone for the specified account.
    *
@@ -174,6 +177,9 @@ public class ContextBasedRestrictions extends BaseService {
       builder.header(header.getKey(), header.getValue());
     }
     builder.header("Accept", "application/json");
+    if (listZonesOptions.xCorrelationId() != null) {
+      builder.header("X-Correlation-Id", listZonesOptions.xCorrelationId());
+    }
     if (listZonesOptions.transactionId() != null) {
       builder.header("Transaction-Id", listZonesOptions.transactionId());
     }
@@ -190,9 +196,9 @@ public class ContextBasedRestrictions extends BaseService {
   }
 
   /**
-   * Get the specified network zone.
+   * Get a network zone.
    *
-   * This operation returns the network zone for the specified ID.
+   * This operation retrieves the network zone identified by the specified zone ID.
    *
    * @param getZoneOptions the {@link GetZoneOptions} containing the options for the call
    * @return a {@link ServiceCall} with a result of type {@link Zone}
@@ -208,6 +214,9 @@ public class ContextBasedRestrictions extends BaseService {
       builder.header(header.getKey(), header.getValue());
     }
     builder.header("Accept", "application/json");
+    if (getZoneOptions.xCorrelationId() != null) {
+      builder.header("X-Correlation-Id", getZoneOptions.xCorrelationId());
+    }
     if (getZoneOptions.transactionId() != null) {
       builder.header("Transaction-Id", getZoneOptions.transactionId());
     }
@@ -217,9 +226,10 @@ public class ContextBasedRestrictions extends BaseService {
   }
 
   /**
-   * Update the specified network zone.
+   * Replace a network zone.
    *
-   * This operation updates the network zone with the specified ID.
+   * This operation replaces the network zone identified by the specified zone ID. Partial updates are not supported.
+   * The entire network zone object must be replaced.
    *
    * @param replaceZoneOptions the {@link ReplaceZoneOptions} containing the options for the call
    * @return a {@link ServiceCall} with a result of type {@link Zone}
@@ -236,6 +246,9 @@ public class ContextBasedRestrictions extends BaseService {
     }
     builder.header("Accept", "application/json");
     builder.header("If-Match", replaceZoneOptions.ifMatch());
+    if (replaceZoneOptions.xCorrelationId() != null) {
+      builder.header("X-Correlation-Id", replaceZoneOptions.xCorrelationId());
+    }
     if (replaceZoneOptions.transactionId() != null) {
       builder.header("Transaction-Id", replaceZoneOptions.transactionId());
     }
@@ -262,9 +275,9 @@ public class ContextBasedRestrictions extends BaseService {
   }
 
   /**
-   * Delete the specified network zone.
+   * Delete a network zone.
    *
-   * This operation deletes the network zone with the specified home ID.
+   * This operation deletes the network zone identified by the specified zone ID.
    *
    * @param deleteZoneOptions the {@link DeleteZoneOptions} containing the options for the call
    * @return a {@link ServiceCall} with a void result
@@ -278,6 +291,9 @@ public class ContextBasedRestrictions extends BaseService {
     Map<String, String> sdkHeaders = SdkCommon.getSdkHeaders("context_based_restrictions", "v1", "deleteZone");
     for (Entry<String, String> header : sdkHeaders.entrySet()) {
       builder.header(header.getKey(), header.getValue());
+    }
+    if (deleteZoneOptions.xCorrelationId() != null) {
+      builder.header("X-Correlation-Id", deleteZoneOptions.xCorrelationId());
     }
     if (deleteZoneOptions.transactionId() != null) {
       builder.header("Transaction-Id", deleteZoneOptions.transactionId());
@@ -304,6 +320,12 @@ public class ContextBasedRestrictions extends BaseService {
       builder.header(header.getKey(), header.getValue());
     }
     builder.header("Accept", "application/json");
+    if (listAvailableServicerefTargetsOptions.xCorrelationId() != null) {
+      builder.header("X-Correlation-Id", listAvailableServicerefTargetsOptions.xCorrelationId());
+    }
+    if (listAvailableServicerefTargetsOptions.transactionId() != null) {
+      builder.header("Transaction-Id", listAvailableServicerefTargetsOptions.transactionId());
+    }
     if (listAvailableServicerefTargetsOptions.type() != null) {
       builder.query("type", String.valueOf(listAvailableServicerefTargetsOptions.type()));
     }
@@ -343,6 +365,9 @@ public class ContextBasedRestrictions extends BaseService {
       builder.header(header.getKey(), header.getValue());
     }
     builder.header("Accept", "application/json");
+    if (createRuleOptions.xCorrelationId() != null) {
+      builder.header("X-Correlation-Id", createRuleOptions.xCorrelationId());
+    }
     if (createRuleOptions.transactionId() != null) {
       builder.header("Transaction-Id", createRuleOptions.transactionId());
     }
@@ -378,7 +403,7 @@ public class ContextBasedRestrictions extends BaseService {
   /**
    * List rules.
    *
-   * This operation lists rules for the specified account.
+   * This operation lists rules in the specified account.
    *
    * @param listRulesOptions the {@link ListRulesOptions} containing the options for the call
    * @return a {@link ServiceCall} with a result of type {@link RuleList}
@@ -392,6 +417,9 @@ public class ContextBasedRestrictions extends BaseService {
       builder.header(header.getKey(), header.getValue());
     }
     builder.header("Accept", "application/json");
+    if (listRulesOptions.xCorrelationId() != null) {
+      builder.header("X-Correlation-Id", listRulesOptions.xCorrelationId());
+    }
     if (listRulesOptions.transactionId() != null) {
       builder.header("Transaction-Id", listRulesOptions.transactionId());
     }
@@ -426,9 +454,9 @@ public class ContextBasedRestrictions extends BaseService {
   }
 
   /**
-   * Get the specified rule.
+   * Get a rule.
    *
-   * This operation gets the rule for the specified ID.
+   * This operation retrieves the rule identified by the specified rule ID.
    *
    * @param getRuleOptions the {@link GetRuleOptions} containing the options for the call
    * @return a {@link ServiceCall} with a result of type {@link Rule}
@@ -444,6 +472,9 @@ public class ContextBasedRestrictions extends BaseService {
       builder.header(header.getKey(), header.getValue());
     }
     builder.header("Accept", "application/json");
+    if (getRuleOptions.xCorrelationId() != null) {
+      builder.header("X-Correlation-Id", getRuleOptions.xCorrelationId());
+    }
     if (getRuleOptions.transactionId() != null) {
       builder.header("Transaction-Id", getRuleOptions.transactionId());
     }
@@ -453,9 +484,10 @@ public class ContextBasedRestrictions extends BaseService {
   }
 
   /**
-   * Update the specified rule.
+   * Replace a rule.
    *
-   * This operation updates the rule for the specified ID.
+   * This operation replaces the rule identified by the specified rule ID. Partial updates are not supported. The entire
+   * rule object must be replaced.
    *
    * @param replaceRuleOptions the {@link ReplaceRuleOptions} containing the options for the call
    * @return a {@link ServiceCall} with a result of type {@link Rule}
@@ -472,6 +504,9 @@ public class ContextBasedRestrictions extends BaseService {
     }
     builder.header("Accept", "application/json");
     builder.header("If-Match", replaceRuleOptions.ifMatch());
+    if (replaceRuleOptions.xCorrelationId() != null) {
+      builder.header("X-Correlation-Id", replaceRuleOptions.xCorrelationId());
+    }
     if (replaceRuleOptions.transactionId() != null) {
       builder.header("Transaction-Id", replaceRuleOptions.transactionId());
     }
@@ -492,9 +527,9 @@ public class ContextBasedRestrictions extends BaseService {
   }
 
   /**
-   * Delete the specified rule.
+   * Delete a rule.
    *
-   * This operation deletes the rule for the specified home ID.
+   * This operation deletes the rule identified by the specified rule ID.
    *
    * @param deleteRuleOptions the {@link DeleteRuleOptions} containing the options for the call
    * @return a {@link ServiceCall} with a void result
@@ -509,6 +544,9 @@ public class ContextBasedRestrictions extends BaseService {
     for (Entry<String, String> header : sdkHeaders.entrySet()) {
       builder.header(header.getKey(), header.getValue());
     }
+    if (deleteRuleOptions.xCorrelationId() != null) {
+      builder.header("X-Correlation-Id", deleteRuleOptions.xCorrelationId());
+    }
     if (deleteRuleOptions.transactionId() != null) {
       builder.header("Transaction-Id", deleteRuleOptions.transactionId());
     }
@@ -517,9 +555,9 @@ public class ContextBasedRestrictions extends BaseService {
   }
 
   /**
-   * Get the specified account settings.
+   * Get account settings.
    *
-   * This operation gets the settings for the specified account ID.
+   * This operation retrieves the settings for the specified account ID.
    *
    * @param getAccountSettingsOptions the {@link GetAccountSettingsOptions} containing the options for the call
    * @return a {@link ServiceCall} with a result of type {@link AccountSettings}
@@ -535,6 +573,9 @@ public class ContextBasedRestrictions extends BaseService {
       builder.header(header.getKey(), header.getValue());
     }
     builder.header("Accept", "application/json");
+    if (getAccountSettingsOptions.xCorrelationId() != null) {
+      builder.header("X-Correlation-Id", getAccountSettingsOptions.xCorrelationId());
+    }
     if (getAccountSettingsOptions.transactionId() != null) {
       builder.header("Transaction-Id", getAccountSettingsOptions.transactionId());
     }

--- a/modules/context-based-restrictions/src/main/java/com/ibm/cloud/platform_services/context_based_restrictions/v1/model/CreateRuleOptions.java
+++ b/modules/context-based-restrictions/src/main/java/com/ibm/cloud/platform_services/context_based_restrictions/v1/model/CreateRuleOptions.java
@@ -25,6 +25,7 @@ public class CreateRuleOptions extends GenericModel {
   protected String description;
   protected List<RuleContext> contexts;
   protected List<Resource> resources;
+  protected String xCorrelationId;
   protected String transactionId;
 
   /**
@@ -34,12 +35,14 @@ public class CreateRuleOptions extends GenericModel {
     private String description;
     private List<RuleContext> contexts;
     private List<Resource> resources;
+    private String xCorrelationId;
     private String transactionId;
 
     private Builder(CreateRuleOptions createRuleOptions) {
       this.description = createRuleOptions.description;
       this.contexts = createRuleOptions.contexts;
       this.resources = createRuleOptions.resources;
+      this.xCorrelationId = createRuleOptions.xCorrelationId;
       this.transactionId = createRuleOptions.transactionId;
     }
 
@@ -126,6 +129,17 @@ public class CreateRuleOptions extends GenericModel {
     }
 
     /**
+     * Set the xCorrelationId.
+     *
+     * @param xCorrelationId the xCorrelationId
+     * @return the CreateRuleOptions builder
+     */
+    public Builder xCorrelationId(String xCorrelationId) {
+      this.xCorrelationId = xCorrelationId;
+      return this;
+    }
+
+    /**
      * Set the transactionId.
      *
      * @param transactionId the transactionId
@@ -141,6 +155,7 @@ public class CreateRuleOptions extends GenericModel {
     description = builder.description;
     contexts = builder.contexts;
     resources = builder.resources;
+    xCorrelationId = builder.xCorrelationId;
     transactionId = builder.transactionId;
   }
 
@@ -187,12 +202,24 @@ public class CreateRuleOptions extends GenericModel {
   }
 
   /**
+   * Gets the xCorrelationId.
+   *
+   * The supplied or generated value of this header is logged for a request and repeated in a response header for the
+   * corresponding response. The same value is used for downstream requests and retries of those requests. If a value of
+   * this headers is not supplied in a request, the service generates a random (version 4) UUID.
+   *
+   * @return the xCorrelationId
+   */
+  public String xCorrelationId() {
+    return xCorrelationId;
+  }
+
+  /**
    * Gets the transactionId.
    *
-   * The UUID that is used to correlate and track transactions. If you omit this field, the service generates and sends
-   * a transaction ID in the response.
-   * **Note:** To help with debugging, we strongly recommend that you generate and supply a `Transaction-Id` with each
-   * request.
+   * The `Transaction-Id` header behaves as the `X-Correlation-Id` header. It is supported for backward compatibility
+   * with other IBM platform services that support the `Transaction-Id` header only. If both `X-Correlation-Id` and
+   * `Transaction-Id` are provided, `X-Correlation-Id` has the precedence over `Transaction-Id`.
    *
    * @return the transactionId
    */

--- a/modules/context-based-restrictions/src/main/java/com/ibm/cloud/platform_services/context_based_restrictions/v1/model/CreateZoneOptions.java
+++ b/modules/context-based-restrictions/src/main/java/com/ibm/cloud/platform_services/context_based_restrictions/v1/model/CreateZoneOptions.java
@@ -27,6 +27,7 @@ public class CreateZoneOptions extends GenericModel {
   protected String description;
   protected List<Address> addresses;
   protected List<Address> excluded;
+  protected String xCorrelationId;
   protected String transactionId;
 
   /**
@@ -38,6 +39,7 @@ public class CreateZoneOptions extends GenericModel {
     private String description;
     private List<Address> addresses;
     private List<Address> excluded;
+    private String xCorrelationId;
     private String transactionId;
 
     private Builder(CreateZoneOptions createZoneOptions) {
@@ -46,6 +48,7 @@ public class CreateZoneOptions extends GenericModel {
       this.description = createZoneOptions.description;
       this.addresses = createZoneOptions.addresses;
       this.excluded = createZoneOptions.excluded;
+      this.xCorrelationId = createZoneOptions.xCorrelationId;
       this.transactionId = createZoneOptions.transactionId;
     }
 
@@ -154,6 +157,17 @@ public class CreateZoneOptions extends GenericModel {
     }
 
     /**
+     * Set the xCorrelationId.
+     *
+     * @param xCorrelationId the xCorrelationId
+     * @return the CreateZoneOptions builder
+     */
+    public Builder xCorrelationId(String xCorrelationId) {
+      this.xCorrelationId = xCorrelationId;
+      return this;
+    }
+
+    /**
      * Set the transactionId.
      *
      * @param transactionId the transactionId
@@ -171,6 +185,7 @@ public class CreateZoneOptions extends GenericModel {
     description = builder.description;
     addresses = builder.addresses;
     excluded = builder.excluded;
+    xCorrelationId = builder.xCorrelationId;
     transactionId = builder.transactionId;
   }
 
@@ -230,7 +245,8 @@ public class CreateZoneOptions extends GenericModel {
   /**
    * Gets the excluded.
    *
-   * The list of excluded addresses in the zone.
+   * The list of excluded addresses in the zone. Only addresses of type `ipAddress`, `ipRange`, and `subnet` can be
+   * excluded.
    *
    * @return the excluded
    */
@@ -239,12 +255,24 @@ public class CreateZoneOptions extends GenericModel {
   }
 
   /**
+   * Gets the xCorrelationId.
+   *
+   * The supplied or generated value of this header is logged for a request and repeated in a response header for the
+   * corresponding response. The same value is used for downstream requests and retries of those requests. If a value of
+   * this headers is not supplied in a request, the service generates a random (version 4) UUID.
+   *
+   * @return the xCorrelationId
+   */
+  public String xCorrelationId() {
+    return xCorrelationId;
+  }
+
+  /**
    * Gets the transactionId.
    *
-   * The UUID that is used to correlate and track transactions. If you omit this field, the service generates and sends
-   * a transaction ID in the response.
-   * **Note:** To help with debugging, we strongly recommend that you generate and supply a `Transaction-Id` with each
-   * request.
+   * The `Transaction-Id` header behaves as the `X-Correlation-Id` header. It is supported for backward compatibility
+   * with other IBM platform services that support the `Transaction-Id` header only. If both `X-Correlation-Id` and
+   * `Transaction-Id` are provided, `X-Correlation-Id` has the precedence over `Transaction-Id`.
    *
    * @return the transactionId
    */

--- a/modules/context-based-restrictions/src/main/java/com/ibm/cloud/platform_services/context_based_restrictions/v1/model/DeleteRuleOptions.java
+++ b/modules/context-based-restrictions/src/main/java/com/ibm/cloud/platform_services/context_based_restrictions/v1/model/DeleteRuleOptions.java
@@ -20,6 +20,7 @@ import com.ibm.cloud.sdk.core.service.model.GenericModel;
 public class DeleteRuleOptions extends GenericModel {
 
   protected String ruleId;
+  protected String xCorrelationId;
   protected String transactionId;
 
   /**
@@ -27,10 +28,12 @@ public class DeleteRuleOptions extends GenericModel {
    */
   public static class Builder {
     private String ruleId;
+    private String xCorrelationId;
     private String transactionId;
 
     private Builder(DeleteRuleOptions deleteRuleOptions) {
       this.ruleId = deleteRuleOptions.ruleId;
+      this.xCorrelationId = deleteRuleOptions.xCorrelationId;
       this.transactionId = deleteRuleOptions.transactionId;
     }
 
@@ -70,6 +73,17 @@ public class DeleteRuleOptions extends GenericModel {
     }
 
     /**
+     * Set the xCorrelationId.
+     *
+     * @param xCorrelationId the xCorrelationId
+     * @return the DeleteRuleOptions builder
+     */
+    public Builder xCorrelationId(String xCorrelationId) {
+      this.xCorrelationId = xCorrelationId;
+      return this;
+    }
+
+    /**
      * Set the transactionId.
      *
      * @param transactionId the transactionId
@@ -85,6 +99,7 @@ public class DeleteRuleOptions extends GenericModel {
     com.ibm.cloud.sdk.core.util.Validator.notEmpty(builder.ruleId,
       "ruleId cannot be empty");
     ruleId = builder.ruleId;
+    xCorrelationId = builder.xCorrelationId;
     transactionId = builder.transactionId;
   }
 
@@ -109,12 +124,24 @@ public class DeleteRuleOptions extends GenericModel {
   }
 
   /**
+   * Gets the xCorrelationId.
+   *
+   * The supplied or generated value of this header is logged for a request and repeated in a response header for the
+   * corresponding response. The same value is used for downstream requests and retries of those requests. If a value of
+   * this headers is not supplied in a request, the service generates a random (version 4) UUID.
+   *
+   * @return the xCorrelationId
+   */
+  public String xCorrelationId() {
+    return xCorrelationId;
+  }
+
+  /**
    * Gets the transactionId.
    *
-   * The UUID that is used to correlate and track transactions. If you omit this field, the service generates and sends
-   * a transaction ID in the response.
-   * **Note:** To help with debugging, we strongly recommend that you generate and supply a `Transaction-Id` with each
-   * request.
+   * The `Transaction-Id` header behaves as the `X-Correlation-Id` header. It is supported for backward compatibility
+   * with other IBM platform services that support the `Transaction-Id` header only. If both `X-Correlation-Id` and
+   * `Transaction-Id` are provided, `X-Correlation-Id` has the precedence over `Transaction-Id`.
    *
    * @return the transactionId
    */

--- a/modules/context-based-restrictions/src/main/java/com/ibm/cloud/platform_services/context_based_restrictions/v1/model/DeleteZoneOptions.java
+++ b/modules/context-based-restrictions/src/main/java/com/ibm/cloud/platform_services/context_based_restrictions/v1/model/DeleteZoneOptions.java
@@ -20,6 +20,7 @@ import com.ibm.cloud.sdk.core.service.model.GenericModel;
 public class DeleteZoneOptions extends GenericModel {
 
   protected String zoneId;
+  protected String xCorrelationId;
   protected String transactionId;
 
   /**
@@ -27,10 +28,12 @@ public class DeleteZoneOptions extends GenericModel {
    */
   public static class Builder {
     private String zoneId;
+    private String xCorrelationId;
     private String transactionId;
 
     private Builder(DeleteZoneOptions deleteZoneOptions) {
       this.zoneId = deleteZoneOptions.zoneId;
+      this.xCorrelationId = deleteZoneOptions.xCorrelationId;
       this.transactionId = deleteZoneOptions.transactionId;
     }
 
@@ -70,6 +73,17 @@ public class DeleteZoneOptions extends GenericModel {
     }
 
     /**
+     * Set the xCorrelationId.
+     *
+     * @param xCorrelationId the xCorrelationId
+     * @return the DeleteZoneOptions builder
+     */
+    public Builder xCorrelationId(String xCorrelationId) {
+      this.xCorrelationId = xCorrelationId;
+      return this;
+    }
+
+    /**
      * Set the transactionId.
      *
      * @param transactionId the transactionId
@@ -85,6 +99,7 @@ public class DeleteZoneOptions extends GenericModel {
     com.ibm.cloud.sdk.core.util.Validator.notEmpty(builder.zoneId,
       "zoneId cannot be empty");
     zoneId = builder.zoneId;
+    xCorrelationId = builder.xCorrelationId;
     transactionId = builder.transactionId;
   }
 
@@ -109,12 +124,24 @@ public class DeleteZoneOptions extends GenericModel {
   }
 
   /**
+   * Gets the xCorrelationId.
+   *
+   * The supplied or generated value of this header is logged for a request and repeated in a response header for the
+   * corresponding response. The same value is used for downstream requests and retries of those requests. If a value of
+   * this headers is not supplied in a request, the service generates a random (version 4) UUID.
+   *
+   * @return the xCorrelationId
+   */
+  public String xCorrelationId() {
+    return xCorrelationId;
+  }
+
+  /**
    * Gets the transactionId.
    *
-   * The UUID that is used to correlate and track transactions. If you omit this field, the service generates and sends
-   * a transaction ID in the response.
-   * **Note:** To help with debugging, we strongly recommend that you generate and supply a `Transaction-Id` with each
-   * request.
+   * The `Transaction-Id` header behaves as the `X-Correlation-Id` header. It is supported for backward compatibility
+   * with other IBM platform services that support the `Transaction-Id` header only. If both `X-Correlation-Id` and
+   * `Transaction-Id` are provided, `X-Correlation-Id` has the precedence over `Transaction-Id`.
    *
    * @return the transactionId
    */

--- a/modules/context-based-restrictions/src/main/java/com/ibm/cloud/platform_services/context_based_restrictions/v1/model/GetAccountSettingsOptions.java
+++ b/modules/context-based-restrictions/src/main/java/com/ibm/cloud/platform_services/context_based_restrictions/v1/model/GetAccountSettingsOptions.java
@@ -20,6 +20,7 @@ import com.ibm.cloud.sdk.core.service.model.GenericModel;
 public class GetAccountSettingsOptions extends GenericModel {
 
   protected String accountId;
+  protected String xCorrelationId;
   protected String transactionId;
 
   /**
@@ -27,10 +28,12 @@ public class GetAccountSettingsOptions extends GenericModel {
    */
   public static class Builder {
     private String accountId;
+    private String xCorrelationId;
     private String transactionId;
 
     private Builder(GetAccountSettingsOptions getAccountSettingsOptions) {
       this.accountId = getAccountSettingsOptions.accountId;
+      this.xCorrelationId = getAccountSettingsOptions.xCorrelationId;
       this.transactionId = getAccountSettingsOptions.transactionId;
     }
 
@@ -70,6 +73,17 @@ public class GetAccountSettingsOptions extends GenericModel {
     }
 
     /**
+     * Set the xCorrelationId.
+     *
+     * @param xCorrelationId the xCorrelationId
+     * @return the GetAccountSettingsOptions builder
+     */
+    public Builder xCorrelationId(String xCorrelationId) {
+      this.xCorrelationId = xCorrelationId;
+      return this;
+    }
+
+    /**
      * Set the transactionId.
      *
      * @param transactionId the transactionId
@@ -85,6 +99,7 @@ public class GetAccountSettingsOptions extends GenericModel {
     com.ibm.cloud.sdk.core.util.Validator.notEmpty(builder.accountId,
       "accountId cannot be empty");
     accountId = builder.accountId;
+    xCorrelationId = builder.xCorrelationId;
     transactionId = builder.transactionId;
   }
 
@@ -109,12 +124,24 @@ public class GetAccountSettingsOptions extends GenericModel {
   }
 
   /**
+   * Gets the xCorrelationId.
+   *
+   * The supplied or generated value of this header is logged for a request and repeated in a response header for the
+   * corresponding response. The same value is used for downstream requests and retries of those requests. If a value of
+   * this headers is not supplied in a request, the service generates a random (version 4) UUID.
+   *
+   * @return the xCorrelationId
+   */
+  public String xCorrelationId() {
+    return xCorrelationId;
+  }
+
+  /**
    * Gets the transactionId.
    *
-   * The UUID that is used to correlate and track transactions. If you omit this field, the service generates and sends
-   * a transaction ID in the response.
-   * **Note:** To help with debugging, we strongly recommend that you generate and supply a `Transaction-Id` with each
-   * request.
+   * The `Transaction-Id` header behaves as the `X-Correlation-Id` header. It is supported for backward compatibility
+   * with other IBM platform services that support the `Transaction-Id` header only. If both `X-Correlation-Id` and
+   * `Transaction-Id` are provided, `X-Correlation-Id` has the precedence over `Transaction-Id`.
    *
    * @return the transactionId
    */

--- a/modules/context-based-restrictions/src/main/java/com/ibm/cloud/platform_services/context_based_restrictions/v1/model/GetRuleOptions.java
+++ b/modules/context-based-restrictions/src/main/java/com/ibm/cloud/platform_services/context_based_restrictions/v1/model/GetRuleOptions.java
@@ -20,6 +20,7 @@ import com.ibm.cloud.sdk.core.service.model.GenericModel;
 public class GetRuleOptions extends GenericModel {
 
   protected String ruleId;
+  protected String xCorrelationId;
   protected String transactionId;
 
   /**
@@ -27,10 +28,12 @@ public class GetRuleOptions extends GenericModel {
    */
   public static class Builder {
     private String ruleId;
+    private String xCorrelationId;
     private String transactionId;
 
     private Builder(GetRuleOptions getRuleOptions) {
       this.ruleId = getRuleOptions.ruleId;
+      this.xCorrelationId = getRuleOptions.xCorrelationId;
       this.transactionId = getRuleOptions.transactionId;
     }
 
@@ -70,6 +73,17 @@ public class GetRuleOptions extends GenericModel {
     }
 
     /**
+     * Set the xCorrelationId.
+     *
+     * @param xCorrelationId the xCorrelationId
+     * @return the GetRuleOptions builder
+     */
+    public Builder xCorrelationId(String xCorrelationId) {
+      this.xCorrelationId = xCorrelationId;
+      return this;
+    }
+
+    /**
      * Set the transactionId.
      *
      * @param transactionId the transactionId
@@ -85,6 +99,7 @@ public class GetRuleOptions extends GenericModel {
     com.ibm.cloud.sdk.core.util.Validator.notEmpty(builder.ruleId,
       "ruleId cannot be empty");
     ruleId = builder.ruleId;
+    xCorrelationId = builder.xCorrelationId;
     transactionId = builder.transactionId;
   }
 
@@ -109,12 +124,24 @@ public class GetRuleOptions extends GenericModel {
   }
 
   /**
+   * Gets the xCorrelationId.
+   *
+   * The supplied or generated value of this header is logged for a request and repeated in a response header for the
+   * corresponding response. The same value is used for downstream requests and retries of those requests. If a value of
+   * this headers is not supplied in a request, the service generates a random (version 4) UUID.
+   *
+   * @return the xCorrelationId
+   */
+  public String xCorrelationId() {
+    return xCorrelationId;
+  }
+
+  /**
    * Gets the transactionId.
    *
-   * The UUID that is used to correlate and track transactions. If you omit this field, the service generates and sends
-   * a transaction ID in the response.
-   * **Note:** To help with debugging, we strongly recommend that you generate and supply a `Transaction-Id` with each
-   * request.
+   * The `Transaction-Id` header behaves as the `X-Correlation-Id` header. It is supported for backward compatibility
+   * with other IBM platform services that support the `Transaction-Id` header only. If both `X-Correlation-Id` and
+   * `Transaction-Id` are provided, `X-Correlation-Id` has the precedence over `Transaction-Id`.
    *
    * @return the transactionId
    */

--- a/modules/context-based-restrictions/src/main/java/com/ibm/cloud/platform_services/context_based_restrictions/v1/model/GetZoneOptions.java
+++ b/modules/context-based-restrictions/src/main/java/com/ibm/cloud/platform_services/context_based_restrictions/v1/model/GetZoneOptions.java
@@ -20,6 +20,7 @@ import com.ibm.cloud.sdk.core.service.model.GenericModel;
 public class GetZoneOptions extends GenericModel {
 
   protected String zoneId;
+  protected String xCorrelationId;
   protected String transactionId;
 
   /**
@@ -27,10 +28,12 @@ public class GetZoneOptions extends GenericModel {
    */
   public static class Builder {
     private String zoneId;
+    private String xCorrelationId;
     private String transactionId;
 
     private Builder(GetZoneOptions getZoneOptions) {
       this.zoneId = getZoneOptions.zoneId;
+      this.xCorrelationId = getZoneOptions.xCorrelationId;
       this.transactionId = getZoneOptions.transactionId;
     }
 
@@ -70,6 +73,17 @@ public class GetZoneOptions extends GenericModel {
     }
 
     /**
+     * Set the xCorrelationId.
+     *
+     * @param xCorrelationId the xCorrelationId
+     * @return the GetZoneOptions builder
+     */
+    public Builder xCorrelationId(String xCorrelationId) {
+      this.xCorrelationId = xCorrelationId;
+      return this;
+    }
+
+    /**
      * Set the transactionId.
      *
      * @param transactionId the transactionId
@@ -85,6 +99,7 @@ public class GetZoneOptions extends GenericModel {
     com.ibm.cloud.sdk.core.util.Validator.notEmpty(builder.zoneId,
       "zoneId cannot be empty");
     zoneId = builder.zoneId;
+    xCorrelationId = builder.xCorrelationId;
     transactionId = builder.transactionId;
   }
 
@@ -109,12 +124,24 @@ public class GetZoneOptions extends GenericModel {
   }
 
   /**
+   * Gets the xCorrelationId.
+   *
+   * The supplied or generated value of this header is logged for a request and repeated in a response header for the
+   * corresponding response. The same value is used for downstream requests and retries of those requests. If a value of
+   * this headers is not supplied in a request, the service generates a random (version 4) UUID.
+   *
+   * @return the xCorrelationId
+   */
+  public String xCorrelationId() {
+    return xCorrelationId;
+  }
+
+  /**
    * Gets the transactionId.
    *
-   * The UUID that is used to correlate and track transactions. If you omit this field, the service generates and sends
-   * a transaction ID in the response.
-   * **Note:** To help with debugging, we strongly recommend that you generate and supply a `Transaction-Id` with each
-   * request.
+   * The `Transaction-Id` header behaves as the `X-Correlation-Id` header. It is supported for backward compatibility
+   * with other IBM platform services that support the `Transaction-Id` header only. If both `X-Correlation-Id` and
+   * `Transaction-Id` are provided, `X-Correlation-Id` has the precedence over `Transaction-Id`.
    *
    * @return the transactionId
    */

--- a/modules/context-based-restrictions/src/main/java/com/ibm/cloud/platform_services/context_based_restrictions/v1/model/ListAvailableServicerefTargetsOptions.java
+++ b/modules/context-based-restrictions/src/main/java/com/ibm/cloud/platform_services/context_based_restrictions/v1/model/ListAvailableServicerefTargetsOptions.java
@@ -29,15 +29,21 @@ public class ListAvailableServicerefTargetsOptions extends GenericModel {
     String PLATFORM_SERVICE = "platform_service";
   }
 
+  protected String xCorrelationId;
+  protected String transactionId;
   protected String type;
 
   /**
    * Builder.
    */
   public static class Builder {
+    private String xCorrelationId;
+    private String transactionId;
     private String type;
 
     private Builder(ListAvailableServicerefTargetsOptions listAvailableServicerefTargetsOptions) {
+      this.xCorrelationId = listAvailableServicerefTargetsOptions.xCorrelationId;
+      this.transactionId = listAvailableServicerefTargetsOptions.transactionId;
       this.type = listAvailableServicerefTargetsOptions.type;
     }
 
@@ -57,6 +63,28 @@ public class ListAvailableServicerefTargetsOptions extends GenericModel {
     }
 
     /**
+     * Set the xCorrelationId.
+     *
+     * @param xCorrelationId the xCorrelationId
+     * @return the ListAvailableServicerefTargetsOptions builder
+     */
+    public Builder xCorrelationId(String xCorrelationId) {
+      this.xCorrelationId = xCorrelationId;
+      return this;
+    }
+
+    /**
+     * Set the transactionId.
+     *
+     * @param transactionId the transactionId
+     * @return the ListAvailableServicerefTargetsOptions builder
+     */
+    public Builder transactionId(String transactionId) {
+      this.transactionId = transactionId;
+      return this;
+    }
+
+    /**
      * Set the type.
      *
      * @param type the type
@@ -69,6 +97,8 @@ public class ListAvailableServicerefTargetsOptions extends GenericModel {
   }
 
   protected ListAvailableServicerefTargetsOptions(Builder builder) {
+    xCorrelationId = builder.xCorrelationId;
+    transactionId = builder.transactionId;
     type = builder.type;
   }
 
@@ -79,6 +109,32 @@ public class ListAvailableServicerefTargetsOptions extends GenericModel {
    */
   public Builder newBuilder() {
     return new Builder(this);
+  }
+
+  /**
+   * Gets the xCorrelationId.
+   *
+   * The supplied or generated value of this header is logged for a request and repeated in a response header for the
+   * corresponding response. The same value is used for downstream requests and retries of those requests. If a value of
+   * this headers is not supplied in a request, the service generates a random (version 4) UUID.
+   *
+   * @return the xCorrelationId
+   */
+  public String xCorrelationId() {
+    return xCorrelationId;
+  }
+
+  /**
+   * Gets the transactionId.
+   *
+   * The `Transaction-Id` header behaves as the `X-Correlation-Id` header. It is supported for backward compatibility
+   * with other IBM platform services that support the `Transaction-Id` header only. If both `X-Correlation-Id` and
+   * `Transaction-Id` are provided, `X-Correlation-Id` has the precedence over `Transaction-Id`.
+   *
+   * @return the transactionId
+   */
+  public String transactionId() {
+    return transactionId;
   }
 
   /**

--- a/modules/context-based-restrictions/src/main/java/com/ibm/cloud/platform_services/context_based_restrictions/v1/model/ListRulesOptions.java
+++ b/modules/context-based-restrictions/src/main/java/com/ibm/cloud/platform_services/context_based_restrictions/v1/model/ListRulesOptions.java
@@ -20,6 +20,7 @@ import com.ibm.cloud.sdk.core.service.model.GenericModel;
 public class ListRulesOptions extends GenericModel {
 
   protected String accountId;
+  protected String xCorrelationId;
   protected String transactionId;
   protected String region;
   protected String resource;
@@ -35,6 +36,7 @@ public class ListRulesOptions extends GenericModel {
    */
   public static class Builder {
     private String accountId;
+    private String xCorrelationId;
     private String transactionId;
     private String region;
     private String resource;
@@ -47,6 +49,7 @@ public class ListRulesOptions extends GenericModel {
 
     private Builder(ListRulesOptions listRulesOptions) {
       this.accountId = listRulesOptions.accountId;
+      this.xCorrelationId = listRulesOptions.xCorrelationId;
       this.transactionId = listRulesOptions.transactionId;
       this.region = listRulesOptions.region;
       this.resource = listRulesOptions.resource;
@@ -90,6 +93,17 @@ public class ListRulesOptions extends GenericModel {
      */
     public Builder accountId(String accountId) {
       this.accountId = accountId;
+      return this;
+    }
+
+    /**
+     * Set the xCorrelationId.
+     *
+     * @param xCorrelationId the xCorrelationId
+     * @return the ListRulesOptions builder
+     */
+    public Builder xCorrelationId(String xCorrelationId) {
+      this.xCorrelationId = xCorrelationId;
       return this;
     }
 
@@ -197,6 +211,7 @@ public class ListRulesOptions extends GenericModel {
     com.ibm.cloud.sdk.core.util.Validator.notNull(builder.accountId,
       "accountId cannot be null");
     accountId = builder.accountId;
+    xCorrelationId = builder.xCorrelationId;
     transactionId = builder.transactionId;
     region = builder.region;
     resource = builder.resource;
@@ -229,12 +244,24 @@ public class ListRulesOptions extends GenericModel {
   }
 
   /**
+   * Gets the xCorrelationId.
+   *
+   * The supplied or generated value of this header is logged for a request and repeated in a response header for the
+   * corresponding response. The same value is used for downstream requests and retries of those requests. If a value of
+   * this headers is not supplied in a request, the service generates a random (version 4) UUID.
+   *
+   * @return the xCorrelationId
+   */
+  public String xCorrelationId() {
+    return xCorrelationId;
+  }
+
+  /**
    * Gets the transactionId.
    *
-   * The UUID that is used to correlate and track transactions. If you omit this field, the service generates and sends
-   * a transaction ID in the response.
-   * **Note:** To help with debugging, we strongly recommend that you generate and supply a `Transaction-Id` with each
-   * request.
+   * The `Transaction-Id` header behaves as the `X-Correlation-Id` header. It is supported for backward compatibility
+   * with other IBM platform services that support the `Transaction-Id` header only. If both `X-Correlation-Id` and
+   * `Transaction-Id` are provided, `X-Correlation-Id` has the precedence over `Transaction-Id`.
    *
    * @return the transactionId
    */

--- a/modules/context-based-restrictions/src/main/java/com/ibm/cloud/platform_services/context_based_restrictions/v1/model/ListZonesOptions.java
+++ b/modules/context-based-restrictions/src/main/java/com/ibm/cloud/platform_services/context_based_restrictions/v1/model/ListZonesOptions.java
@@ -20,6 +20,7 @@ import com.ibm.cloud.sdk.core.service.model.GenericModel;
 public class ListZonesOptions extends GenericModel {
 
   protected String accountId;
+  protected String xCorrelationId;
   protected String transactionId;
   protected String name;
   protected String sort;
@@ -29,12 +30,14 @@ public class ListZonesOptions extends GenericModel {
    */
   public static class Builder {
     private String accountId;
+    private String xCorrelationId;
     private String transactionId;
     private String name;
     private String sort;
 
     private Builder(ListZonesOptions listZonesOptions) {
       this.accountId = listZonesOptions.accountId;
+      this.xCorrelationId = listZonesOptions.xCorrelationId;
       this.transactionId = listZonesOptions.transactionId;
       this.name = listZonesOptions.name;
       this.sort = listZonesOptions.sort;
@@ -76,6 +79,17 @@ public class ListZonesOptions extends GenericModel {
     }
 
     /**
+     * Set the xCorrelationId.
+     *
+     * @param xCorrelationId the xCorrelationId
+     * @return the ListZonesOptions builder
+     */
+    public Builder xCorrelationId(String xCorrelationId) {
+      this.xCorrelationId = xCorrelationId;
+      return this;
+    }
+
+    /**
      * Set the transactionId.
      *
      * @param transactionId the transactionId
@@ -113,6 +127,7 @@ public class ListZonesOptions extends GenericModel {
     com.ibm.cloud.sdk.core.util.Validator.notNull(builder.accountId,
       "accountId cannot be null");
     accountId = builder.accountId;
+    xCorrelationId = builder.xCorrelationId;
     transactionId = builder.transactionId;
     name = builder.name;
     sort = builder.sort;
@@ -139,12 +154,24 @@ public class ListZonesOptions extends GenericModel {
   }
 
   /**
+   * Gets the xCorrelationId.
+   *
+   * The supplied or generated value of this header is logged for a request and repeated in a response header for the
+   * corresponding response. The same value is used for downstream requests and retries of those requests. If a value of
+   * this headers is not supplied in a request, the service generates a random (version 4) UUID.
+   *
+   * @return the xCorrelationId
+   */
+  public String xCorrelationId() {
+    return xCorrelationId;
+  }
+
+  /**
    * Gets the transactionId.
    *
-   * The UUID that is used to correlate and track transactions. If you omit this field, the service generates and sends
-   * a transaction ID in the response.
-   * **Note:** To help with debugging, we strongly recommend that you generate and supply a `Transaction-Id` with each
-   * request.
+   * The `Transaction-Id` header behaves as the `X-Correlation-Id` header. It is supported for backward compatibility
+   * with other IBM platform services that support the `Transaction-Id` header only. If both `X-Correlation-Id` and
+   * `Transaction-Id` are provided, `X-Correlation-Id` has the precedence over `Transaction-Id`.
    *
    * @return the transactionId
    */

--- a/modules/context-based-restrictions/src/main/java/com/ibm/cloud/platform_services/context_based_restrictions/v1/model/ReplaceRuleOptions.java
+++ b/modules/context-based-restrictions/src/main/java/com/ibm/cloud/platform_services/context_based_restrictions/v1/model/ReplaceRuleOptions.java
@@ -27,6 +27,7 @@ public class ReplaceRuleOptions extends GenericModel {
   protected String description;
   protected List<RuleContext> contexts;
   protected List<Resource> resources;
+  protected String xCorrelationId;
   protected String transactionId;
 
   /**
@@ -38,6 +39,7 @@ public class ReplaceRuleOptions extends GenericModel {
     private String description;
     private List<RuleContext> contexts;
     private List<Resource> resources;
+    private String xCorrelationId;
     private String transactionId;
 
     private Builder(ReplaceRuleOptions replaceRuleOptions) {
@@ -46,6 +48,7 @@ public class ReplaceRuleOptions extends GenericModel {
       this.description = replaceRuleOptions.description;
       this.contexts = replaceRuleOptions.contexts;
       this.resources = replaceRuleOptions.resources;
+      this.xCorrelationId = replaceRuleOptions.xCorrelationId;
       this.transactionId = replaceRuleOptions.transactionId;
     }
 
@@ -165,6 +168,17 @@ public class ReplaceRuleOptions extends GenericModel {
     }
 
     /**
+     * Set the xCorrelationId.
+     *
+     * @param xCorrelationId the xCorrelationId
+     * @return the ReplaceRuleOptions builder
+     */
+    public Builder xCorrelationId(String xCorrelationId) {
+      this.xCorrelationId = xCorrelationId;
+      return this;
+    }
+
+    /**
      * Set the transactionId.
      *
      * @param transactionId the transactionId
@@ -186,6 +200,7 @@ public class ReplaceRuleOptions extends GenericModel {
     description = builder.description;
     contexts = builder.contexts;
     resources = builder.resources;
+    xCorrelationId = builder.xCorrelationId;
     transactionId = builder.transactionId;
   }
 
@@ -255,12 +270,24 @@ public class ReplaceRuleOptions extends GenericModel {
   }
 
   /**
+   * Gets the xCorrelationId.
+   *
+   * The supplied or generated value of this header is logged for a request and repeated in a response header for the
+   * corresponding response. The same value is used for downstream requests and retries of those requests. If a value of
+   * this headers is not supplied in a request, the service generates a random (version 4) UUID.
+   *
+   * @return the xCorrelationId
+   */
+  public String xCorrelationId() {
+    return xCorrelationId;
+  }
+
+  /**
    * Gets the transactionId.
    *
-   * The UUID that is used to correlate and track transactions. If you omit this field, the service generates and sends
-   * a transaction ID in the response.
-   * **Note:** To help with debugging, we strongly recommend that you generate and supply a `Transaction-Id` with each
-   * request.
+   * The `Transaction-Id` header behaves as the `X-Correlation-Id` header. It is supported for backward compatibility
+   * with other IBM platform services that support the `Transaction-Id` header only. If both `X-Correlation-Id` and
+   * `Transaction-Id` are provided, `X-Correlation-Id` has the precedence over `Transaction-Id`.
    *
    * @return the transactionId
    */

--- a/modules/context-based-restrictions/src/main/java/com/ibm/cloud/platform_services/context_based_restrictions/v1/model/ReplaceZoneOptions.java
+++ b/modules/context-based-restrictions/src/main/java/com/ibm/cloud/platform_services/context_based_restrictions/v1/model/ReplaceZoneOptions.java
@@ -29,6 +29,7 @@ public class ReplaceZoneOptions extends GenericModel {
   protected String description;
   protected List<Address> addresses;
   protected List<Address> excluded;
+  protected String xCorrelationId;
   protected String transactionId;
 
   /**
@@ -42,6 +43,7 @@ public class ReplaceZoneOptions extends GenericModel {
     private String description;
     private List<Address> addresses;
     private List<Address> excluded;
+    private String xCorrelationId;
     private String transactionId;
 
     private Builder(ReplaceZoneOptions replaceZoneOptions) {
@@ -52,6 +54,7 @@ public class ReplaceZoneOptions extends GenericModel {
       this.description = replaceZoneOptions.description;
       this.addresses = replaceZoneOptions.addresses;
       this.excluded = replaceZoneOptions.excluded;
+      this.xCorrelationId = replaceZoneOptions.xCorrelationId;
       this.transactionId = replaceZoneOptions.transactionId;
     }
 
@@ -193,6 +196,17 @@ public class ReplaceZoneOptions extends GenericModel {
     }
 
     /**
+     * Set the xCorrelationId.
+     *
+     * @param xCorrelationId the xCorrelationId
+     * @return the ReplaceZoneOptions builder
+     */
+    public Builder xCorrelationId(String xCorrelationId) {
+      this.xCorrelationId = xCorrelationId;
+      return this;
+    }
+
+    /**
      * Set the transactionId.
      *
      * @param transactionId the transactionId
@@ -216,6 +230,7 @@ public class ReplaceZoneOptions extends GenericModel {
     description = builder.description;
     addresses = builder.addresses;
     excluded = builder.excluded;
+    xCorrelationId = builder.xCorrelationId;
     transactionId = builder.transactionId;
   }
 
@@ -298,7 +313,8 @@ public class ReplaceZoneOptions extends GenericModel {
   /**
    * Gets the excluded.
    *
-   * The list of excluded addresses in the zone.
+   * The list of excluded addresses in the zone. Only addresses of type `ipAddress`, `ipRange`, and `subnet` can be
+   * excluded.
    *
    * @return the excluded
    */
@@ -307,12 +323,24 @@ public class ReplaceZoneOptions extends GenericModel {
   }
 
   /**
+   * Gets the xCorrelationId.
+   *
+   * The supplied or generated value of this header is logged for a request and repeated in a response header for the
+   * corresponding response. The same value is used for downstream requests and retries of those requests. If a value of
+   * this headers is not supplied in a request, the service generates a random (version 4) UUID.
+   *
+   * @return the xCorrelationId
+   */
+  public String xCorrelationId() {
+    return xCorrelationId;
+  }
+
+  /**
    * Gets the transactionId.
    *
-   * The UUID that is used to correlate and track transactions. If you omit this field, the service generates and sends
-   * a transaction ID in the response.
-   * **Note:** To help with debugging, we strongly recommend that you generate and supply a `Transaction-Id` with each
-   * request.
+   * The `Transaction-Id` header behaves as the `X-Correlation-Id` header. It is supported for backward compatibility
+   * with other IBM platform services that support the `Transaction-Id` header only. If both `X-Correlation-Id` and
+   * `Transaction-Id` are provided, `X-Correlation-Id` has the precedence over `Transaction-Id`.
    *
    * @return the transactionId
    */

--- a/modules/context-based-restrictions/src/main/java/com/ibm/cloud/platform_services/context_based_restrictions/v1/model/Zone.java
+++ b/modules/context-based-restrictions/src/main/java/com/ibm/cloud/platform_services/context_based_restrictions/v1/model/Zone.java
@@ -136,7 +136,8 @@ public class Zone extends GenericModel {
   /**
    * Gets the excluded.
    *
-   * The list of excluded addresses in the zone.
+   * The list of excluded addresses in the zone. Only addresses of type `ipAddress`, `ipRange`, and `subnet` can be
+   * excluded.
    *
    * @return the excluded
    */

--- a/modules/context-based-restrictions/src/test/java/com/ibm/cloud/platform_services/context_based_restrictions/v1/ContextBasedRestrictionsIT.java
+++ b/modules/context-based-restrictions/src/test/java/com/ibm/cloud/platform_services/context_based_restrictions/v1/ContextBasedRestrictionsIT.java
@@ -769,7 +769,8 @@ public class ContextBasedRestrictionsIT extends SdkIntegrationTestBase {
         try {
             DeleteZoneOptions deleteZoneOptions = new DeleteZoneOptions.Builder()
                     .zoneId(zoneID)
-                    .transactionId(getTransactionID())
+                    // Using the standard X-Correlation-Id header in this case
+                    .xCorrelationId(getTransactionID())
                     .build();
 
             // Invoke operation

--- a/modules/context-based-restrictions/src/test/java/com/ibm/cloud/platform_services/context_based_restrictions/v1/ContextBasedRestrictionsTest.java
+++ b/modules/context-based-restrictions/src/test/java/com/ibm/cloud/platform_services/context_based_restrictions/v1/ContextBasedRestrictionsTest.java
@@ -137,6 +137,7 @@ public class ContextBasedRestrictionsTest extends PowerMockTestCase {
     .description("this is an example of zone")
     .addresses(new java.util.ArrayList<Address>(java.util.Arrays.asList(addressModel)))
     .excluded(new java.util.ArrayList<Address>(java.util.Arrays.asList(addressModel)))
+    .xCorrelationId("testString")
     .transactionId("testString")
     .build();
 
@@ -176,6 +177,7 @@ public class ContextBasedRestrictionsTest extends PowerMockTestCase {
     // Construct an instance of the ListZonesOptions model
     ListZonesOptions listZonesOptionsModel = new ListZonesOptions.Builder()
     .accountId("testString")
+    .xCorrelationId("testString")
     .transactionId("testString")
     .name("testString")
     .sort("testString")
@@ -232,6 +234,7 @@ public class ContextBasedRestrictionsTest extends PowerMockTestCase {
     // Construct an instance of the GetZoneOptions model
     GetZoneOptions getZoneOptionsModel = new GetZoneOptions.Builder()
     .zoneId("testString")
+    .xCorrelationId("testString")
     .transactionId("testString")
     .build();
 
@@ -295,6 +298,7 @@ public class ContextBasedRestrictionsTest extends PowerMockTestCase {
     .description("this is an example of zone")
     .addresses(new java.util.ArrayList<Address>(java.util.Arrays.asList(addressModel)))
     .excluded(new java.util.ArrayList<Address>(java.util.Arrays.asList(addressModel)))
+    .xCorrelationId("testString")
     .transactionId("testString")
     .build();
 
@@ -346,6 +350,7 @@ public class ContextBasedRestrictionsTest extends PowerMockTestCase {
     // Construct an instance of the DeleteZoneOptions model
     DeleteZoneOptions deleteZoneOptionsModel = new DeleteZoneOptions.Builder()
     .zoneId("testString")
+    .xCorrelationId("testString")
     .transactionId("testString")
     .build();
 
@@ -397,6 +402,8 @@ public class ContextBasedRestrictionsTest extends PowerMockTestCase {
 
     // Construct an instance of the ListAvailableServicerefTargetsOptions model
     ListAvailableServicerefTargetsOptions listAvailableServicerefTargetsOptionsModel = new ListAvailableServicerefTargetsOptions.Builder()
+    .xCorrelationId("testString")
+    .transactionId("testString")
     .type("all")
     .build();
 
@@ -470,6 +477,7 @@ public class ContextBasedRestrictionsTest extends PowerMockTestCase {
     .description("this is an example of rule")
     .contexts(new java.util.ArrayList<RuleContext>(java.util.Arrays.asList(ruleContextModel)))
     .resources(new java.util.ArrayList<Resource>(java.util.Arrays.asList(resourceModel)))
+    .xCorrelationId("testString")
     .transactionId("testString")
     .build();
 
@@ -509,6 +517,7 @@ public class ContextBasedRestrictionsTest extends PowerMockTestCase {
     // Construct an instance of the ListRulesOptions model
     ListRulesOptions listRulesOptionsModel = new ListRulesOptions.Builder()
     .accountId("testString")
+    .xCorrelationId("testString")
     .transactionId("testString")
     .region("testString")
     .resource("testString")
@@ -577,6 +586,7 @@ public class ContextBasedRestrictionsTest extends PowerMockTestCase {
     // Construct an instance of the GetRuleOptions model
     GetRuleOptions getRuleOptionsModel = new GetRuleOptions.Builder()
     .ruleId("testString")
+    .xCorrelationId("testString")
     .transactionId("testString")
     .build();
 
@@ -663,6 +673,7 @@ public class ContextBasedRestrictionsTest extends PowerMockTestCase {
     .description("this is an example of rule")
     .contexts(new java.util.ArrayList<RuleContext>(java.util.Arrays.asList(ruleContextModel)))
     .resources(new java.util.ArrayList<Resource>(java.util.Arrays.asList(resourceModel)))
+    .xCorrelationId("testString")
     .transactionId("testString")
     .build();
 
@@ -714,6 +725,7 @@ public class ContextBasedRestrictionsTest extends PowerMockTestCase {
     // Construct an instance of the DeleteRuleOptions model
     DeleteRuleOptions deleteRuleOptionsModel = new DeleteRuleOptions.Builder()
     .ruleId("testString")
+    .xCorrelationId("testString")
     .transactionId("testString")
     .build();
 
@@ -766,6 +778,7 @@ public class ContextBasedRestrictionsTest extends PowerMockTestCase {
     // Construct an instance of the GetAccountSettingsOptions model
     GetAccountSettingsOptions getAccountSettingsOptionsModel = new GetAccountSettingsOptions.Builder()
     .accountId("testString")
+    .xCorrelationId("testString")
     .transactionId("testString")
     .build();
 

--- a/modules/context-based-restrictions/src/test/java/com/ibm/cloud/platform_services/context_based_restrictions/v1/model/CreateRuleOptionsTest.java
+++ b/modules/context-based-restrictions/src/test/java/com/ibm/cloud/platform_services/context_based_restrictions/v1/model/CreateRuleOptionsTest.java
@@ -79,11 +79,13 @@ public class CreateRuleOptionsTest {
       .description("testString")
       .contexts(new java.util.ArrayList<RuleContext>(java.util.Arrays.asList(ruleContextModel)))
       .resources(new java.util.ArrayList<Resource>(java.util.Arrays.asList(resourceModel)))
+      .xCorrelationId("testString")
       .transactionId("testString")
       .build();
     assertEquals(createRuleOptionsModel.description(), "testString");
     assertEquals(createRuleOptionsModel.contexts(), new java.util.ArrayList<RuleContext>(java.util.Arrays.asList(ruleContextModel)));
     assertEquals(createRuleOptionsModel.resources(), new java.util.ArrayList<Resource>(java.util.Arrays.asList(resourceModel)));
+    assertEquals(createRuleOptionsModel.xCorrelationId(), "testString");
     assertEquals(createRuleOptionsModel.transactionId(), "testString");
   }
 }

--- a/modules/context-based-restrictions/src/test/java/com/ibm/cloud/platform_services/context_based_restrictions/v1/model/CreateZoneOptionsTest.java
+++ b/modules/context-based-restrictions/src/test/java/com/ibm/cloud/platform_services/context_based_restrictions/v1/model/CreateZoneOptionsTest.java
@@ -47,6 +47,7 @@ public class CreateZoneOptionsTest {
       .description("testString")
       .addresses(new java.util.ArrayList<Address>(java.util.Arrays.asList(addressModel)))
       .excluded(new java.util.ArrayList<Address>(java.util.Arrays.asList(addressModel)))
+      .xCorrelationId("testString")
       .transactionId("testString")
       .build();
     assertEquals(createZoneOptionsModel.name(), "testString");
@@ -54,6 +55,7 @@ public class CreateZoneOptionsTest {
     assertEquals(createZoneOptionsModel.description(), "testString");
     assertEquals(createZoneOptionsModel.addresses(), new java.util.ArrayList<Address>(java.util.Arrays.asList(addressModel)));
     assertEquals(createZoneOptionsModel.excluded(), new java.util.ArrayList<Address>(java.util.Arrays.asList(addressModel)));
+    assertEquals(createZoneOptionsModel.xCorrelationId(), "testString");
     assertEquals(createZoneOptionsModel.transactionId(), "testString");
   }
 }

--- a/modules/context-based-restrictions/src/test/java/com/ibm/cloud/platform_services/context_based_restrictions/v1/model/DeleteRuleOptionsTest.java
+++ b/modules/context-based-restrictions/src/test/java/com/ibm/cloud/platform_services/context_based_restrictions/v1/model/DeleteRuleOptionsTest.java
@@ -33,9 +33,11 @@ public class DeleteRuleOptionsTest {
   public void testDeleteRuleOptions() throws Throwable {
     DeleteRuleOptions deleteRuleOptionsModel = new DeleteRuleOptions.Builder()
       .ruleId("testString")
+      .xCorrelationId("testString")
       .transactionId("testString")
       .build();
     assertEquals(deleteRuleOptionsModel.ruleId(), "testString");
+    assertEquals(deleteRuleOptionsModel.xCorrelationId(), "testString");
     assertEquals(deleteRuleOptionsModel.transactionId(), "testString");
   }
 

--- a/modules/context-based-restrictions/src/test/java/com/ibm/cloud/platform_services/context_based_restrictions/v1/model/DeleteZoneOptionsTest.java
+++ b/modules/context-based-restrictions/src/test/java/com/ibm/cloud/platform_services/context_based_restrictions/v1/model/DeleteZoneOptionsTest.java
@@ -33,9 +33,11 @@ public class DeleteZoneOptionsTest {
   public void testDeleteZoneOptions() throws Throwable {
     DeleteZoneOptions deleteZoneOptionsModel = new DeleteZoneOptions.Builder()
       .zoneId("testString")
+      .xCorrelationId("testString")
       .transactionId("testString")
       .build();
     assertEquals(deleteZoneOptionsModel.zoneId(), "testString");
+    assertEquals(deleteZoneOptionsModel.xCorrelationId(), "testString");
     assertEquals(deleteZoneOptionsModel.transactionId(), "testString");
   }
 

--- a/modules/context-based-restrictions/src/test/java/com/ibm/cloud/platform_services/context_based_restrictions/v1/model/GetAccountSettingsOptionsTest.java
+++ b/modules/context-based-restrictions/src/test/java/com/ibm/cloud/platform_services/context_based_restrictions/v1/model/GetAccountSettingsOptionsTest.java
@@ -33,9 +33,11 @@ public class GetAccountSettingsOptionsTest {
   public void testGetAccountSettingsOptions() throws Throwable {
     GetAccountSettingsOptions getAccountSettingsOptionsModel = new GetAccountSettingsOptions.Builder()
       .accountId("testString")
+      .xCorrelationId("testString")
       .transactionId("testString")
       .build();
     assertEquals(getAccountSettingsOptionsModel.accountId(), "testString");
+    assertEquals(getAccountSettingsOptionsModel.xCorrelationId(), "testString");
     assertEquals(getAccountSettingsOptionsModel.transactionId(), "testString");
   }
 

--- a/modules/context-based-restrictions/src/test/java/com/ibm/cloud/platform_services/context_based_restrictions/v1/model/GetRuleOptionsTest.java
+++ b/modules/context-based-restrictions/src/test/java/com/ibm/cloud/platform_services/context_based_restrictions/v1/model/GetRuleOptionsTest.java
@@ -33,9 +33,11 @@ public class GetRuleOptionsTest {
   public void testGetRuleOptions() throws Throwable {
     GetRuleOptions getRuleOptionsModel = new GetRuleOptions.Builder()
       .ruleId("testString")
+      .xCorrelationId("testString")
       .transactionId("testString")
       .build();
     assertEquals(getRuleOptionsModel.ruleId(), "testString");
+    assertEquals(getRuleOptionsModel.xCorrelationId(), "testString");
     assertEquals(getRuleOptionsModel.transactionId(), "testString");
   }
 

--- a/modules/context-based-restrictions/src/test/java/com/ibm/cloud/platform_services/context_based_restrictions/v1/model/GetZoneOptionsTest.java
+++ b/modules/context-based-restrictions/src/test/java/com/ibm/cloud/platform_services/context_based_restrictions/v1/model/GetZoneOptionsTest.java
@@ -33,9 +33,11 @@ public class GetZoneOptionsTest {
   public void testGetZoneOptions() throws Throwable {
     GetZoneOptions getZoneOptionsModel = new GetZoneOptions.Builder()
       .zoneId("testString")
+      .xCorrelationId("testString")
       .transactionId("testString")
       .build();
     assertEquals(getZoneOptionsModel.zoneId(), "testString");
+    assertEquals(getZoneOptionsModel.xCorrelationId(), "testString");
     assertEquals(getZoneOptionsModel.transactionId(), "testString");
   }
 

--- a/modules/context-based-restrictions/src/test/java/com/ibm/cloud/platform_services/context_based_restrictions/v1/model/ListAvailableServicerefTargetsOptionsTest.java
+++ b/modules/context-based-restrictions/src/test/java/com/ibm/cloud/platform_services/context_based_restrictions/v1/model/ListAvailableServicerefTargetsOptionsTest.java
@@ -32,8 +32,12 @@ public class ListAvailableServicerefTargetsOptionsTest {
   @Test
   public void testListAvailableServicerefTargetsOptions() throws Throwable {
     ListAvailableServicerefTargetsOptions listAvailableServicerefTargetsOptionsModel = new ListAvailableServicerefTargetsOptions.Builder()
+      .xCorrelationId("testString")
+      .transactionId("testString")
       .type("all")
       .build();
+    assertEquals(listAvailableServicerefTargetsOptionsModel.xCorrelationId(), "testString");
+    assertEquals(listAvailableServicerefTargetsOptionsModel.transactionId(), "testString");
     assertEquals(listAvailableServicerefTargetsOptionsModel.type(), "all");
   }
 }

--- a/modules/context-based-restrictions/src/test/java/com/ibm/cloud/platform_services/context_based_restrictions/v1/model/ListRulesOptionsTest.java
+++ b/modules/context-based-restrictions/src/test/java/com/ibm/cloud/platform_services/context_based_restrictions/v1/model/ListRulesOptionsTest.java
@@ -33,6 +33,7 @@ public class ListRulesOptionsTest {
   public void testListRulesOptions() throws Throwable {
     ListRulesOptions listRulesOptionsModel = new ListRulesOptions.Builder()
       .accountId("testString")
+      .xCorrelationId("testString")
       .transactionId("testString")
       .region("testString")
       .resource("testString")
@@ -44,6 +45,7 @@ public class ListRulesOptionsTest {
       .sort("testString")
       .build();
     assertEquals(listRulesOptionsModel.accountId(), "testString");
+    assertEquals(listRulesOptionsModel.xCorrelationId(), "testString");
     assertEquals(listRulesOptionsModel.transactionId(), "testString");
     assertEquals(listRulesOptionsModel.region(), "testString");
     assertEquals(listRulesOptionsModel.resource(), "testString");

--- a/modules/context-based-restrictions/src/test/java/com/ibm/cloud/platform_services/context_based_restrictions/v1/model/ListZonesOptionsTest.java
+++ b/modules/context-based-restrictions/src/test/java/com/ibm/cloud/platform_services/context_based_restrictions/v1/model/ListZonesOptionsTest.java
@@ -33,11 +33,13 @@ public class ListZonesOptionsTest {
   public void testListZonesOptions() throws Throwable {
     ListZonesOptions listZonesOptionsModel = new ListZonesOptions.Builder()
       .accountId("testString")
+      .xCorrelationId("testString")
       .transactionId("testString")
       .name("testString")
       .sort("testString")
       .build();
     assertEquals(listZonesOptionsModel.accountId(), "testString");
+    assertEquals(listZonesOptionsModel.xCorrelationId(), "testString");
     assertEquals(listZonesOptionsModel.transactionId(), "testString");
     assertEquals(listZonesOptionsModel.name(), "testString");
     assertEquals(listZonesOptionsModel.sort(), "testString");

--- a/modules/context-based-restrictions/src/test/java/com/ibm/cloud/platform_services/context_based_restrictions/v1/model/ReplaceRuleOptionsTest.java
+++ b/modules/context-based-restrictions/src/test/java/com/ibm/cloud/platform_services/context_based_restrictions/v1/model/ReplaceRuleOptionsTest.java
@@ -81,6 +81,7 @@ public class ReplaceRuleOptionsTest {
       .description("testString")
       .contexts(new java.util.ArrayList<RuleContext>(java.util.Arrays.asList(ruleContextModel)))
       .resources(new java.util.ArrayList<Resource>(java.util.Arrays.asList(resourceModel)))
+      .xCorrelationId("testString")
       .transactionId("testString")
       .build();
     assertEquals(replaceRuleOptionsModel.ruleId(), "testString");
@@ -88,6 +89,7 @@ public class ReplaceRuleOptionsTest {
     assertEquals(replaceRuleOptionsModel.description(), "testString");
     assertEquals(replaceRuleOptionsModel.contexts(), new java.util.ArrayList<RuleContext>(java.util.Arrays.asList(ruleContextModel)));
     assertEquals(replaceRuleOptionsModel.resources(), new java.util.ArrayList<Resource>(java.util.Arrays.asList(resourceModel)));
+    assertEquals(replaceRuleOptionsModel.xCorrelationId(), "testString");
     assertEquals(replaceRuleOptionsModel.transactionId(), "testString");
   }
 

--- a/modules/context-based-restrictions/src/test/java/com/ibm/cloud/platform_services/context_based_restrictions/v1/model/ReplaceZoneOptionsTest.java
+++ b/modules/context-based-restrictions/src/test/java/com/ibm/cloud/platform_services/context_based_restrictions/v1/model/ReplaceZoneOptionsTest.java
@@ -49,6 +49,7 @@ public class ReplaceZoneOptionsTest {
       .description("testString")
       .addresses(new java.util.ArrayList<Address>(java.util.Arrays.asList(addressModel)))
       .excluded(new java.util.ArrayList<Address>(java.util.Arrays.asList(addressModel)))
+      .xCorrelationId("testString")
       .transactionId("testString")
       .build();
     assertEquals(replaceZoneOptionsModel.zoneId(), "testString");
@@ -58,6 +59,7 @@ public class ReplaceZoneOptionsTest {
     assertEquals(replaceZoneOptionsModel.description(), "testString");
     assertEquals(replaceZoneOptionsModel.addresses(), new java.util.ArrayList<Address>(java.util.Arrays.asList(addressModel)));
     assertEquals(replaceZoneOptionsModel.excluded(), new java.util.ArrayList<Address>(java.util.Arrays.asList(addressModel)));
+    assertEquals(replaceZoneOptionsModel.xCorrelationId(), "testString");
     assertEquals(replaceZoneOptionsModel.transactionId(), "testString");
   }
 


### PR DESCRIPTION
Added support for the `X-Correlation-Id` header

## PR summary
- Added support for passing the standard `X-Correlation-Id` header in each request
- Updated some swagger properties summaries and descriptions


## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## Current vs new behavior  
This enhancement adds support for passing the standard `X-Correlation-Id` header in each request. This is an optional header and it does not break backward compatibility. 

## Does this PR introduce a breaking change?    
- [ ] Yes
- [x] No