### PR TITLE
fix: bump java core dependency to get new gson

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- This is the version associated with the Java core. -->
-        <sdk-core-version>9.13.3</sdk-core-version>
+        <sdk-core-version>9.13.4</sdk-core-version>
 
         <testng-version>7.4.0</testng-version>
         <okhttp3-version>4.9.1</okhttp3-version>


### PR DESCRIPTION
## PR summary

This commit updates the java core dependency to 9.13.4
which in turn will use a new version of gson (2.8.9),
which will address a recent security vulnerability.

## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [ ] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## Current vs new behavior  
<!-- Please describe the current behavior that you are modifying and the new behavior. -->

## Does this PR introduce a breaking change?    
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->