### PR TITLE
feat(IAM Identity): add support for inactivity reports

### DIFF
--- a/modules/examples/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/IamIdentityExamples.java
+++ b/modules/examples/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/IamIdentityExamples.java
@@ -28,6 +28,7 @@ import com.ibm.cloud.platform_services.iam_identity.v1.model.CreateClaimRuleOpti
 import com.ibm.cloud.platform_services.iam_identity.v1.model.CreateLinkOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.CreateProfileOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.CreateProfileLinkRequestLink;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.CreateReportOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.CreateServiceIdOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.DeleteApiKeyOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.DeleteClaimRuleOptions;
@@ -40,6 +41,7 @@ import com.ibm.cloud.platform_services.iam_identity.v1.model.GetApiKeysDetailsOp
 import com.ibm.cloud.platform_services.iam_identity.v1.model.GetClaimRuleOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.GetLinkOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.GetProfileOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.GetReportOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.GetServiceIdOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.ListApiKeysOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.ListClaimRulesOptions;
@@ -53,6 +55,8 @@ import com.ibm.cloud.platform_services.iam_identity.v1.model.ProfileClaimRuleCon
 import com.ibm.cloud.platform_services.iam_identity.v1.model.ProfileClaimRuleList;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.ProfileLink;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.ProfileLinkList;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.Report;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.ReportReference;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.ServiceId;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.ServiceIdList;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.TrustedProfile;
@@ -113,6 +117,7 @@ public class IamIdentityExamples {
     private static String claimRuleEtag;
     private static String linkId;
     private static String accountSettingsEtag;
+    private static String reportReferenceValue;
 
     static {
         System.setProperty("IBM_CREDENTIALS_FILE", "../../iam_identity.env");
@@ -204,6 +209,7 @@ public class IamIdentityExamples {
             GetApiKeyOptions getApiKeyOptions = new GetApiKeyOptions.Builder()
                     .id(apikeyId)
                     .includeHistory(true)
+                    .includeActivity(true)
                     .build();
 
             Response<ApiKey> response = service.getApiKey(getApiKeyOptions).execute();
@@ -675,7 +681,7 @@ public class IamIdentityExamples {
             // begin-create_link
 
             CreateProfileLinkRequestLink link = new CreateProfileLinkRequestLink.Builder()
-                    .crn("crn:v1:staging:public:iam-identity::a/18e3020749ce4744b0b472466d61fdb4::computeresource:Fake-Compute-Resource")
+                    .crn("crn:v1:staging:public:iam-identity::a/" + accountId + "::computeresource:Fake-Compute-Resource")
                     .namespace("default")
                     .name("nice name")
                     .build();
@@ -827,6 +833,51 @@ public class IamIdentityExamples {
             System.out.println(accountSettingsResponse);
 
             // end-updateAccountSettings
+
+        } catch (ServiceResponseException e) {
+            logger.error(String.format("Service returned status code %s: %s\nError details: %s",
+                    e.getStatusCode(), e.getMessage(), e.getDebuggingInfo()), e);
+        }
+
+        try {
+            System.out.println("createReport() result:");
+
+            // begin-createReport
+
+            CreateReportOptions createReportOptions = new CreateReportOptions.Builder()
+                    .accountId(accountId)
+                    .build();
+
+            Response<ReportReference> response = service.createReport(createReportOptions).execute();
+            ReportReference reportReference = response.getResult();
+
+            reportReferenceValue = reportReference.getReference();
+
+            System.out.println(reportReferenceValue);
+
+            // end-createReport
+
+        } catch (ServiceResponseException e) {
+            logger.error(String.format("Service returned status code %s: %s\nError details: %s",
+                    e.getStatusCode(), e.getMessage(), e.getDebuggingInfo()), e);
+        }
+
+        try {
+            System.out.println("getReport() result:");
+
+            // begin-getReport
+
+            GetReportOptions getReportOptions = new GetReportOptions.Builder()
+                    .accountId(accountId)
+                    .reference(reportReferenceValue)
+                    .build();
+
+            Response<Report> response = service.getReport(getReportOptions).execute();
+            Report fetchedReport = response.getResult();
+
+            System.out.println(fetchedReport);
+
+            // end-getReport
 
         } catch (ServiceResponseException e) {
             logger.error(String.format("Service returned status code %s: %s\nError details: %s",

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/IamIdentity.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/IamIdentity.java
@@ -85,7 +85,7 @@ public class IamIdentity extends BaseService {
 
   public static final String DEFAULT_SERVICE_NAME = "iam_identity";
 
-  public static final String DEFAULT_SERVICE_URL = "https://iam.test.cloud.ibm.com";
+  public static final String DEFAULT_SERVICE_URL = "https://iam.cloud.ibm.com";
 
  /**
    * Class method which constructs an instance of the `IamIdentity` client.
@@ -1167,8 +1167,8 @@ public class IamIdentity extends BaseService {
     com.ibm.cloud.sdk.core.util.Validator.notNull(createReportOptions,
       "createReportOptions cannot be null");
     Map<String, String> pathParamsMap = new HashMap<String, String>();
-    pathParamsMap.put("account-id", createReportOptions.accountId());
-    RequestBuilder builder = RequestBuilder.post(RequestBuilder.resolveRequestUrl(getServiceUrl(), "/v1/activity/accounts/{account-id}/report", pathParamsMap));
+    pathParamsMap.put("account_id", createReportOptions.accountId());
+    RequestBuilder builder = RequestBuilder.post(RequestBuilder.resolveRequestUrl(getServiceUrl(), "/v1/activity/accounts/{account_id}/report", pathParamsMap));
     Map<String, String> sdkHeaders = SdkCommon.getSdkHeaders("iam_identity", "v1", "createReport");
     for (Entry<String, String> header : sdkHeaders.entrySet()) {
       builder.header(header.getKey(), header.getValue());
@@ -1197,9 +1197,9 @@ public class IamIdentity extends BaseService {
     com.ibm.cloud.sdk.core.util.Validator.notNull(getReportOptions,
       "getReportOptions cannot be null");
     Map<String, String> pathParamsMap = new HashMap<String, String>();
-    pathParamsMap.put("account-id", getReportOptions.accountId());
+    pathParamsMap.put("account_id", getReportOptions.accountId());
     pathParamsMap.put("reference", getReportOptions.reference());
-    RequestBuilder builder = RequestBuilder.get(RequestBuilder.resolveRequestUrl(getServiceUrl(), "/v1/activity/accounts/{account-id}/report/{reference}", pathParamsMap));
+    RequestBuilder builder = RequestBuilder.get(RequestBuilder.resolveRequestUrl(getServiceUrl(), "/v1/activity/accounts/{account_id}/report/{reference}", pathParamsMap));
     Map<String, String> sdkHeaders = SdkCommon.getSdkHeaders("iam_identity", "v1", "getReport");
     for (Entry<String, String> header : sdkHeaders.entrySet()) {
       builder.header(header.getKey(), header.getValue());

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/IamIdentity.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/IamIdentity.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -12,7 +12,7 @@
  */
 
 /*
- * IBM OpenAPI SDK Code Generator Version: 3.37.0-a85661cd-20210802-190136
+ * IBM OpenAPI SDK Code Generator Version: 3.47.0-60650593-20220330-200002
  */
 
 package com.ibm.cloud.platform_services.iam_identity.v1;
@@ -26,6 +26,7 @@ import com.ibm.cloud.platform_services.iam_identity.v1.model.CreateApiKeyOptions
 import com.ibm.cloud.platform_services.iam_identity.v1.model.CreateClaimRuleOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.CreateLinkOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.CreateProfileOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.CreateReportOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.CreateServiceIdOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.DeleteApiKeyOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.DeleteClaimRuleOptions;
@@ -38,6 +39,7 @@ import com.ibm.cloud.platform_services.iam_identity.v1.model.GetApiKeysDetailsOp
 import com.ibm.cloud.platform_services.iam_identity.v1.model.GetClaimRuleOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.GetLinkOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.GetProfileOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.GetReportOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.GetServiceIdOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.ListApiKeysOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.ListClaimRulesOptions;
@@ -50,6 +52,8 @@ import com.ibm.cloud.platform_services.iam_identity.v1.model.ProfileClaimRule;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.ProfileClaimRuleList;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.ProfileLink;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.ProfileLinkList;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.Report;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.ReportReference;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.ServiceId;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.ServiceIdList;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.TrustedProfile;
@@ -75,13 +79,13 @@ import java.util.Map.Entry;
 /**
  * The IAM Identity Service API allows for the management of Account Settings and Identities (Service IDs, ApiKeys).
  *
- * @version v1
+ * API Version: 1.0.0
  */
 public class IamIdentity extends BaseService {
 
   public static final String DEFAULT_SERVICE_NAME = "iam_identity";
 
-  public static final String DEFAULT_SERVICE_URL = "https://iam.cloud.ibm.com";
+  public static final String DEFAULT_SERVICE_URL = "https://iam.test.cloud.ibm.com";
 
  /**
    * Class method which constructs an instance of the `IamIdentity` client.
@@ -295,6 +299,9 @@ public class IamIdentity extends BaseService {
     if (getApiKeyOptions.includeHistory() != null) {
       builder.query("include_history", String.valueOf(getApiKeyOptions.includeHistory()));
     }
+    if (getApiKeyOptions.includeActivity() != null) {
+      builder.query("include_activity", String.valueOf(getApiKeyOptions.includeActivity()));
+    }
     ResponseConverter<ApiKey> responseConverter =
       ResponseConverterUtils.getValue(new com.google.gson.reflect.TypeToken<ApiKey>() { }.getType());
     return createServiceCall(builder.build(), responseConverter);
@@ -412,7 +419,7 @@ public class IamIdentity extends BaseService {
    *
    * Returns a list of service IDs. Users can manage user API keys for themself, or service ID API keys for service IDs
    * that are bound to an entity they have access to. Note: apikey details are only included in the response when
-   * creating a Service ID with an apikey.
+   * creating a Service ID with an api key.
    *
    * @param listServiceIdsOptions the {@link ListServiceIdsOptions} containing the options for the call
    * @return a {@link ServiceCall} with a result of type {@link ServiceIdList}
@@ -458,7 +465,7 @@ public class IamIdentity extends BaseService {
    *
    * Returns a list of service IDs. Users can manage user API keys for themself, or service ID API keys for service IDs
    * that are bound to an entity they have access to. Note: apikey details are only included in the response when
-   * creating a Service ID with an apikey.
+   * creating a Service ID with an api key.
    *
    * @return a {@link ServiceCall} with a result of type {@link ServiceIdList}
    */
@@ -510,7 +517,7 @@ public class IamIdentity extends BaseService {
    *
    * Returns the details of a service ID. Users can manage user API keys for themself, or service ID API keys for
    * service IDs that are bound to an entity they have access to. Note: apikey details are only included in the response
-   * when  creating a Service ID with an apikey.
+   * when  creating a Service ID with an api key.
    *
    * @param getServiceIdOptions the {@link GetServiceIdOptions} containing the options for the call
    * @return a {@link ServiceCall} with a result of type {@link ServiceId}
@@ -528,6 +535,9 @@ public class IamIdentity extends BaseService {
     builder.header("Accept", "application/json");
     if (getServiceIdOptions.includeHistory() != null) {
       builder.query("include_history", String.valueOf(getServiceIdOptions.includeHistory()));
+    }
+    if (getServiceIdOptions.includeActivity() != null) {
+      builder.query("include_activity", String.valueOf(getServiceIdOptions.includeActivity()));
     }
     ResponseConverter<ServiceId> responseConverter =
       ResponseConverterUtils.getValue(new com.google.gson.reflect.TypeToken<ServiceId>() { }.getType());
@@ -739,6 +749,9 @@ public class IamIdentity extends BaseService {
       builder.header(header.getKey(), header.getValue());
     }
     builder.header("Accept", "application/json");
+    if (getProfileOptions.includeActivity() != null) {
+      builder.query("include_activity", String.valueOf(getProfileOptions.includeActivity()));
+    }
     ResponseConverter<TrustedProfile> responseConverter =
       ResponseConverterUtils.getValue(new com.google.gson.reflect.TypeToken<TrustedProfile>() { }.getType());
     return createServiceCall(builder.build(), responseConverter);
@@ -1139,6 +1152,61 @@ public class IamIdentity extends BaseService {
     builder.bodyJson(contentJson);
     ResponseConverter<AccountSettingsResponse> responseConverter =
       ResponseConverterUtils.getValue(new com.google.gson.reflect.TypeToken<AccountSettingsResponse>() { }.getType());
+    return createServiceCall(builder.build(), responseConverter);
+  }
+
+  /**
+   * Trigger activity report across on account scope.
+   *
+   * Trigger activity report across on account scope for a given accountid.
+   *
+   * @param createReportOptions the {@link CreateReportOptions} containing the options for the call
+   * @return a {@link ServiceCall} with a result of type {@link ReportReference}
+   */
+  public ServiceCall<ReportReference> createReport(CreateReportOptions createReportOptions) {
+    com.ibm.cloud.sdk.core.util.Validator.notNull(createReportOptions,
+      "createReportOptions cannot be null");
+    Map<String, String> pathParamsMap = new HashMap<String, String>();
+    pathParamsMap.put("account-id", createReportOptions.accountId());
+    RequestBuilder builder = RequestBuilder.post(RequestBuilder.resolveRequestUrl(getServiceUrl(), "/v1/activity/accounts/{account-id}/report", pathParamsMap));
+    Map<String, String> sdkHeaders = SdkCommon.getSdkHeaders("iam_identity", "v1", "createReport");
+    for (Entry<String, String> header : sdkHeaders.entrySet()) {
+      builder.header(header.getKey(), header.getValue());
+    }
+    builder.header("Accept", "application/json");
+    if (createReportOptions.type() != null) {
+      builder.query("type", String.valueOf(createReportOptions.type()));
+    }
+    if (createReportOptions.duration() != null) {
+      builder.query("duration", String.valueOf(createReportOptions.duration()));
+    }
+    ResponseConverter<ReportReference> responseConverter =
+      ResponseConverterUtils.getValue(new com.google.gson.reflect.TypeToken<ReportReference>() { }.getType());
+    return createServiceCall(builder.build(), responseConverter);
+  }
+
+  /**
+   * Get activity report across on account scope.
+   *
+   * Get activity report across on account scope for a given accountid.
+   *
+   * @param getReportOptions the {@link GetReportOptions} containing the options for the call
+   * @return a {@link ServiceCall} with a result of type {@link Report}
+   */
+  public ServiceCall<Report> getReport(GetReportOptions getReportOptions) {
+    com.ibm.cloud.sdk.core.util.Validator.notNull(getReportOptions,
+      "getReportOptions cannot be null");
+    Map<String, String> pathParamsMap = new HashMap<String, String>();
+    pathParamsMap.put("account-id", getReportOptions.accountId());
+    pathParamsMap.put("reference", getReportOptions.reference());
+    RequestBuilder builder = RequestBuilder.get(RequestBuilder.resolveRequestUrl(getServiceUrl(), "/v1/activity/accounts/{account-id}/report/{reference}", pathParamsMap));
+    Map<String, String> sdkHeaders = SdkCommon.getSdkHeaders("iam_identity", "v1", "getReport");
+    for (Entry<String, String> header : sdkHeaders.entrySet()) {
+      builder.header(header.getKey(), header.getValue());
+    }
+    builder.header("Accept", "application/json");
+    ResponseConverter<Report> responseConverter =
+      ResponseConverterUtils.getValue(new com.google.gson.reflect.TypeToken<Report>() { }.getType());
     return createServiceCall(builder.build(), responseConverter);
   }
 

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/AccountSettingsResponse.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/AccountSettingsResponse.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/Activity.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/Activity.java
@@ -1,0 +1,50 @@
+/*
+ * (C) Copyright IBM Corp. 2022.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import com.google.gson.annotations.SerializedName;
+import com.ibm.cloud.sdk.core.service.model.GenericModel;
+
+/**
+ * Activity.
+ */
+public class Activity extends GenericModel {
+
+  @SerializedName("last_authn")
+  protected String lastAuthn;
+  @SerializedName("authn_count")
+  protected Long authnCount;
+
+  /**
+   * Gets the lastAuthn.
+   *
+   * Time when the entity was last authenticated.
+   *
+   * @return the lastAuthn
+   */
+  public String getLastAuthn() {
+    return lastAuthn;
+  }
+
+  /**
+   * Gets the authnCount.
+   *
+   * Authentication count, number of times the entity was authenticated.
+   *
+   * @return the authnCount
+   */
+  public Long getAuthnCount() {
+    return authnCount;
+  }
+}
+

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ApiKey.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ApiKey.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -43,6 +43,7 @@ public class ApiKey extends GenericModel {
   protected String accountId;
   protected String apikey;
   protected List<EnityHistoryRecord> history;
+  protected Activity activity;
 
   /**
    * Gets the context.
@@ -203,6 +204,15 @@ public class ApiKey extends GenericModel {
    */
   public List<EnityHistoryRecord> getHistory() {
     return history;
+  }
+
+  /**
+   * Gets the activity.
+   *
+   * @return the activity
+   */
+  public Activity getActivity() {
+    return activity;
   }
 }
 

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ApiKeyInsideCreateServiceIdRequest.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ApiKeyInsideCreateServiceIdRequest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ApiKeyList.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ApiKeyList.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/CreateApiKeyOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/CreateApiKeyOptions.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/CreateClaimRuleOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/CreateClaimRuleOptions.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/CreateLinkOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/CreateLinkOptions.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/CreateProfileLinkRequestLink.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/CreateProfileLinkRequestLink.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/CreateProfileOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/CreateProfileOptions.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/CreateReportOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/CreateReportOptions.java
@@ -1,0 +1,149 @@
+/*
+ * (C) Copyright IBM Corp. 2022.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import com.ibm.cloud.sdk.core.service.model.GenericModel;
+
+/**
+ * The createReport options.
+ */
+public class CreateReportOptions extends GenericModel {
+
+  protected String accountId;
+  protected String type;
+  protected String duration;
+
+  /**
+   * Builder.
+   */
+  public static class Builder {
+    private String accountId;
+    private String type;
+    private String duration;
+
+    private Builder(CreateReportOptions createReportOptions) {
+      this.accountId = createReportOptions.accountId;
+      this.type = createReportOptions.type;
+      this.duration = createReportOptions.duration;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public Builder() {
+    }
+
+    /**
+     * Instantiates a new builder with required properties.
+     *
+     * @param accountId the accountId
+     */
+    public Builder(String accountId) {
+      this.accountId = accountId;
+    }
+
+    /**
+     * Builds a CreateReportOptions.
+     *
+     * @return the new CreateReportOptions instance
+     */
+    public CreateReportOptions build() {
+      return new CreateReportOptions(this);
+    }
+
+    /**
+     * Set the accountId.
+     *
+     * @param accountId the accountId
+     * @return the CreateReportOptions builder
+     */
+    public Builder accountId(String accountId) {
+      this.accountId = accountId;
+      return this;
+    }
+
+    /**
+     * Set the type.
+     *
+     * @param type the type
+     * @return the CreateReportOptions builder
+     */
+    public Builder type(String type) {
+      this.type = type;
+      return this;
+    }
+
+    /**
+     * Set the duration.
+     *
+     * @param duration the duration
+     * @return the CreateReportOptions builder
+     */
+    public Builder duration(String duration) {
+      this.duration = duration;
+      return this;
+    }
+  }
+
+  protected CreateReportOptions(Builder builder) {
+    com.ibm.cloud.sdk.core.util.Validator.notEmpty(builder.accountId,
+      "accountId cannot be empty");
+    accountId = builder.accountId;
+    type = builder.type;
+    duration = builder.duration;
+  }
+
+  /**
+   * New builder.
+   *
+   * @return a CreateReportOptions builder
+   */
+  public Builder newBuilder() {
+    return new Builder(this);
+  }
+
+  /**
+   * Gets the accountId.
+   *
+   * ID of the account.
+   *
+   * @return the accountId
+   */
+  public String accountId() {
+    return accountId;
+  }
+
+  /**
+   * Gets the type.
+   *
+   * Optional report type, supported value is 'inactive' - List all identities that have not authenticated within the
+   * time indicated by duration.
+   *
+   * @return the type
+   */
+  public String type() {
+    return type;
+  }
+
+  /**
+   * Gets the duration.
+   *
+   * Optional duration of the report, supported unit of duration is hours.
+   *
+   * @return the duration
+   */
+  public String duration() {
+    return duration;
+  }
+}
+

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/CreateServiceIdOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/CreateServiceIdOptions.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/DeleteApiKeyOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/DeleteApiKeyOptions.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/DeleteClaimRuleOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/DeleteClaimRuleOptions.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/DeleteLinkOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/DeleteLinkOptions.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/DeleteProfileOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/DeleteProfileOptions.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/DeleteServiceIdOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/DeleteServiceIdOptions.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/EnityHistoryRecord.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/EnityHistoryRecord.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/EntityActivity.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/EntityActivity.java
@@ -1,0 +1,61 @@
+/*
+ * (C) Copyright IBM Corp. 2022.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import com.google.gson.annotations.SerializedName;
+import com.ibm.cloud.sdk.core.service.model.GenericModel;
+
+/**
+ * EntityActivity.
+ */
+public class EntityActivity extends GenericModel {
+
+  protected String id;
+  protected String name;
+  @SerializedName("last_authn")
+  protected String lastAuthn;
+
+  /**
+   * Gets the id.
+   *
+   * Unique id of the entity.
+   *
+   * @return the id
+   */
+  public String getId() {
+    return id;
+  }
+
+  /**
+   * Gets the name.
+   *
+   * Name provided during creation of the entity.
+   *
+   * @return the name
+   */
+  public String getName() {
+    return name;
+  }
+
+  /**
+   * Gets the lastAuthn.
+   *
+   * Time when the entity was last authenticated.
+   *
+   * @return the lastAuthn
+   */
+  public String getLastAuthn() {
+    return lastAuthn;
+  }
+}
+

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/GetAccountSettingsOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/GetAccountSettingsOptions.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/GetApiKeyOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/GetApiKeyOptions.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -21,6 +21,7 @@ public class GetApiKeyOptions extends GenericModel {
 
   protected String id;
   protected Boolean includeHistory;
+  protected Boolean includeActivity;
 
   /**
    * Builder.
@@ -28,10 +29,12 @@ public class GetApiKeyOptions extends GenericModel {
   public static class Builder {
     private String id;
     private Boolean includeHistory;
+    private Boolean includeActivity;
 
     private Builder(GetApiKeyOptions getApiKeyOptions) {
       this.id = getApiKeyOptions.id;
       this.includeHistory = getApiKeyOptions.includeHistory;
+      this.includeActivity = getApiKeyOptions.includeActivity;
     }
 
     /**
@@ -79,6 +82,17 @@ public class GetApiKeyOptions extends GenericModel {
       this.includeHistory = includeHistory;
       return this;
     }
+
+    /**
+     * Set the includeActivity.
+     *
+     * @param includeActivity the includeActivity
+     * @return the GetApiKeyOptions builder
+     */
+    public Builder includeActivity(Boolean includeActivity) {
+      this.includeActivity = includeActivity;
+      return this;
+    }
   }
 
   protected GetApiKeyOptions(Builder builder) {
@@ -86,6 +100,7 @@ public class GetApiKeyOptions extends GenericModel {
       "id cannot be empty");
     id = builder.id;
     includeHistory = builder.includeHistory;
+    includeActivity = builder.includeActivity;
   }
 
   /**
@@ -117,6 +132,18 @@ public class GetApiKeyOptions extends GenericModel {
    */
   public Boolean includeHistory() {
     return includeHistory;
+  }
+
+  /**
+   * Gets the includeActivity.
+   *
+   * Defines if the entity's activity is included in the response. Retrieving activity data is an expensive operation,
+   * so please only request this when needed.
+   *
+   * @return the includeActivity
+   */
+  public Boolean includeActivity() {
+    return includeActivity;
   }
 }
 

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/GetApiKeysDetailsOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/GetApiKeysDetailsOptions.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/GetClaimRuleOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/GetClaimRuleOptions.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/GetLinkOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/GetLinkOptions.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/GetProfileOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/GetProfileOptions.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -20,15 +20,18 @@ import com.ibm.cloud.sdk.core.service.model.GenericModel;
 public class GetProfileOptions extends GenericModel {
 
   protected String profileId;
+  protected Boolean includeActivity;
 
   /**
    * Builder.
    */
   public static class Builder {
     private String profileId;
+    private Boolean includeActivity;
 
     private Builder(GetProfileOptions getProfileOptions) {
       this.profileId = getProfileOptions.profileId;
+      this.includeActivity = getProfileOptions.includeActivity;
     }
 
     /**
@@ -65,12 +68,24 @@ public class GetProfileOptions extends GenericModel {
       this.profileId = profileId;
       return this;
     }
+
+    /**
+     * Set the includeActivity.
+     *
+     * @param includeActivity the includeActivity
+     * @return the GetProfileOptions builder
+     */
+    public Builder includeActivity(Boolean includeActivity) {
+      this.includeActivity = includeActivity;
+      return this;
+    }
   }
 
   protected GetProfileOptions(Builder builder) {
     com.ibm.cloud.sdk.core.util.Validator.notEmpty(builder.profileId,
       "profileId cannot be empty");
     profileId = builder.profileId;
+    includeActivity = builder.includeActivity;
   }
 
   /**
@@ -91,6 +106,18 @@ public class GetProfileOptions extends GenericModel {
    */
   public String profileId() {
     return profileId;
+  }
+
+  /**
+   * Gets the includeActivity.
+   *
+   * Defines if the entity's activity is included in the response. Retrieving activity data is an expensive operation,
+   * so please only request this when needed.
+   *
+   * @return the includeActivity
+   */
+  public Boolean includeActivity() {
+    return includeActivity;
   }
 }
 

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/GetReportOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/GetReportOptions.java
@@ -1,0 +1,126 @@
+/*
+ * (C) Copyright IBM Corp. 2022.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import com.ibm.cloud.sdk.core.service.model.GenericModel;
+
+/**
+ * The getReport options.
+ */
+public class GetReportOptions extends GenericModel {
+
+  protected String accountId;
+  protected String reference;
+
+  /**
+   * Builder.
+   */
+  public static class Builder {
+    private String accountId;
+    private String reference;
+
+    private Builder(GetReportOptions getReportOptions) {
+      this.accountId = getReportOptions.accountId;
+      this.reference = getReportOptions.reference;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public Builder() {
+    }
+
+    /**
+     * Instantiates a new builder with required properties.
+     *
+     * @param accountId the accountId
+     * @param reference the reference
+     */
+    public Builder(String accountId, String reference) {
+      this.accountId = accountId;
+      this.reference = reference;
+    }
+
+    /**
+     * Builds a GetReportOptions.
+     *
+     * @return the new GetReportOptions instance
+     */
+    public GetReportOptions build() {
+      return new GetReportOptions(this);
+    }
+
+    /**
+     * Set the accountId.
+     *
+     * @param accountId the accountId
+     * @return the GetReportOptions builder
+     */
+    public Builder accountId(String accountId) {
+      this.accountId = accountId;
+      return this;
+    }
+
+    /**
+     * Set the reference.
+     *
+     * @param reference the reference
+     * @return the GetReportOptions builder
+     */
+    public Builder reference(String reference) {
+      this.reference = reference;
+      return this;
+    }
+  }
+
+  protected GetReportOptions(Builder builder) {
+    com.ibm.cloud.sdk.core.util.Validator.notEmpty(builder.accountId,
+      "accountId cannot be empty");
+    com.ibm.cloud.sdk.core.util.Validator.notEmpty(builder.reference,
+      "reference cannot be empty");
+    accountId = builder.accountId;
+    reference = builder.reference;
+  }
+
+  /**
+   * New builder.
+   *
+   * @return a GetReportOptions builder
+   */
+  public Builder newBuilder() {
+    return new Builder(this);
+  }
+
+  /**
+   * Gets the accountId.
+   *
+   * ID of the account.
+   *
+   * @return the accountId
+   */
+  public String accountId() {
+    return accountId;
+  }
+
+  /**
+   * Gets the reference.
+   *
+   * Reference for the report to be generated, You can use 'latest' to get the latest report for the given account.
+   *
+   * @return the reference
+   */
+  public String reference() {
+    return reference;
+  }
+}
+

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/GetServiceIdOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/GetServiceIdOptions.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -21,6 +21,7 @@ public class GetServiceIdOptions extends GenericModel {
 
   protected String id;
   protected Boolean includeHistory;
+  protected Boolean includeActivity;
 
   /**
    * Builder.
@@ -28,10 +29,12 @@ public class GetServiceIdOptions extends GenericModel {
   public static class Builder {
     private String id;
     private Boolean includeHistory;
+    private Boolean includeActivity;
 
     private Builder(GetServiceIdOptions getServiceIdOptions) {
       this.id = getServiceIdOptions.id;
       this.includeHistory = getServiceIdOptions.includeHistory;
+      this.includeActivity = getServiceIdOptions.includeActivity;
     }
 
     /**
@@ -79,6 +82,17 @@ public class GetServiceIdOptions extends GenericModel {
       this.includeHistory = includeHistory;
       return this;
     }
+
+    /**
+     * Set the includeActivity.
+     *
+     * @param includeActivity the includeActivity
+     * @return the GetServiceIdOptions builder
+     */
+    public Builder includeActivity(Boolean includeActivity) {
+      this.includeActivity = includeActivity;
+      return this;
+    }
   }
 
   protected GetServiceIdOptions(Builder builder) {
@@ -86,6 +100,7 @@ public class GetServiceIdOptions extends GenericModel {
       "id cannot be empty");
     id = builder.id;
     includeHistory = builder.includeHistory;
+    includeActivity = builder.includeActivity;
   }
 
   /**
@@ -117,6 +132,18 @@ public class GetServiceIdOptions extends GenericModel {
    */
   public Boolean includeHistory() {
     return includeHistory;
+  }
+
+  /**
+   * Gets the includeActivity.
+   *
+   * Defines if the entity's activity is included in the response. Retrieving activity data is an expensive operation,
+   * so please only request this when needed.
+   *
+   * @return the includeActivity
+   */
+  public Boolean includeActivity() {
+    return includeActivity;
   }
 }
 

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ListApiKeysOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ListApiKeysOptions.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -20,7 +20,7 @@ import com.ibm.cloud.sdk.core.service.model.GenericModel;
 public class ListApiKeysOptions extends GenericModel {
 
   /**
-   * Optional parameter to define the scope of the queried API Keys. Can be 'entity' (default) or 'account'.
+   * Optional parameter to define the scope of the queried API keys. Can be 'entity' (default) or 'account'.
    */
   public interface Scope {
     /** entity. */
@@ -30,7 +30,7 @@ public class ListApiKeysOptions extends GenericModel {
   }
 
   /**
-   * Optional parameter to filter the type of the queried API Keys. Can be 'user' or 'serviceid'.
+   * Optional parameter to filter the type of the queried API keys. Can be 'user' or 'serviceid'.
    */
   public interface Type {
     /** user. */
@@ -224,7 +224,7 @@ public class ListApiKeysOptions extends GenericModel {
   /**
    * Gets the accountId.
    *
-   * Account ID of the API keys(s) to query. If a service IAM ID is specified in iam_id then account_id must match the
+   * Account ID of the API keys to query. If a service IAM ID is specified in iam_id then account_id must match the
    * account of the IAM ID. If a user IAM ID is specified in iam_id then then account_id must match the account of the
    * Authorization token.
    *
@@ -237,8 +237,8 @@ public class ListApiKeysOptions extends GenericModel {
   /**
    * Gets the iamId.
    *
-   * IAM ID of the API key(s) to be queried. The IAM ID may be that of a user or a service. For a user IAM ID iam_id
-   * must match the Authorization token.
+   * IAM ID of the API keys to be queried. The IAM ID may be that of a user or a service. For a user IAM ID iam_id must
+   * match the Authorization token.
    *
    * @return the iamId
    */
@@ -271,7 +271,7 @@ public class ListApiKeysOptions extends GenericModel {
   /**
    * Gets the scope.
    *
-   * Optional parameter to define the scope of the queried API Keys. Can be 'entity' (default) or 'account'.
+   * Optional parameter to define the scope of the queried API keys. Can be 'entity' (default) or 'account'.
    *
    * @return the scope
    */
@@ -282,7 +282,7 @@ public class ListApiKeysOptions extends GenericModel {
   /**
    * Gets the type.
    *
-   * Optional parameter to filter the type of the queried API Keys. Can be 'user' or 'serviceid'.
+   * Optional parameter to filter the type of the queried API keys. Can be 'user' or 'serviceid'.
    *
    * @return the type
    */

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ListClaimRulesOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ListClaimRulesOptions.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ListLinksOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ListLinksOptions.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ListProfilesOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ListProfilesOptions.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ListServiceIdsOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ListServiceIdsOptions.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/LockApiKeyOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/LockApiKeyOptions.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/LockServiceIdOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/LockServiceIdOptions.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ProfileClaimRule.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ProfileClaimRule.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ProfileClaimRuleConditions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ProfileClaimRuleConditions.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ProfileClaimRuleList.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ProfileClaimRuleList.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ProfileLink.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ProfileLink.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ProfileLinkLink.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ProfileLinkLink.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ProfileLinkList.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ProfileLinkList.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/Report.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/Report.java
@@ -1,0 +1,138 @@
+/*
+ * (C) Copyright IBM Corp. 2022.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import java.util.List;
+
+import com.google.gson.annotations.SerializedName;
+import com.ibm.cloud.sdk.core.service.model.GenericModel;
+
+/**
+ * Report.
+ */
+public class Report extends GenericModel {
+
+  @SerializedName("created_by")
+  protected String createdBy;
+  protected String reference;
+  @SerializedName("report_duration")
+  protected String reportDuration;
+  @SerializedName("report_start_time")
+  protected String reportStartTime;
+  @SerializedName("report_end_time")
+  protected String reportEndTime;
+  protected List<UserActivity> users;
+  protected List<EntityActivity> apikeys;
+  protected List<EntityActivity> serviceids;
+  protected List<EntityActivity> profiles;
+
+  /**
+   * Gets the createdBy.
+   *
+   * IAMid of the user who triggered the report.
+   *
+   * @return the createdBy
+   */
+  public String getCreatedBy() {
+    return createdBy;
+  }
+
+  /**
+   * Gets the reference.
+   *
+   * Unique reference used to generate the report.
+   *
+   * @return the reference
+   */
+  public String getReference() {
+    return reference;
+  }
+
+  /**
+   * Gets the reportDuration.
+   *
+   * Duration in hours for which the report is generated.
+   *
+   * @return the reportDuration
+   */
+  public String getReportDuration() {
+    return reportDuration;
+  }
+
+  /**
+   * Gets the reportStartTime.
+   *
+   * Start time of the report.
+   *
+   * @return the reportStartTime
+   */
+  public String getReportStartTime() {
+    return reportStartTime;
+  }
+
+  /**
+   * Gets the reportEndTime.
+   *
+   * End time of the report.
+   *
+   * @return the reportEndTime
+   */
+  public String getReportEndTime() {
+    return reportEndTime;
+  }
+
+  /**
+   * Gets the users.
+   *
+   * List of users.
+   *
+   * @return the users
+   */
+  public List<UserActivity> getUsers() {
+    return users;
+  }
+
+  /**
+   * Gets the apikeys.
+   *
+   * List of apikeys.
+   *
+   * @return the apikeys
+   */
+  public List<EntityActivity> getApikeys() {
+    return apikeys;
+  }
+
+  /**
+   * Gets the serviceids.
+   *
+   * List of serviceids.
+   *
+   * @return the serviceids
+   */
+  public List<EntityActivity> getServiceids() {
+    return serviceids;
+  }
+
+  /**
+   * Gets the profiles.
+   *
+   * List of profiles.
+   *
+   * @return the profiles
+   */
+  public List<EntityActivity> getProfiles() {
+    return profiles;
+  }
+}
+

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ReportReference.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ReportReference.java
@@ -1,0 +1,35 @@
+/*
+ * (C) Copyright IBM Corp. 2022.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import com.ibm.cloud.sdk.core.service.model.GenericModel;
+
+/**
+ * ReportReference.
+ */
+public class ReportReference extends GenericModel {
+
+  protected String reference;
+
+  /**
+   * Gets the reference.
+   *
+   * Reference for the report to be generated.
+   *
+   * @return the reference
+   */
+  public String getReference() {
+    return reference;
+  }
+}
+

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ResponseContext.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ResponseContext.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ServiceId.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ServiceId.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -43,6 +43,7 @@ public class ServiceId extends GenericModel {
   protected List<String> uniqueInstanceCrns;
   protected List<EnityHistoryRecord> history;
   protected ApiKey apikey;
+  protected Activity activity;
 
   /**
    * Gets the context.
@@ -200,6 +201,15 @@ public class ServiceId extends GenericModel {
    */
   public ApiKey getApikey() {
     return apikey;
+  }
+
+  /**
+   * Gets the activity.
+   *
+   * @return the activity
+   */
+  public Activity getActivity() {
+    return activity;
   }
 }
 

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ServiceIdList.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ServiceIdList.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/TrustedProfile.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/TrustedProfile.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -43,6 +43,7 @@ public class TrustedProfile extends GenericModel {
   @SerializedName("ims_user_id")
   protected Long imsUserId;
   protected List<EnityHistoryRecord> history;
+  protected Activity activity;
 
   /**
    * Gets the context.
@@ -189,6 +190,15 @@ public class TrustedProfile extends GenericModel {
    */
   public List<EnityHistoryRecord> getHistory() {
     return history;
+  }
+
+  /**
+   * Gets the activity.
+   *
+   * @return the activity
+   */
+  public Activity getActivity() {
+    return activity;
   }
 }
 

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/TrustedProfilesList.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/TrustedProfilesList.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/UnlockApiKeyOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/UnlockApiKeyOptions.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/UnlockServiceIdOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/UnlockServiceIdOptions.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/UpdateAccountSettingsOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/UpdateAccountSettingsOptions.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/UpdateApiKeyOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/UpdateApiKeyOptions.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/UpdateClaimRuleOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/UpdateClaimRuleOptions.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/UpdateProfileOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/UpdateProfileOptions.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/UpdateServiceIdOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/UpdateServiceIdOptions.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/UserActivity.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/UserActivity.java
@@ -1,0 +1,62 @@
+/*
+ * (C) Copyright IBM Corp. 2022.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import com.google.gson.annotations.SerializedName;
+import com.ibm.cloud.sdk.core.service.model.GenericModel;
+
+/**
+ * UserActivity.
+ */
+public class UserActivity extends GenericModel {
+
+  @SerializedName("iam_id")
+  protected String iamId;
+  protected String username;
+  @SerializedName("last_authn")
+  protected String lastAuthn;
+
+  /**
+   * Gets the iamId.
+   *
+   * IAMid of the user.
+   *
+   * @return the iamId
+   */
+  public String getIamId() {
+    return iamId;
+  }
+
+  /**
+   * Gets the username.
+   *
+   * Username of the user.
+   *
+   * @return the username
+   */
+  public String getUsername() {
+    return username;
+  }
+
+  /**
+   * Gets the lastAuthn.
+   *
+   * Time when the user was last authenticated.
+   *
+   * @return the lastAuthn
+   */
+  public String getLastAuthn() {
+    return lastAuthn;
+  }
+}
+

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/package-info.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/package-info.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/IamIdentityTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/IamIdentityTest.java
@@ -117,7 +117,7 @@ public class IamIdentityTest extends PowerMockTestCase {
   // Test the listApiKeys operation with a valid options model parameter
   @Test
   public void testListApiKeysWOptions() throws Throwable {
-    // Register a mock response
+    // Schedule some responses.
     String mockResponseBody = "{\"context\": {\"transaction_id\": \"transactionId\", \"operation\": \"operation\", \"user_agent\": \"userAgent\", \"url\": \"url\", \"instance_id\": \"instanceId\", \"thread_id\": \"threadId\", \"host\": \"host\", \"start_time\": \"startTime\", \"end_time\": \"endTime\", \"elapsed_time\": \"elapsedTime\", \"cluster_name\": \"clusterName\"}, \"offset\": 6, \"limit\": 5, \"first\": \"first\", \"previous\": \"previous\", \"next\": \"next\", \"apikeys\": [{\"context\": {\"transaction_id\": \"transactionId\", \"operation\": \"operation\", \"user_agent\": \"userAgent\", \"url\": \"url\", \"instance_id\": \"instanceId\", \"thread_id\": \"threadId\", \"host\": \"host\", \"start_time\": \"startTime\", \"end_time\": \"endTime\", \"elapsed_time\": \"elapsedTime\", \"cluster_name\": \"clusterName\"}, \"id\": \"id\", \"entity_tag\": \"entityTag\", \"crn\": \"crn\", \"locked\": true, \"created_at\": \"2019-01-01T12:00:00.000Z\", \"created_by\": \"createdBy\", \"modified_at\": \"2019-01-01T12:00:00.000Z\", \"name\": \"name\", \"description\": \"description\", \"iam_id\": \"iamId\", \"account_id\": \"accountId\", \"apikey\": \"apikey\", \"history\": [{\"timestamp\": \"timestamp\", \"iam_id\": \"iamId\", \"iam_id_account\": \"iamIdAccount\", \"action\": \"action\", \"params\": [\"params\"], \"message\": \"message\"}], \"activity\": {\"last_authn\": \"lastAuthn\", \"authn_count\": 10}}]}";
     String listApiKeysPath = "/v1/apikeys";
     server.enqueue(new MockResponse()
@@ -178,7 +178,7 @@ public class IamIdentityTest extends PowerMockTestCase {
   // Test the createApiKey operation with a valid options model parameter
   @Test
   public void testCreateApiKeyWOptions() throws Throwable {
-    // Register a mock response
+    // Schedule some responses.
     String mockResponseBody = "{\"context\": {\"transaction_id\": \"transactionId\", \"operation\": \"operation\", \"user_agent\": \"userAgent\", \"url\": \"url\", \"instance_id\": \"instanceId\", \"thread_id\": \"threadId\", \"host\": \"host\", \"start_time\": \"startTime\", \"end_time\": \"endTime\", \"elapsed_time\": \"elapsedTime\", \"cluster_name\": \"clusterName\"}, \"id\": \"id\", \"entity_tag\": \"entityTag\", \"crn\": \"crn\", \"locked\": true, \"created_at\": \"2019-01-01T12:00:00.000Z\", \"created_by\": \"createdBy\", \"modified_at\": \"2019-01-01T12:00:00.000Z\", \"name\": \"name\", \"description\": \"description\", \"iam_id\": \"iamId\", \"account_id\": \"accountId\", \"apikey\": \"apikey\", \"history\": [{\"timestamp\": \"timestamp\", \"iam_id\": \"iamId\", \"iam_id_account\": \"iamIdAccount\", \"action\": \"action\", \"params\": [\"params\"], \"message\": \"message\"}], \"activity\": {\"last_authn\": \"lastAuthn\", \"authn_count\": 10}}";
     String createApiKeyPath = "/v1/apikeys";
     server.enqueue(new MockResponse()
@@ -235,7 +235,7 @@ public class IamIdentityTest extends PowerMockTestCase {
   // Test the getApiKeysDetails operation with a valid options model parameter
   @Test
   public void testGetApiKeysDetailsWOptions() throws Throwable {
-    // Register a mock response
+    // Schedule some responses.
     String mockResponseBody = "{\"context\": {\"transaction_id\": \"transactionId\", \"operation\": \"operation\", \"user_agent\": \"userAgent\", \"url\": \"url\", \"instance_id\": \"instanceId\", \"thread_id\": \"threadId\", \"host\": \"host\", \"start_time\": \"startTime\", \"end_time\": \"endTime\", \"elapsed_time\": \"elapsedTime\", \"cluster_name\": \"clusterName\"}, \"id\": \"id\", \"entity_tag\": \"entityTag\", \"crn\": \"crn\", \"locked\": true, \"created_at\": \"2019-01-01T12:00:00.000Z\", \"created_by\": \"createdBy\", \"modified_at\": \"2019-01-01T12:00:00.000Z\", \"name\": \"name\", \"description\": \"description\", \"iam_id\": \"iamId\", \"account_id\": \"accountId\", \"apikey\": \"apikey\", \"history\": [{\"timestamp\": \"timestamp\", \"iam_id\": \"iamId\", \"iam_id_account\": \"iamIdAccount\", \"action\": \"action\", \"params\": [\"params\"], \"message\": \"message\"}], \"activity\": {\"last_authn\": \"lastAuthn\", \"authn_count\": 10}}";
     String getApiKeysDetailsPath = "/v1/apikeys/details";
     server.enqueue(new MockResponse()
@@ -281,7 +281,7 @@ public class IamIdentityTest extends PowerMockTestCase {
   // Test the getApiKey operation with a valid options model parameter
   @Test
   public void testGetApiKeyWOptions() throws Throwable {
-    // Register a mock response
+    // Schedule some responses.
     String mockResponseBody = "{\"context\": {\"transaction_id\": \"transactionId\", \"operation\": \"operation\", \"user_agent\": \"userAgent\", \"url\": \"url\", \"instance_id\": \"instanceId\", \"thread_id\": \"threadId\", \"host\": \"host\", \"start_time\": \"startTime\", \"end_time\": \"endTime\", \"elapsed_time\": \"elapsedTime\", \"cluster_name\": \"clusterName\"}, \"id\": \"id\", \"entity_tag\": \"entityTag\", \"crn\": \"crn\", \"locked\": true, \"created_at\": \"2019-01-01T12:00:00.000Z\", \"created_by\": \"createdBy\", \"modified_at\": \"2019-01-01T12:00:00.000Z\", \"name\": \"name\", \"description\": \"description\", \"iam_id\": \"iamId\", \"account_id\": \"accountId\", \"apikey\": \"apikey\", \"history\": [{\"timestamp\": \"timestamp\", \"iam_id\": \"iamId\", \"iam_id_account\": \"iamIdAccount\", \"action\": \"action\", \"params\": [\"params\"], \"message\": \"message\"}], \"activity\": {\"last_authn\": \"lastAuthn\", \"authn_count\": 10}}";
     String getApiKeyPath = "/v1/apikeys/testString";
     server.enqueue(new MockResponse()
@@ -291,10 +291,10 @@ public class IamIdentityTest extends PowerMockTestCase {
 
     // Construct an instance of the GetApiKeyOptions model
     GetApiKeyOptions getApiKeyOptionsModel = new GetApiKeyOptions.Builder()
-      .id("testString")
-      .includeHistory(false)
-      .includeActivity(false)
-      .build();
+    .id("testString")
+    .includeHistory(false)
+    .includeActivity(false)
+    .build();
 
     // Invoke getApiKey() with a valid options model and verify the result
     Response<ApiKey> response = iamIdentityService.getApiKey(getApiKeyOptionsModel).execute();
@@ -314,6 +314,9 @@ public class IamIdentityTest extends PowerMockTestCase {
     assertNotNull(query);
     assertEquals(Boolean.valueOf(query.get("include_history")), Boolean.valueOf(false));
     assertEquals(Boolean.valueOf(query.get("include_activity")), Boolean.valueOf(false));
+    // Check request path
+    String parsedPath = TestUtilities.parseReqPath(request);
+    assertEquals(parsedPath, getApiKeyPath);
   }
 
   // Test the getApiKey operation with and without retries enabled
@@ -336,7 +339,7 @@ public class IamIdentityTest extends PowerMockTestCase {
   // Test the updateApiKey operation with a valid options model parameter
   @Test
   public void testUpdateApiKeyWOptions() throws Throwable {
-    // Register a mock response
+    // Schedule some responses.
     String mockResponseBody = "{\"context\": {\"transaction_id\": \"transactionId\", \"operation\": \"operation\", \"user_agent\": \"userAgent\", \"url\": \"url\", \"instance_id\": \"instanceId\", \"thread_id\": \"threadId\", \"host\": \"host\", \"start_time\": \"startTime\", \"end_time\": \"endTime\", \"elapsed_time\": \"elapsedTime\", \"cluster_name\": \"clusterName\"}, \"id\": \"id\", \"entity_tag\": \"entityTag\", \"crn\": \"crn\", \"locked\": true, \"created_at\": \"2019-01-01T12:00:00.000Z\", \"created_by\": \"createdBy\", \"modified_at\": \"2019-01-01T12:00:00.000Z\", \"name\": \"name\", \"description\": \"description\", \"iam_id\": \"iamId\", \"account_id\": \"accountId\", \"apikey\": \"apikey\", \"history\": [{\"timestamp\": \"timestamp\", \"iam_id\": \"iamId\", \"iam_id_account\": \"iamIdAccount\", \"action\": \"action\", \"params\": [\"params\"], \"message\": \"message\"}], \"activity\": {\"last_authn\": \"lastAuthn\", \"authn_count\": 10}}";
     String updateApiKeyPath = "/v1/apikeys/testString";
     server.enqueue(new MockResponse()
@@ -542,7 +545,7 @@ public class IamIdentityTest extends PowerMockTestCase {
   // Test the listServiceIds operation with a valid options model parameter
   @Test
   public void testListServiceIdsWOptions() throws Throwable {
-    // Register a mock response
+    // Schedule some responses.
     String mockResponseBody = "{\"context\": {\"transaction_id\": \"transactionId\", \"operation\": \"operation\", \"user_agent\": \"userAgent\", \"url\": \"url\", \"instance_id\": \"instanceId\", \"thread_id\": \"threadId\", \"host\": \"host\", \"start_time\": \"startTime\", \"end_time\": \"endTime\", \"elapsed_time\": \"elapsedTime\", \"cluster_name\": \"clusterName\"}, \"offset\": 6, \"limit\": 5, \"first\": \"first\", \"previous\": \"previous\", \"next\": \"next\", \"serviceids\": [{\"context\": {\"transaction_id\": \"transactionId\", \"operation\": \"operation\", \"user_agent\": \"userAgent\", \"url\": \"url\", \"instance_id\": \"instanceId\", \"thread_id\": \"threadId\", \"host\": \"host\", \"start_time\": \"startTime\", \"end_time\": \"endTime\", \"elapsed_time\": \"elapsedTime\", \"cluster_name\": \"clusterName\"}, \"id\": \"id\", \"iam_id\": \"iamId\", \"entity_tag\": \"entityTag\", \"crn\": \"crn\", \"locked\": true, \"created_at\": \"2019-01-01T12:00:00.000Z\", \"modified_at\": \"2019-01-01T12:00:00.000Z\", \"account_id\": \"accountId\", \"name\": \"name\", \"description\": \"description\", \"unique_instance_crns\": [\"uniqueInstanceCrns\"], \"history\": [{\"timestamp\": \"timestamp\", \"iam_id\": \"iamId\", \"iam_id_account\": \"iamIdAccount\", \"action\": \"action\", \"params\": [\"params\"], \"message\": \"message\"}], \"apikey\": {\"context\": {\"transaction_id\": \"transactionId\", \"operation\": \"operation\", \"user_agent\": \"userAgent\", \"url\": \"url\", \"instance_id\": \"instanceId\", \"thread_id\": \"threadId\", \"host\": \"host\", \"start_time\": \"startTime\", \"end_time\": \"endTime\", \"elapsed_time\": \"elapsedTime\", \"cluster_name\": \"clusterName\"}, \"id\": \"id\", \"entity_tag\": \"entityTag\", \"crn\": \"crn\", \"locked\": true, \"created_at\": \"2019-01-01T12:00:00.000Z\", \"created_by\": \"createdBy\", \"modified_at\": \"2019-01-01T12:00:00.000Z\", \"name\": \"name\", \"description\": \"description\", \"iam_id\": \"iamId\", \"account_id\": \"accountId\", \"apikey\": \"apikey\", \"history\": [{\"timestamp\": \"timestamp\", \"iam_id\": \"iamId\", \"iam_id_account\": \"iamIdAccount\", \"action\": \"action\", \"params\": [\"params\"], \"message\": \"message\"}], \"activity\": {\"last_authn\": \"lastAuthn\", \"authn_count\": 10}}, \"activity\": {\"last_authn\": \"lastAuthn\", \"authn_count\": 10}}]}";
     String listServiceIdsPath = "/v1/serviceids/";
     server.enqueue(new MockResponse()
@@ -599,7 +602,7 @@ public class IamIdentityTest extends PowerMockTestCase {
   // Test the createServiceId operation with a valid options model parameter
   @Test
   public void testCreateServiceIdWOptions() throws Throwable {
-    // Register a mock response
+    // Schedule some responses.
     String mockResponseBody = "{\"context\": {\"transaction_id\": \"transactionId\", \"operation\": \"operation\", \"user_agent\": \"userAgent\", \"url\": \"url\", \"instance_id\": \"instanceId\", \"thread_id\": \"threadId\", \"host\": \"host\", \"start_time\": \"startTime\", \"end_time\": \"endTime\", \"elapsed_time\": \"elapsedTime\", \"cluster_name\": \"clusterName\"}, \"id\": \"id\", \"iam_id\": \"iamId\", \"entity_tag\": \"entityTag\", \"crn\": \"crn\", \"locked\": true, \"created_at\": \"2019-01-01T12:00:00.000Z\", \"modified_at\": \"2019-01-01T12:00:00.000Z\", \"account_id\": \"accountId\", \"name\": \"name\", \"description\": \"description\", \"unique_instance_crns\": [\"uniqueInstanceCrns\"], \"history\": [{\"timestamp\": \"timestamp\", \"iam_id\": \"iamId\", \"iam_id_account\": \"iamIdAccount\", \"action\": \"action\", \"params\": [\"params\"], \"message\": \"message\"}], \"apikey\": {\"context\": {\"transaction_id\": \"transactionId\", \"operation\": \"operation\", \"user_agent\": \"userAgent\", \"url\": \"url\", \"instance_id\": \"instanceId\", \"thread_id\": \"threadId\", \"host\": \"host\", \"start_time\": \"startTime\", \"end_time\": \"endTime\", \"elapsed_time\": \"elapsedTime\", \"cluster_name\": \"clusterName\"}, \"id\": \"id\", \"entity_tag\": \"entityTag\", \"crn\": \"crn\", \"locked\": true, \"created_at\": \"2019-01-01T12:00:00.000Z\", \"created_by\": \"createdBy\", \"modified_at\": \"2019-01-01T12:00:00.000Z\", \"name\": \"name\", \"description\": \"description\", \"iam_id\": \"iamId\", \"account_id\": \"accountId\", \"apikey\": \"apikey\", \"history\": [{\"timestamp\": \"timestamp\", \"iam_id\": \"iamId\", \"iam_id_account\": \"iamIdAccount\", \"action\": \"action\", \"params\": [\"params\"], \"message\": \"message\"}], \"activity\": {\"last_authn\": \"lastAuthn\", \"authn_count\": 10}}, \"activity\": {\"last_authn\": \"lastAuthn\", \"authn_count\": 10}}";
     String createServiceIdPath = "/v1/serviceids/";
     server.enqueue(new MockResponse()
@@ -663,7 +666,7 @@ public class IamIdentityTest extends PowerMockTestCase {
   // Test the getServiceId operation with a valid options model parameter
   @Test
   public void testGetServiceIdWOptions() throws Throwable {
-    // Register a mock response
+    // Schedule some responses.
     String mockResponseBody = "{\"context\": {\"transaction_id\": \"transactionId\", \"operation\": \"operation\", \"user_agent\": \"userAgent\", \"url\": \"url\", \"instance_id\": \"instanceId\", \"thread_id\": \"threadId\", \"host\": \"host\", \"start_time\": \"startTime\", \"end_time\": \"endTime\", \"elapsed_time\": \"elapsedTime\", \"cluster_name\": \"clusterName\"}, \"id\": \"id\", \"iam_id\": \"iamId\", \"entity_tag\": \"entityTag\", \"crn\": \"crn\", \"locked\": true, \"created_at\": \"2019-01-01T12:00:00.000Z\", \"modified_at\": \"2019-01-01T12:00:00.000Z\", \"account_id\": \"accountId\", \"name\": \"name\", \"description\": \"description\", \"unique_instance_crns\": [\"uniqueInstanceCrns\"], \"history\": [{\"timestamp\": \"timestamp\", \"iam_id\": \"iamId\", \"iam_id_account\": \"iamIdAccount\", \"action\": \"action\", \"params\": [\"params\"], \"message\": \"message\"}], \"apikey\": {\"context\": {\"transaction_id\": \"transactionId\", \"operation\": \"operation\", \"user_agent\": \"userAgent\", \"url\": \"url\", \"instance_id\": \"instanceId\", \"thread_id\": \"threadId\", \"host\": \"host\", \"start_time\": \"startTime\", \"end_time\": \"endTime\", \"elapsed_time\": \"elapsedTime\", \"cluster_name\": \"clusterName\"}, \"id\": \"id\", \"entity_tag\": \"entityTag\", \"crn\": \"crn\", \"locked\": true, \"created_at\": \"2019-01-01T12:00:00.000Z\", \"created_by\": \"createdBy\", \"modified_at\": \"2019-01-01T12:00:00.000Z\", \"name\": \"name\", \"description\": \"description\", \"iam_id\": \"iamId\", \"account_id\": \"accountId\", \"apikey\": \"apikey\", \"history\": [{\"timestamp\": \"timestamp\", \"iam_id\": \"iamId\", \"iam_id_account\": \"iamIdAccount\", \"action\": \"action\", \"params\": [\"params\"], \"message\": \"message\"}], \"activity\": {\"last_authn\": \"lastAuthn\", \"authn_count\": 10}}, \"activity\": {\"last_authn\": \"lastAuthn\", \"authn_count\": 10}}";
     String getServiceIdPath = "/v1/serviceids/testString";
     server.enqueue(new MockResponse()
@@ -673,10 +676,10 @@ public class IamIdentityTest extends PowerMockTestCase {
 
     // Construct an instance of the GetServiceIdOptions model
     GetServiceIdOptions getServiceIdOptionsModel = new GetServiceIdOptions.Builder()
-      .id("testString")
-      .includeHistory(false)
-      .includeActivity(false)
-      .build();
+    .id("testString")
+    .includeHistory(false)
+    .includeActivity(false)
+    .build();
 
     // Invoke getServiceId() with a valid options model and verify the result
     Response<ServiceId> response = iamIdentityService.getServiceId(getServiceIdOptionsModel).execute();
@@ -696,6 +699,9 @@ public class IamIdentityTest extends PowerMockTestCase {
     assertNotNull(query);
     assertEquals(Boolean.valueOf(query.get("include_history")), Boolean.valueOf(false));
     assertEquals(Boolean.valueOf(query.get("include_activity")), Boolean.valueOf(false));
+    // Check request path
+    String parsedPath = TestUtilities.parseReqPath(request);
+    assertEquals(parsedPath, getServiceIdPath);
   }
 
   // Test the getServiceId operation with and without retries enabled
@@ -718,7 +724,7 @@ public class IamIdentityTest extends PowerMockTestCase {
   // Test the updateServiceId operation with a valid options model parameter
   @Test
   public void testUpdateServiceIdWOptions() throws Throwable {
-    // Register a mock response
+    // Schedule some responses.
     String mockResponseBody = "{\"context\": {\"transaction_id\": \"transactionId\", \"operation\": \"operation\", \"user_agent\": \"userAgent\", \"url\": \"url\", \"instance_id\": \"instanceId\", \"thread_id\": \"threadId\", \"host\": \"host\", \"start_time\": \"startTime\", \"end_time\": \"endTime\", \"elapsed_time\": \"elapsedTime\", \"cluster_name\": \"clusterName\"}, \"id\": \"id\", \"iam_id\": \"iamId\", \"entity_tag\": \"entityTag\", \"crn\": \"crn\", \"locked\": true, \"created_at\": \"2019-01-01T12:00:00.000Z\", \"modified_at\": \"2019-01-01T12:00:00.000Z\", \"account_id\": \"accountId\", \"name\": \"name\", \"description\": \"description\", \"unique_instance_crns\": [\"uniqueInstanceCrns\"], \"history\": [{\"timestamp\": \"timestamp\", \"iam_id\": \"iamId\", \"iam_id_account\": \"iamIdAccount\", \"action\": \"action\", \"params\": [\"params\"], \"message\": \"message\"}], \"apikey\": {\"context\": {\"transaction_id\": \"transactionId\", \"operation\": \"operation\", \"user_agent\": \"userAgent\", \"url\": \"url\", \"instance_id\": \"instanceId\", \"thread_id\": \"threadId\", \"host\": \"host\", \"start_time\": \"startTime\", \"end_time\": \"endTime\", \"elapsed_time\": \"elapsedTime\", \"cluster_name\": \"clusterName\"}, \"id\": \"id\", \"entity_tag\": \"entityTag\", \"crn\": \"crn\", \"locked\": true, \"created_at\": \"2019-01-01T12:00:00.000Z\", \"created_by\": \"createdBy\", \"modified_at\": \"2019-01-01T12:00:00.000Z\", \"name\": \"name\", \"description\": \"description\", \"iam_id\": \"iamId\", \"account_id\": \"accountId\", \"apikey\": \"apikey\", \"history\": [{\"timestamp\": \"timestamp\", \"iam_id\": \"iamId\", \"iam_id_account\": \"iamIdAccount\", \"action\": \"action\", \"params\": [\"params\"], \"message\": \"message\"}], \"activity\": {\"last_authn\": \"lastAuthn\", \"authn_count\": 10}}, \"activity\": {\"last_authn\": \"lastAuthn\", \"authn_count\": 10}}";
     String updateServiceIdPath = "/v1/serviceids/testString";
     server.enqueue(new MockResponse()
@@ -925,7 +931,7 @@ public class IamIdentityTest extends PowerMockTestCase {
   // Test the createProfile operation with a valid options model parameter
   @Test
   public void testCreateProfileWOptions() throws Throwable {
-    // Register a mock response
+    // Schedule some responses.
     String mockResponseBody = "{\"context\": {\"transaction_id\": \"transactionId\", \"operation\": \"operation\", \"user_agent\": \"userAgent\", \"url\": \"url\", \"instance_id\": \"instanceId\", \"thread_id\": \"threadId\", \"host\": \"host\", \"start_time\": \"startTime\", \"end_time\": \"endTime\", \"elapsed_time\": \"elapsedTime\", \"cluster_name\": \"clusterName\"}, \"id\": \"id\", \"entity_tag\": \"entityTag\", \"crn\": \"crn\", \"name\": \"name\", \"description\": \"description\", \"created_at\": \"2019-01-01T12:00:00.000Z\", \"modified_at\": \"2019-01-01T12:00:00.000Z\", \"iam_id\": \"iamId\", \"account_id\": \"accountId\", \"ims_account_id\": 12, \"ims_user_id\": 9, \"history\": [{\"timestamp\": \"timestamp\", \"iam_id\": \"iamId\", \"iam_id_account\": \"iamIdAccount\", \"action\": \"action\", \"params\": [\"params\"], \"message\": \"message\"}], \"activity\": {\"last_authn\": \"lastAuthn\", \"authn_count\": 10}}";
     String createProfilePath = "/v1/profiles";
     server.enqueue(new MockResponse()
@@ -978,7 +984,7 @@ public class IamIdentityTest extends PowerMockTestCase {
   // Test the listProfiles operation with a valid options model parameter
   @Test
   public void testListProfilesWOptions() throws Throwable {
-    // Register a mock response
+    // Schedule some responses.
     String mockResponseBody = "{\"context\": {\"transaction_id\": \"transactionId\", \"operation\": \"operation\", \"user_agent\": \"userAgent\", \"url\": \"url\", \"instance_id\": \"instanceId\", \"thread_id\": \"threadId\", \"host\": \"host\", \"start_time\": \"startTime\", \"end_time\": \"endTime\", \"elapsed_time\": \"elapsedTime\", \"cluster_name\": \"clusterName\"}, \"offset\": 6, \"limit\": 5, \"first\": \"first\", \"previous\": \"previous\", \"next\": \"next\", \"profiles\": [{\"context\": {\"transaction_id\": \"transactionId\", \"operation\": \"operation\", \"user_agent\": \"userAgent\", \"url\": \"url\", \"instance_id\": \"instanceId\", \"thread_id\": \"threadId\", \"host\": \"host\", \"start_time\": \"startTime\", \"end_time\": \"endTime\", \"elapsed_time\": \"elapsedTime\", \"cluster_name\": \"clusterName\"}, \"id\": \"id\", \"entity_tag\": \"entityTag\", \"crn\": \"crn\", \"name\": \"name\", \"description\": \"description\", \"created_at\": \"2019-01-01T12:00:00.000Z\", \"modified_at\": \"2019-01-01T12:00:00.000Z\", \"iam_id\": \"iamId\", \"account_id\": \"accountId\", \"ims_account_id\": 12, \"ims_user_id\": 9, \"history\": [{\"timestamp\": \"timestamp\", \"iam_id\": \"iamId\", \"iam_id_account\": \"iamIdAccount\", \"action\": \"action\", \"params\": [\"params\"], \"message\": \"message\"}], \"activity\": {\"last_authn\": \"lastAuthn\", \"authn_count\": 10}}]}";
     String listProfilesPath = "/v1/profiles";
     server.enqueue(new MockResponse()
@@ -1042,7 +1048,7 @@ public class IamIdentityTest extends PowerMockTestCase {
   // Test the getProfile operation with a valid options model parameter
   @Test
   public void testGetProfileWOptions() throws Throwable {
-    // Register a mock response
+    // Schedule some responses.
     String mockResponseBody = "{\"context\": {\"transaction_id\": \"transactionId\", \"operation\": \"operation\", \"user_agent\": \"userAgent\", \"url\": \"url\", \"instance_id\": \"instanceId\", \"thread_id\": \"threadId\", \"host\": \"host\", \"start_time\": \"startTime\", \"end_time\": \"endTime\", \"elapsed_time\": \"elapsedTime\", \"cluster_name\": \"clusterName\"}, \"id\": \"id\", \"entity_tag\": \"entityTag\", \"crn\": \"crn\", \"name\": \"name\", \"description\": \"description\", \"created_at\": \"2019-01-01T12:00:00.000Z\", \"modified_at\": \"2019-01-01T12:00:00.000Z\", \"iam_id\": \"iamId\", \"account_id\": \"accountId\", \"ims_account_id\": 12, \"ims_user_id\": 9, \"history\": [{\"timestamp\": \"timestamp\", \"iam_id\": \"iamId\", \"iam_id_account\": \"iamIdAccount\", \"action\": \"action\", \"params\": [\"params\"], \"message\": \"message\"}], \"activity\": {\"last_authn\": \"lastAuthn\", \"authn_count\": 10}}";
     String getProfilePath = "/v1/profiles/testString";
     server.enqueue(new MockResponse()
@@ -1052,9 +1058,9 @@ public class IamIdentityTest extends PowerMockTestCase {
 
     // Construct an instance of the GetProfileOptions model
     GetProfileOptions getProfileOptionsModel = new GetProfileOptions.Builder()
-      .profileId("testString")
-      .includeActivity(false)
-      .build();
+    .profileId("testString")
+    .includeActivity(false)
+    .build();
 
     // Invoke getProfile() with a valid options model and verify the result
     Response<TrustedProfile> response = iamIdentityService.getProfile(getProfileOptionsModel).execute();
@@ -1066,7 +1072,13 @@ public class IamIdentityTest extends PowerMockTestCase {
     RecordedRequest request = server.takeRequest();
     assertNotNull(request);
     assertEquals(request.getMethod(), "GET");
-    // Verify request path
+
+    // Check query
+    Map<String, String> query = TestUtilities.parseQueryString(request);
+    assertNotNull(query);
+    // Get query params
+    assertEquals(Boolean.valueOf(query.get("include_activity")), Boolean.valueOf(false));
+    // Check request path
     String parsedPath = TestUtilities.parseReqPath(request);
     assertEquals(parsedPath, getProfilePath);
     // Verify query params
@@ -1095,7 +1107,7 @@ public class IamIdentityTest extends PowerMockTestCase {
   // Test the updateProfile operation with a valid options model parameter
   @Test
   public void testUpdateProfileWOptions() throws Throwable {
-    // Register a mock response
+    // Schedule some responses.
     String mockResponseBody = "{\"context\": {\"transaction_id\": \"transactionId\", \"operation\": \"operation\", \"user_agent\": \"userAgent\", \"url\": \"url\", \"instance_id\": \"instanceId\", \"thread_id\": \"threadId\", \"host\": \"host\", \"start_time\": \"startTime\", \"end_time\": \"endTime\", \"elapsed_time\": \"elapsedTime\", \"cluster_name\": \"clusterName\"}, \"id\": \"id\", \"entity_tag\": \"entityTag\", \"crn\": \"crn\", \"name\": \"name\", \"description\": \"description\", \"created_at\": \"2019-01-01T12:00:00.000Z\", \"modified_at\": \"2019-01-01T12:00:00.000Z\", \"iam_id\": \"iamId\", \"account_id\": \"accountId\", \"ims_account_id\": 12, \"ims_user_id\": 9, \"history\": [{\"timestamp\": \"timestamp\", \"iam_id\": \"iamId\", \"iam_id_account\": \"iamIdAccount\", \"action\": \"action\", \"params\": [\"params\"], \"message\": \"message\"}], \"activity\": {\"last_authn\": \"lastAuthn\", \"authn_count\": 10}}";
     String updateProfilePath = "/v1/profiles/testString";
     server.enqueue(new MockResponse()
@@ -1952,7 +1964,112 @@ public class IamIdentityTest extends PowerMockTestCase {
     iamIdentityService.getReport(null).execute();
   }
 
-  // Perform setup needed before each test method
+  @Test
+  public void testCreateReportWOptions() throws Throwable {
+    // Schedule some responses.
+    String mockResponseBody = "{\"reference\": \"reference\"}";
+    String createReportPath = "/v1/activity/accounts/testString/report";
+
+    server.enqueue(new MockResponse()
+    .setHeader("Content-type", "application/json")
+    .setResponseCode(202)
+    .setBody(mockResponseBody));
+
+    constructClientService();
+
+    // Construct an instance of the CreateReportOptions model
+    CreateReportOptions createReportOptionsModel = new CreateReportOptions.Builder()
+    .accountId("testString")
+    .type("inactive")
+    .duration("720")
+    .build();
+
+    // Invoke operation with valid options model (positive test)
+    Response<ReportReference> response = iamIdentityService.createReport(createReportOptionsModel).execute();
+    assertNotNull(response);
+    ReportReference responseObj = response.getResult();
+    assertNotNull(responseObj);
+
+    // Verify the contents of the request
+    RecordedRequest request = server.takeRequest();
+    assertNotNull(request);
+    assertEquals(request.getMethod(), "POST");
+
+    // Check query
+    Map<String, String> query = TestUtilities.parseQueryString(request);
+    assertNotNull(query);
+    // Get query params
+    assertEquals(query.get("type"), "inactive");
+    assertEquals(query.get("duration"), "720");
+    // Check request path
+    String parsedPath = TestUtilities.parseReqPath(request);
+    assertEquals(parsedPath, createReportPath);
+  }
+
+  // Test the createReport operation with null options model parameter
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testCreateReportNoOptions() throws Throwable {
+    // construct the service
+    constructClientService();
+
+    server.enqueue(new MockResponse());
+
+    // Invoke operation with null options model (negative test)
+    iamIdentityService.createReport(null).execute();
+  }
+
+  @Test
+  public void testGetReportWOptions() throws Throwable {
+    // Schedule some responses.
+    String mockResponseBody = "{\"created_by\": \"createdBy\", \"reference\": \"reference\", \"report_duration\": \"reportDuration\", \"report_start_time\": \"reportStartTime\", \"report_end_time\": \"unknown property type: reportEndTime\", \"users\": [{\"iam_id\": \"iamId\", \"username\": \"username\", \"last_authn\": \"lastAuthn\"}], \"apikeys\": [{\"id\": \"id\", \"name\": \"name\", \"last_authn\": \"lastAuthn\"}], \"serviceids\": [{\"id\": \"id\", \"name\": \"name\", \"last_authn\": \"lastAuthn\"}], \"profiles\": [{\"id\": \"id\", \"name\": \"name\", \"last_authn\": \"lastAuthn\"}]}";
+    String getReportPath = "/v1/activity/accounts/testString/report/testString";
+
+    server.enqueue(new MockResponse()
+    .setHeader("Content-type", "application/json")
+    .setResponseCode(200)
+    .setBody(mockResponseBody));
+
+    constructClientService();
+
+    // Construct an instance of the GetReportOptions model
+    GetReportOptions getReportOptionsModel = new GetReportOptions.Builder()
+    .accountId("testString")
+    .reference("testString")
+    .build();
+
+    // Invoke operation with valid options model (positive test)
+    Response<Report> response = iamIdentityService.getReport(getReportOptionsModel).execute();
+    assertNotNull(response);
+    Report responseObj = response.getResult();
+    assertNotNull(responseObj);
+
+    // Verify the contents of the request
+    RecordedRequest request = server.takeRequest();
+    assertNotNull(request);
+    assertEquals(request.getMethod(), "GET");
+
+    // Check query
+    Map<String, String> query = TestUtilities.parseQueryString(request);
+    assertNull(query);
+
+    // Check request path
+    String parsedPath = TestUtilities.parseReqPath(request);
+    assertEquals(parsedPath, getReportPath);
+  }
+
+  // Test the getReport operation with null options model parameter
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testGetReportNoOptions() throws Throwable {
+    // construct the service
+    constructClientService();
+
+    server.enqueue(new MockResponse());
+
+    // Invoke operation with null options model (negative test)
+    iamIdentityService.getReport(null).execute();
+  }
+
+  /** Initialize the server */
   @BeforeMethod
   public void beforeEachTest() {
     // Start the mock server.

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/IamIdentityTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/IamIdentityTest.java
@@ -117,7 +117,7 @@ public class IamIdentityTest extends PowerMockTestCase {
   // Test the listApiKeys operation with a valid options model parameter
   @Test
   public void testListApiKeysWOptions() throws Throwable {
-    // Schedule some responses.
+    // Register a mock response
     String mockResponseBody = "{\"context\": {\"transaction_id\": \"transactionId\", \"operation\": \"operation\", \"user_agent\": \"userAgent\", \"url\": \"url\", \"instance_id\": \"instanceId\", \"thread_id\": \"threadId\", \"host\": \"host\", \"start_time\": \"startTime\", \"end_time\": \"endTime\", \"elapsed_time\": \"elapsedTime\", \"cluster_name\": \"clusterName\"}, \"offset\": 6, \"limit\": 5, \"first\": \"first\", \"previous\": \"previous\", \"next\": \"next\", \"apikeys\": [{\"context\": {\"transaction_id\": \"transactionId\", \"operation\": \"operation\", \"user_agent\": \"userAgent\", \"url\": \"url\", \"instance_id\": \"instanceId\", \"thread_id\": \"threadId\", \"host\": \"host\", \"start_time\": \"startTime\", \"end_time\": \"endTime\", \"elapsed_time\": \"elapsedTime\", \"cluster_name\": \"clusterName\"}, \"id\": \"id\", \"entity_tag\": \"entityTag\", \"crn\": \"crn\", \"locked\": true, \"created_at\": \"2019-01-01T12:00:00.000Z\", \"created_by\": \"createdBy\", \"modified_at\": \"2019-01-01T12:00:00.000Z\", \"name\": \"name\", \"description\": \"description\", \"iam_id\": \"iamId\", \"account_id\": \"accountId\", \"apikey\": \"apikey\", \"history\": [{\"timestamp\": \"timestamp\", \"iam_id\": \"iamId\", \"iam_id_account\": \"iamIdAccount\", \"action\": \"action\", \"params\": [\"params\"], \"message\": \"message\"}], \"activity\": {\"last_authn\": \"lastAuthn\", \"authn_count\": 10}}]}";
     String listApiKeysPath = "/v1/apikeys";
     server.enqueue(new MockResponse()
@@ -178,7 +178,7 @@ public class IamIdentityTest extends PowerMockTestCase {
   // Test the createApiKey operation with a valid options model parameter
   @Test
   public void testCreateApiKeyWOptions() throws Throwable {
-    // Schedule some responses.
+    // Register a mock response
     String mockResponseBody = "{\"context\": {\"transaction_id\": \"transactionId\", \"operation\": \"operation\", \"user_agent\": \"userAgent\", \"url\": \"url\", \"instance_id\": \"instanceId\", \"thread_id\": \"threadId\", \"host\": \"host\", \"start_time\": \"startTime\", \"end_time\": \"endTime\", \"elapsed_time\": \"elapsedTime\", \"cluster_name\": \"clusterName\"}, \"id\": \"id\", \"entity_tag\": \"entityTag\", \"crn\": \"crn\", \"locked\": true, \"created_at\": \"2019-01-01T12:00:00.000Z\", \"created_by\": \"createdBy\", \"modified_at\": \"2019-01-01T12:00:00.000Z\", \"name\": \"name\", \"description\": \"description\", \"iam_id\": \"iamId\", \"account_id\": \"accountId\", \"apikey\": \"apikey\", \"history\": [{\"timestamp\": \"timestamp\", \"iam_id\": \"iamId\", \"iam_id_account\": \"iamIdAccount\", \"action\": \"action\", \"params\": [\"params\"], \"message\": \"message\"}], \"activity\": {\"last_authn\": \"lastAuthn\", \"authn_count\": 10}}";
     String createApiKeyPath = "/v1/apikeys";
     server.enqueue(new MockResponse()
@@ -235,7 +235,7 @@ public class IamIdentityTest extends PowerMockTestCase {
   // Test the getApiKeysDetails operation with a valid options model parameter
   @Test
   public void testGetApiKeysDetailsWOptions() throws Throwable {
-    // Schedule some responses.
+    // Register a mock response
     String mockResponseBody = "{\"context\": {\"transaction_id\": \"transactionId\", \"operation\": \"operation\", \"user_agent\": \"userAgent\", \"url\": \"url\", \"instance_id\": \"instanceId\", \"thread_id\": \"threadId\", \"host\": \"host\", \"start_time\": \"startTime\", \"end_time\": \"endTime\", \"elapsed_time\": \"elapsedTime\", \"cluster_name\": \"clusterName\"}, \"id\": \"id\", \"entity_tag\": \"entityTag\", \"crn\": \"crn\", \"locked\": true, \"created_at\": \"2019-01-01T12:00:00.000Z\", \"created_by\": \"createdBy\", \"modified_at\": \"2019-01-01T12:00:00.000Z\", \"name\": \"name\", \"description\": \"description\", \"iam_id\": \"iamId\", \"account_id\": \"accountId\", \"apikey\": \"apikey\", \"history\": [{\"timestamp\": \"timestamp\", \"iam_id\": \"iamId\", \"iam_id_account\": \"iamIdAccount\", \"action\": \"action\", \"params\": [\"params\"], \"message\": \"message\"}], \"activity\": {\"last_authn\": \"lastAuthn\", \"authn_count\": 10}}";
     String getApiKeysDetailsPath = "/v1/apikeys/details";
     server.enqueue(new MockResponse()
@@ -281,7 +281,7 @@ public class IamIdentityTest extends PowerMockTestCase {
   // Test the getApiKey operation with a valid options model parameter
   @Test
   public void testGetApiKeyWOptions() throws Throwable {
-    // Schedule some responses.
+    // Register a mock response
     String mockResponseBody = "{\"context\": {\"transaction_id\": \"transactionId\", \"operation\": \"operation\", \"user_agent\": \"userAgent\", \"url\": \"url\", \"instance_id\": \"instanceId\", \"thread_id\": \"threadId\", \"host\": \"host\", \"start_time\": \"startTime\", \"end_time\": \"endTime\", \"elapsed_time\": \"elapsedTime\", \"cluster_name\": \"clusterName\"}, \"id\": \"id\", \"entity_tag\": \"entityTag\", \"crn\": \"crn\", \"locked\": true, \"created_at\": \"2019-01-01T12:00:00.000Z\", \"created_by\": \"createdBy\", \"modified_at\": \"2019-01-01T12:00:00.000Z\", \"name\": \"name\", \"description\": \"description\", \"iam_id\": \"iamId\", \"account_id\": \"accountId\", \"apikey\": \"apikey\", \"history\": [{\"timestamp\": \"timestamp\", \"iam_id\": \"iamId\", \"iam_id_account\": \"iamIdAccount\", \"action\": \"action\", \"params\": [\"params\"], \"message\": \"message\"}], \"activity\": {\"last_authn\": \"lastAuthn\", \"authn_count\": 10}}";
     String getApiKeyPath = "/v1/apikeys/testString";
     server.enqueue(new MockResponse()
@@ -291,10 +291,10 @@ public class IamIdentityTest extends PowerMockTestCase {
 
     // Construct an instance of the GetApiKeyOptions model
     GetApiKeyOptions getApiKeyOptionsModel = new GetApiKeyOptions.Builder()
-    .id("testString")
-    .includeHistory(false)
-    .includeActivity(false)
-    .build();
+      .id("testString")
+      .includeHistory(false)
+      .includeActivity(false)
+      .build();
 
     // Invoke getApiKey() with a valid options model and verify the result
     Response<ApiKey> response = iamIdentityService.getApiKey(getApiKeyOptionsModel).execute();
@@ -314,9 +314,6 @@ public class IamIdentityTest extends PowerMockTestCase {
     assertNotNull(query);
     assertEquals(Boolean.valueOf(query.get("include_history")), Boolean.valueOf(false));
     assertEquals(Boolean.valueOf(query.get("include_activity")), Boolean.valueOf(false));
-    // Check request path
-    String parsedPath = TestUtilities.parseReqPath(request);
-    assertEquals(parsedPath, getApiKeyPath);
   }
 
   // Test the getApiKey operation with and without retries enabled
@@ -339,7 +336,7 @@ public class IamIdentityTest extends PowerMockTestCase {
   // Test the updateApiKey operation with a valid options model parameter
   @Test
   public void testUpdateApiKeyWOptions() throws Throwable {
-    // Schedule some responses.
+    // Register a mock response
     String mockResponseBody = "{\"context\": {\"transaction_id\": \"transactionId\", \"operation\": \"operation\", \"user_agent\": \"userAgent\", \"url\": \"url\", \"instance_id\": \"instanceId\", \"thread_id\": \"threadId\", \"host\": \"host\", \"start_time\": \"startTime\", \"end_time\": \"endTime\", \"elapsed_time\": \"elapsedTime\", \"cluster_name\": \"clusterName\"}, \"id\": \"id\", \"entity_tag\": \"entityTag\", \"crn\": \"crn\", \"locked\": true, \"created_at\": \"2019-01-01T12:00:00.000Z\", \"created_by\": \"createdBy\", \"modified_at\": \"2019-01-01T12:00:00.000Z\", \"name\": \"name\", \"description\": \"description\", \"iam_id\": \"iamId\", \"account_id\": \"accountId\", \"apikey\": \"apikey\", \"history\": [{\"timestamp\": \"timestamp\", \"iam_id\": \"iamId\", \"iam_id_account\": \"iamIdAccount\", \"action\": \"action\", \"params\": [\"params\"], \"message\": \"message\"}], \"activity\": {\"last_authn\": \"lastAuthn\", \"authn_count\": 10}}";
     String updateApiKeyPath = "/v1/apikeys/testString";
     server.enqueue(new MockResponse()
@@ -545,7 +542,7 @@ public class IamIdentityTest extends PowerMockTestCase {
   // Test the listServiceIds operation with a valid options model parameter
   @Test
   public void testListServiceIdsWOptions() throws Throwable {
-    // Schedule some responses.
+    // Register a mock response
     String mockResponseBody = "{\"context\": {\"transaction_id\": \"transactionId\", \"operation\": \"operation\", \"user_agent\": \"userAgent\", \"url\": \"url\", \"instance_id\": \"instanceId\", \"thread_id\": \"threadId\", \"host\": \"host\", \"start_time\": \"startTime\", \"end_time\": \"endTime\", \"elapsed_time\": \"elapsedTime\", \"cluster_name\": \"clusterName\"}, \"offset\": 6, \"limit\": 5, \"first\": \"first\", \"previous\": \"previous\", \"next\": \"next\", \"serviceids\": [{\"context\": {\"transaction_id\": \"transactionId\", \"operation\": \"operation\", \"user_agent\": \"userAgent\", \"url\": \"url\", \"instance_id\": \"instanceId\", \"thread_id\": \"threadId\", \"host\": \"host\", \"start_time\": \"startTime\", \"end_time\": \"endTime\", \"elapsed_time\": \"elapsedTime\", \"cluster_name\": \"clusterName\"}, \"id\": \"id\", \"iam_id\": \"iamId\", \"entity_tag\": \"entityTag\", \"crn\": \"crn\", \"locked\": true, \"created_at\": \"2019-01-01T12:00:00.000Z\", \"modified_at\": \"2019-01-01T12:00:00.000Z\", \"account_id\": \"accountId\", \"name\": \"name\", \"description\": \"description\", \"unique_instance_crns\": [\"uniqueInstanceCrns\"], \"history\": [{\"timestamp\": \"timestamp\", \"iam_id\": \"iamId\", \"iam_id_account\": \"iamIdAccount\", \"action\": \"action\", \"params\": [\"params\"], \"message\": \"message\"}], \"apikey\": {\"context\": {\"transaction_id\": \"transactionId\", \"operation\": \"operation\", \"user_agent\": \"userAgent\", \"url\": \"url\", \"instance_id\": \"instanceId\", \"thread_id\": \"threadId\", \"host\": \"host\", \"start_time\": \"startTime\", \"end_time\": \"endTime\", \"elapsed_time\": \"elapsedTime\", \"cluster_name\": \"clusterName\"}, \"id\": \"id\", \"entity_tag\": \"entityTag\", \"crn\": \"crn\", \"locked\": true, \"created_at\": \"2019-01-01T12:00:00.000Z\", \"created_by\": \"createdBy\", \"modified_at\": \"2019-01-01T12:00:00.000Z\", \"name\": \"name\", \"description\": \"description\", \"iam_id\": \"iamId\", \"account_id\": \"accountId\", \"apikey\": \"apikey\", \"history\": [{\"timestamp\": \"timestamp\", \"iam_id\": \"iamId\", \"iam_id_account\": \"iamIdAccount\", \"action\": \"action\", \"params\": [\"params\"], \"message\": \"message\"}], \"activity\": {\"last_authn\": \"lastAuthn\", \"authn_count\": 10}}, \"activity\": {\"last_authn\": \"lastAuthn\", \"authn_count\": 10}}]}";
     String listServiceIdsPath = "/v1/serviceids/";
     server.enqueue(new MockResponse()
@@ -602,7 +599,7 @@ public class IamIdentityTest extends PowerMockTestCase {
   // Test the createServiceId operation with a valid options model parameter
   @Test
   public void testCreateServiceIdWOptions() throws Throwable {
-    // Schedule some responses.
+    // Register a mock response
     String mockResponseBody = "{\"context\": {\"transaction_id\": \"transactionId\", \"operation\": \"operation\", \"user_agent\": \"userAgent\", \"url\": \"url\", \"instance_id\": \"instanceId\", \"thread_id\": \"threadId\", \"host\": \"host\", \"start_time\": \"startTime\", \"end_time\": \"endTime\", \"elapsed_time\": \"elapsedTime\", \"cluster_name\": \"clusterName\"}, \"id\": \"id\", \"iam_id\": \"iamId\", \"entity_tag\": \"entityTag\", \"crn\": \"crn\", \"locked\": true, \"created_at\": \"2019-01-01T12:00:00.000Z\", \"modified_at\": \"2019-01-01T12:00:00.000Z\", \"account_id\": \"accountId\", \"name\": \"name\", \"description\": \"description\", \"unique_instance_crns\": [\"uniqueInstanceCrns\"], \"history\": [{\"timestamp\": \"timestamp\", \"iam_id\": \"iamId\", \"iam_id_account\": \"iamIdAccount\", \"action\": \"action\", \"params\": [\"params\"], \"message\": \"message\"}], \"apikey\": {\"context\": {\"transaction_id\": \"transactionId\", \"operation\": \"operation\", \"user_agent\": \"userAgent\", \"url\": \"url\", \"instance_id\": \"instanceId\", \"thread_id\": \"threadId\", \"host\": \"host\", \"start_time\": \"startTime\", \"end_time\": \"endTime\", \"elapsed_time\": \"elapsedTime\", \"cluster_name\": \"clusterName\"}, \"id\": \"id\", \"entity_tag\": \"entityTag\", \"crn\": \"crn\", \"locked\": true, \"created_at\": \"2019-01-01T12:00:00.000Z\", \"created_by\": \"createdBy\", \"modified_at\": \"2019-01-01T12:00:00.000Z\", \"name\": \"name\", \"description\": \"description\", \"iam_id\": \"iamId\", \"account_id\": \"accountId\", \"apikey\": \"apikey\", \"history\": [{\"timestamp\": \"timestamp\", \"iam_id\": \"iamId\", \"iam_id_account\": \"iamIdAccount\", \"action\": \"action\", \"params\": [\"params\"], \"message\": \"message\"}], \"activity\": {\"last_authn\": \"lastAuthn\", \"authn_count\": 10}}, \"activity\": {\"last_authn\": \"lastAuthn\", \"authn_count\": 10}}";
     String createServiceIdPath = "/v1/serviceids/";
     server.enqueue(new MockResponse()
@@ -666,7 +663,7 @@ public class IamIdentityTest extends PowerMockTestCase {
   // Test the getServiceId operation with a valid options model parameter
   @Test
   public void testGetServiceIdWOptions() throws Throwable {
-    // Schedule some responses.
+    // Register a mock response
     String mockResponseBody = "{\"context\": {\"transaction_id\": \"transactionId\", \"operation\": \"operation\", \"user_agent\": \"userAgent\", \"url\": \"url\", \"instance_id\": \"instanceId\", \"thread_id\": \"threadId\", \"host\": \"host\", \"start_time\": \"startTime\", \"end_time\": \"endTime\", \"elapsed_time\": \"elapsedTime\", \"cluster_name\": \"clusterName\"}, \"id\": \"id\", \"iam_id\": \"iamId\", \"entity_tag\": \"entityTag\", \"crn\": \"crn\", \"locked\": true, \"created_at\": \"2019-01-01T12:00:00.000Z\", \"modified_at\": \"2019-01-01T12:00:00.000Z\", \"account_id\": \"accountId\", \"name\": \"name\", \"description\": \"description\", \"unique_instance_crns\": [\"uniqueInstanceCrns\"], \"history\": [{\"timestamp\": \"timestamp\", \"iam_id\": \"iamId\", \"iam_id_account\": \"iamIdAccount\", \"action\": \"action\", \"params\": [\"params\"], \"message\": \"message\"}], \"apikey\": {\"context\": {\"transaction_id\": \"transactionId\", \"operation\": \"operation\", \"user_agent\": \"userAgent\", \"url\": \"url\", \"instance_id\": \"instanceId\", \"thread_id\": \"threadId\", \"host\": \"host\", \"start_time\": \"startTime\", \"end_time\": \"endTime\", \"elapsed_time\": \"elapsedTime\", \"cluster_name\": \"clusterName\"}, \"id\": \"id\", \"entity_tag\": \"entityTag\", \"crn\": \"crn\", \"locked\": true, \"created_at\": \"2019-01-01T12:00:00.000Z\", \"created_by\": \"createdBy\", \"modified_at\": \"2019-01-01T12:00:00.000Z\", \"name\": \"name\", \"description\": \"description\", \"iam_id\": \"iamId\", \"account_id\": \"accountId\", \"apikey\": \"apikey\", \"history\": [{\"timestamp\": \"timestamp\", \"iam_id\": \"iamId\", \"iam_id_account\": \"iamIdAccount\", \"action\": \"action\", \"params\": [\"params\"], \"message\": \"message\"}], \"activity\": {\"last_authn\": \"lastAuthn\", \"authn_count\": 10}}, \"activity\": {\"last_authn\": \"lastAuthn\", \"authn_count\": 10}}";
     String getServiceIdPath = "/v1/serviceids/testString";
     server.enqueue(new MockResponse()
@@ -676,10 +673,10 @@ public class IamIdentityTest extends PowerMockTestCase {
 
     // Construct an instance of the GetServiceIdOptions model
     GetServiceIdOptions getServiceIdOptionsModel = new GetServiceIdOptions.Builder()
-    .id("testString")
-    .includeHistory(false)
-    .includeActivity(false)
-    .build();
+      .id("testString")
+      .includeHistory(false)
+      .includeActivity(false)
+      .build();
 
     // Invoke getServiceId() with a valid options model and verify the result
     Response<ServiceId> response = iamIdentityService.getServiceId(getServiceIdOptionsModel).execute();
@@ -699,9 +696,6 @@ public class IamIdentityTest extends PowerMockTestCase {
     assertNotNull(query);
     assertEquals(Boolean.valueOf(query.get("include_history")), Boolean.valueOf(false));
     assertEquals(Boolean.valueOf(query.get("include_activity")), Boolean.valueOf(false));
-    // Check request path
-    String parsedPath = TestUtilities.parseReqPath(request);
-    assertEquals(parsedPath, getServiceIdPath);
   }
 
   // Test the getServiceId operation with and without retries enabled
@@ -724,7 +718,7 @@ public class IamIdentityTest extends PowerMockTestCase {
   // Test the updateServiceId operation with a valid options model parameter
   @Test
   public void testUpdateServiceIdWOptions() throws Throwable {
-    // Schedule some responses.
+    // Register a mock response
     String mockResponseBody = "{\"context\": {\"transaction_id\": \"transactionId\", \"operation\": \"operation\", \"user_agent\": \"userAgent\", \"url\": \"url\", \"instance_id\": \"instanceId\", \"thread_id\": \"threadId\", \"host\": \"host\", \"start_time\": \"startTime\", \"end_time\": \"endTime\", \"elapsed_time\": \"elapsedTime\", \"cluster_name\": \"clusterName\"}, \"id\": \"id\", \"iam_id\": \"iamId\", \"entity_tag\": \"entityTag\", \"crn\": \"crn\", \"locked\": true, \"created_at\": \"2019-01-01T12:00:00.000Z\", \"modified_at\": \"2019-01-01T12:00:00.000Z\", \"account_id\": \"accountId\", \"name\": \"name\", \"description\": \"description\", \"unique_instance_crns\": [\"uniqueInstanceCrns\"], \"history\": [{\"timestamp\": \"timestamp\", \"iam_id\": \"iamId\", \"iam_id_account\": \"iamIdAccount\", \"action\": \"action\", \"params\": [\"params\"], \"message\": \"message\"}], \"apikey\": {\"context\": {\"transaction_id\": \"transactionId\", \"operation\": \"operation\", \"user_agent\": \"userAgent\", \"url\": \"url\", \"instance_id\": \"instanceId\", \"thread_id\": \"threadId\", \"host\": \"host\", \"start_time\": \"startTime\", \"end_time\": \"endTime\", \"elapsed_time\": \"elapsedTime\", \"cluster_name\": \"clusterName\"}, \"id\": \"id\", \"entity_tag\": \"entityTag\", \"crn\": \"crn\", \"locked\": true, \"created_at\": \"2019-01-01T12:00:00.000Z\", \"created_by\": \"createdBy\", \"modified_at\": \"2019-01-01T12:00:00.000Z\", \"name\": \"name\", \"description\": \"description\", \"iam_id\": \"iamId\", \"account_id\": \"accountId\", \"apikey\": \"apikey\", \"history\": [{\"timestamp\": \"timestamp\", \"iam_id\": \"iamId\", \"iam_id_account\": \"iamIdAccount\", \"action\": \"action\", \"params\": [\"params\"], \"message\": \"message\"}], \"activity\": {\"last_authn\": \"lastAuthn\", \"authn_count\": 10}}, \"activity\": {\"last_authn\": \"lastAuthn\", \"authn_count\": 10}}";
     String updateServiceIdPath = "/v1/serviceids/testString";
     server.enqueue(new MockResponse()
@@ -931,7 +925,7 @@ public class IamIdentityTest extends PowerMockTestCase {
   // Test the createProfile operation with a valid options model parameter
   @Test
   public void testCreateProfileWOptions() throws Throwable {
-    // Schedule some responses.
+    // Register a mock response
     String mockResponseBody = "{\"context\": {\"transaction_id\": \"transactionId\", \"operation\": \"operation\", \"user_agent\": \"userAgent\", \"url\": \"url\", \"instance_id\": \"instanceId\", \"thread_id\": \"threadId\", \"host\": \"host\", \"start_time\": \"startTime\", \"end_time\": \"endTime\", \"elapsed_time\": \"elapsedTime\", \"cluster_name\": \"clusterName\"}, \"id\": \"id\", \"entity_tag\": \"entityTag\", \"crn\": \"crn\", \"name\": \"name\", \"description\": \"description\", \"created_at\": \"2019-01-01T12:00:00.000Z\", \"modified_at\": \"2019-01-01T12:00:00.000Z\", \"iam_id\": \"iamId\", \"account_id\": \"accountId\", \"ims_account_id\": 12, \"ims_user_id\": 9, \"history\": [{\"timestamp\": \"timestamp\", \"iam_id\": \"iamId\", \"iam_id_account\": \"iamIdAccount\", \"action\": \"action\", \"params\": [\"params\"], \"message\": \"message\"}], \"activity\": {\"last_authn\": \"lastAuthn\", \"authn_count\": 10}}";
     String createProfilePath = "/v1/profiles";
     server.enqueue(new MockResponse()
@@ -984,7 +978,7 @@ public class IamIdentityTest extends PowerMockTestCase {
   // Test the listProfiles operation with a valid options model parameter
   @Test
   public void testListProfilesWOptions() throws Throwable {
-    // Schedule some responses.
+    // Register a mock response
     String mockResponseBody = "{\"context\": {\"transaction_id\": \"transactionId\", \"operation\": \"operation\", \"user_agent\": \"userAgent\", \"url\": \"url\", \"instance_id\": \"instanceId\", \"thread_id\": \"threadId\", \"host\": \"host\", \"start_time\": \"startTime\", \"end_time\": \"endTime\", \"elapsed_time\": \"elapsedTime\", \"cluster_name\": \"clusterName\"}, \"offset\": 6, \"limit\": 5, \"first\": \"first\", \"previous\": \"previous\", \"next\": \"next\", \"profiles\": [{\"context\": {\"transaction_id\": \"transactionId\", \"operation\": \"operation\", \"user_agent\": \"userAgent\", \"url\": \"url\", \"instance_id\": \"instanceId\", \"thread_id\": \"threadId\", \"host\": \"host\", \"start_time\": \"startTime\", \"end_time\": \"endTime\", \"elapsed_time\": \"elapsedTime\", \"cluster_name\": \"clusterName\"}, \"id\": \"id\", \"entity_tag\": \"entityTag\", \"crn\": \"crn\", \"name\": \"name\", \"description\": \"description\", \"created_at\": \"2019-01-01T12:00:00.000Z\", \"modified_at\": \"2019-01-01T12:00:00.000Z\", \"iam_id\": \"iamId\", \"account_id\": \"accountId\", \"ims_account_id\": 12, \"ims_user_id\": 9, \"history\": [{\"timestamp\": \"timestamp\", \"iam_id\": \"iamId\", \"iam_id_account\": \"iamIdAccount\", \"action\": \"action\", \"params\": [\"params\"], \"message\": \"message\"}], \"activity\": {\"last_authn\": \"lastAuthn\", \"authn_count\": 10}}]}";
     String listProfilesPath = "/v1/profiles";
     server.enqueue(new MockResponse()
@@ -1048,7 +1042,7 @@ public class IamIdentityTest extends PowerMockTestCase {
   // Test the getProfile operation with a valid options model parameter
   @Test
   public void testGetProfileWOptions() throws Throwable {
-    // Schedule some responses.
+    // Register a mock response
     String mockResponseBody = "{\"context\": {\"transaction_id\": \"transactionId\", \"operation\": \"operation\", \"user_agent\": \"userAgent\", \"url\": \"url\", \"instance_id\": \"instanceId\", \"thread_id\": \"threadId\", \"host\": \"host\", \"start_time\": \"startTime\", \"end_time\": \"endTime\", \"elapsed_time\": \"elapsedTime\", \"cluster_name\": \"clusterName\"}, \"id\": \"id\", \"entity_tag\": \"entityTag\", \"crn\": \"crn\", \"name\": \"name\", \"description\": \"description\", \"created_at\": \"2019-01-01T12:00:00.000Z\", \"modified_at\": \"2019-01-01T12:00:00.000Z\", \"iam_id\": \"iamId\", \"account_id\": \"accountId\", \"ims_account_id\": 12, \"ims_user_id\": 9, \"history\": [{\"timestamp\": \"timestamp\", \"iam_id\": \"iamId\", \"iam_id_account\": \"iamIdAccount\", \"action\": \"action\", \"params\": [\"params\"], \"message\": \"message\"}], \"activity\": {\"last_authn\": \"lastAuthn\", \"authn_count\": 10}}";
     String getProfilePath = "/v1/profiles/testString";
     server.enqueue(new MockResponse()
@@ -1058,9 +1052,9 @@ public class IamIdentityTest extends PowerMockTestCase {
 
     // Construct an instance of the GetProfileOptions model
     GetProfileOptions getProfileOptionsModel = new GetProfileOptions.Builder()
-    .profileId("testString")
-    .includeActivity(false)
-    .build();
+      .profileId("testString")
+      .includeActivity(false)
+      .build();
 
     // Invoke getProfile() with a valid options model and verify the result
     Response<TrustedProfile> response = iamIdentityService.getProfile(getProfileOptionsModel).execute();
@@ -1072,13 +1066,7 @@ public class IamIdentityTest extends PowerMockTestCase {
     RecordedRequest request = server.takeRequest();
     assertNotNull(request);
     assertEquals(request.getMethod(), "GET");
-
-    // Check query
-    Map<String, String> query = TestUtilities.parseQueryString(request);
-    assertNotNull(query);
-    // Get query params
-    assertEquals(Boolean.valueOf(query.get("include_activity")), Boolean.valueOf(false));
-    // Check request path
+    // Verify request path
     String parsedPath = TestUtilities.parseReqPath(request);
     assertEquals(parsedPath, getProfilePath);
     // Verify query params
@@ -1107,7 +1095,7 @@ public class IamIdentityTest extends PowerMockTestCase {
   // Test the updateProfile operation with a valid options model parameter
   @Test
   public void testUpdateProfileWOptions() throws Throwable {
-    // Schedule some responses.
+    // Register a mock response
     String mockResponseBody = "{\"context\": {\"transaction_id\": \"transactionId\", \"operation\": \"operation\", \"user_agent\": \"userAgent\", \"url\": \"url\", \"instance_id\": \"instanceId\", \"thread_id\": \"threadId\", \"host\": \"host\", \"start_time\": \"startTime\", \"end_time\": \"endTime\", \"elapsed_time\": \"elapsedTime\", \"cluster_name\": \"clusterName\"}, \"id\": \"id\", \"entity_tag\": \"entityTag\", \"crn\": \"crn\", \"name\": \"name\", \"description\": \"description\", \"created_at\": \"2019-01-01T12:00:00.000Z\", \"modified_at\": \"2019-01-01T12:00:00.000Z\", \"iam_id\": \"iamId\", \"account_id\": \"accountId\", \"ims_account_id\": 12, \"ims_user_id\": 9, \"history\": [{\"timestamp\": \"timestamp\", \"iam_id\": \"iamId\", \"iam_id_account\": \"iamIdAccount\", \"action\": \"action\", \"params\": [\"params\"], \"message\": \"message\"}], \"activity\": {\"last_authn\": \"lastAuthn\", \"authn_count\": 10}}";
     String updateProfilePath = "/v1/profiles/testString";
     server.enqueue(new MockResponse()
@@ -1964,112 +1952,7 @@ public class IamIdentityTest extends PowerMockTestCase {
     iamIdentityService.getReport(null).execute();
   }
 
-  @Test
-  public void testCreateReportWOptions() throws Throwable {
-    // Schedule some responses.
-    String mockResponseBody = "{\"reference\": \"reference\"}";
-    String createReportPath = "/v1/activity/accounts/testString/report";
-
-    server.enqueue(new MockResponse()
-    .setHeader("Content-type", "application/json")
-    .setResponseCode(202)
-    .setBody(mockResponseBody));
-
-    constructClientService();
-
-    // Construct an instance of the CreateReportOptions model
-    CreateReportOptions createReportOptionsModel = new CreateReportOptions.Builder()
-    .accountId("testString")
-    .type("inactive")
-    .duration("720")
-    .build();
-
-    // Invoke operation with valid options model (positive test)
-    Response<ReportReference> response = iamIdentityService.createReport(createReportOptionsModel).execute();
-    assertNotNull(response);
-    ReportReference responseObj = response.getResult();
-    assertNotNull(responseObj);
-
-    // Verify the contents of the request
-    RecordedRequest request = server.takeRequest();
-    assertNotNull(request);
-    assertEquals(request.getMethod(), "POST");
-
-    // Check query
-    Map<String, String> query = TestUtilities.parseQueryString(request);
-    assertNotNull(query);
-    // Get query params
-    assertEquals(query.get("type"), "inactive");
-    assertEquals(query.get("duration"), "720");
-    // Check request path
-    String parsedPath = TestUtilities.parseReqPath(request);
-    assertEquals(parsedPath, createReportPath);
-  }
-
-  // Test the createReport operation with null options model parameter
-  @Test(expectedExceptions = IllegalArgumentException.class)
-  public void testCreateReportNoOptions() throws Throwable {
-    // construct the service
-    constructClientService();
-
-    server.enqueue(new MockResponse());
-
-    // Invoke operation with null options model (negative test)
-    iamIdentityService.createReport(null).execute();
-  }
-
-  @Test
-  public void testGetReportWOptions() throws Throwable {
-    // Schedule some responses.
-    String mockResponseBody = "{\"created_by\": \"createdBy\", \"reference\": \"reference\", \"report_duration\": \"reportDuration\", \"report_start_time\": \"reportStartTime\", \"report_end_time\": \"unknown property type: reportEndTime\", \"users\": [{\"iam_id\": \"iamId\", \"username\": \"username\", \"last_authn\": \"lastAuthn\"}], \"apikeys\": [{\"id\": \"id\", \"name\": \"name\", \"last_authn\": \"lastAuthn\"}], \"serviceids\": [{\"id\": \"id\", \"name\": \"name\", \"last_authn\": \"lastAuthn\"}], \"profiles\": [{\"id\": \"id\", \"name\": \"name\", \"last_authn\": \"lastAuthn\"}]}";
-    String getReportPath = "/v1/activity/accounts/testString/report/testString";
-
-    server.enqueue(new MockResponse()
-    .setHeader("Content-type", "application/json")
-    .setResponseCode(200)
-    .setBody(mockResponseBody));
-
-    constructClientService();
-
-    // Construct an instance of the GetReportOptions model
-    GetReportOptions getReportOptionsModel = new GetReportOptions.Builder()
-    .accountId("testString")
-    .reference("testString")
-    .build();
-
-    // Invoke operation with valid options model (positive test)
-    Response<Report> response = iamIdentityService.getReport(getReportOptionsModel).execute();
-    assertNotNull(response);
-    Report responseObj = response.getResult();
-    assertNotNull(responseObj);
-
-    // Verify the contents of the request
-    RecordedRequest request = server.takeRequest();
-    assertNotNull(request);
-    assertEquals(request.getMethod(), "GET");
-
-    // Check query
-    Map<String, String> query = TestUtilities.parseQueryString(request);
-    assertNull(query);
-
-    // Check request path
-    String parsedPath = TestUtilities.parseReqPath(request);
-    assertEquals(parsedPath, getReportPath);
-  }
-
-  // Test the getReport operation with null options model parameter
-  @Test(expectedExceptions = IllegalArgumentException.class)
-  public void testGetReportNoOptions() throws Throwable {
-    // construct the service
-    constructClientService();
-
-    server.enqueue(new MockResponse());
-
-    // Invoke operation with null options model (negative test)
-    iamIdentityService.getReport(null).execute();
-  }
-
-  /** Initialize the server */
+  // Perform setup needed before each test method
   @BeforeMethod
   public void beforeEachTest() {
     // Start the mock server.

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/AccountSettingsResponseTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/AccountSettingsResponseTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ActivityTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ActivityTest.java
@@ -1,0 +1,38 @@
+/*
+ * (C) Copyright IBM Corp. 2022.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import com.ibm.cloud.platform_services.iam_identity.v1.model.Activity;
+import com.ibm.cloud.platform_services.iam_identity.v1.utils.TestUtilities;
+import com.ibm.cloud.sdk.core.service.model.FileWithMetadata;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.List;
+import org.testng.annotations.Test;
+import static org.testng.Assert.*;
+
+/**
+ * Unit test class for the Activity model.
+ */
+public class ActivityTest {
+  final HashMap<String, InputStream> mockStreamMap = TestUtilities.createMockStreamMap();
+  final List<FileWithMetadata> mockListFileWithMetadata = TestUtilities.creatMockListFileWithMetadata();
+
+  @Test
+  public void testActivity() throws Throwable {
+    Activity activityModel = new Activity();
+    assertNull(activityModel.getLastAuthn());
+    assertNull(activityModel.getAuthnCount());
+  }
+}

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ApiKeyInsideCreateServiceIdRequestTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ApiKeyInsideCreateServiceIdRequestTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ApiKeyListTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ApiKeyListTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -13,6 +13,7 @@
 
 package com.ibm.cloud.platform_services.iam_identity.v1.model;
 
+import com.ibm.cloud.platform_services.iam_identity.v1.model.Activity;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.ApiKey;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.ApiKeyList;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.EnityHistoryRecord;

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ApiKeyTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ApiKeyTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -13,6 +13,7 @@
 
 package com.ibm.cloud.platform_services.iam_identity.v1.model;
 
+import com.ibm.cloud.platform_services.iam_identity.v1.model.Activity;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.ApiKey;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.EnityHistoryRecord;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.ResponseContext;
@@ -50,5 +51,6 @@ public class ApiKeyTest {
     assertNull(apiKeyModel.getAccountId());
     assertNull(apiKeyModel.getApikey());
     assertNull(apiKeyModel.getHistory());
+    assertNull(apiKeyModel.getActivity());
   }
 }

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/CreateApiKeyOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/CreateApiKeyOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/CreateClaimRuleOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/CreateClaimRuleOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/CreateLinkOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/CreateLinkOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/CreateProfileLinkRequestLinkTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/CreateProfileLinkRequestLinkTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/CreateProfileOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/CreateProfileOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/CreateReportOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/CreateReportOptionsTest.java
@@ -1,0 +1,49 @@
+/*
+ * (C) Copyright IBM Corp. 2022.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import com.ibm.cloud.platform_services.iam_identity.v1.model.CreateReportOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.utils.TestUtilities;
+import com.ibm.cloud.sdk.core.service.model.FileWithMetadata;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.List;
+import org.testng.annotations.Test;
+import static org.testng.Assert.*;
+
+/**
+ * Unit test class for the CreateReportOptions model.
+ */
+public class CreateReportOptionsTest {
+  final HashMap<String, InputStream> mockStreamMap = TestUtilities.createMockStreamMap();
+  final List<FileWithMetadata> mockListFileWithMetadata = TestUtilities.creatMockListFileWithMetadata();
+
+  @Test
+  public void testCreateReportOptions() throws Throwable {
+    CreateReportOptions createReportOptionsModel = new CreateReportOptions.Builder()
+      .accountId("testString")
+      .type("inactive")
+      .duration("720")
+      .build();
+    assertEquals(createReportOptionsModel.accountId(), "testString");
+    assertEquals(createReportOptionsModel.type(), "inactive");
+    assertEquals(createReportOptionsModel.duration(), "720");
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testCreateReportOptionsError() throws Throwable {
+    new CreateReportOptions.Builder().build();
+  }
+
+}

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/CreateServiceIdOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/CreateServiceIdOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/DeleteApiKeyOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/DeleteApiKeyOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/DeleteClaimRuleOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/DeleteClaimRuleOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/DeleteLinkOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/DeleteLinkOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/DeleteProfileOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/DeleteProfileOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/DeleteServiceIdOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/DeleteServiceIdOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/EnityHistoryRecordTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/EnityHistoryRecordTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/EntityActivityTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/EntityActivityTest.java
@@ -1,0 +1,39 @@
+/*
+ * (C) Copyright IBM Corp. 2022.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import com.ibm.cloud.platform_services.iam_identity.v1.model.EntityActivity;
+import com.ibm.cloud.platform_services.iam_identity.v1.utils.TestUtilities;
+import com.ibm.cloud.sdk.core.service.model.FileWithMetadata;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.List;
+import org.testng.annotations.Test;
+import static org.testng.Assert.*;
+
+/**
+ * Unit test class for the EntityActivity model.
+ */
+public class EntityActivityTest {
+  final HashMap<String, InputStream> mockStreamMap = TestUtilities.createMockStreamMap();
+  final List<FileWithMetadata> mockListFileWithMetadata = TestUtilities.creatMockListFileWithMetadata();
+
+  @Test
+  public void testEntityActivity() throws Throwable {
+    EntityActivity entityActivityModel = new EntityActivity();
+    assertNull(entityActivityModel.getId());
+    assertNull(entityActivityModel.getName());
+    assertNull(entityActivityModel.getLastAuthn());
+  }
+}

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/GetAccountSettingsOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/GetAccountSettingsOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/GetApiKeyOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/GetApiKeyOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -34,9 +34,11 @@ public class GetApiKeyOptionsTest {
     GetApiKeyOptions getApiKeyOptionsModel = new GetApiKeyOptions.Builder()
       .id("testString")
       .includeHistory(false)
+      .includeActivity(false)
       .build();
     assertEquals(getApiKeyOptionsModel.id(), "testString");
     assertEquals(getApiKeyOptionsModel.includeHistory(), Boolean.valueOf(false));
+    assertEquals(getApiKeyOptionsModel.includeActivity(), Boolean.valueOf(false));
   }
 
   @Test(expectedExceptions = IllegalArgumentException.class)

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/GetApiKeysDetailsOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/GetApiKeysDetailsOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/GetClaimRuleOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/GetClaimRuleOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/GetLinkOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/GetLinkOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/GetProfileOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/GetProfileOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -33,8 +33,10 @@ public class GetProfileOptionsTest {
   public void testGetProfileOptions() throws Throwable {
     GetProfileOptions getProfileOptionsModel = new GetProfileOptions.Builder()
       .profileId("testString")
+      .includeActivity(false)
       .build();
     assertEquals(getProfileOptionsModel.profileId(), "testString");
+    assertEquals(getProfileOptionsModel.includeActivity(), Boolean.valueOf(false));
   }
 
   @Test(expectedExceptions = IllegalArgumentException.class)

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/GetReportOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/GetReportOptionsTest.java
@@ -1,0 +1,47 @@
+/*
+ * (C) Copyright IBM Corp. 2022.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import com.ibm.cloud.platform_services.iam_identity.v1.model.GetReportOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.utils.TestUtilities;
+import com.ibm.cloud.sdk.core.service.model.FileWithMetadata;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.List;
+import org.testng.annotations.Test;
+import static org.testng.Assert.*;
+
+/**
+ * Unit test class for the GetReportOptions model.
+ */
+public class GetReportOptionsTest {
+  final HashMap<String, InputStream> mockStreamMap = TestUtilities.createMockStreamMap();
+  final List<FileWithMetadata> mockListFileWithMetadata = TestUtilities.creatMockListFileWithMetadata();
+
+  @Test
+  public void testGetReportOptions() throws Throwable {
+    GetReportOptions getReportOptionsModel = new GetReportOptions.Builder()
+      .accountId("testString")
+      .reference("testString")
+      .build();
+    assertEquals(getReportOptionsModel.accountId(), "testString");
+    assertEquals(getReportOptionsModel.reference(), "testString");
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testGetReportOptionsError() throws Throwable {
+    new GetReportOptions.Builder().build();
+  }
+
+}

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/GetServiceIdOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/GetServiceIdOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -34,9 +34,11 @@ public class GetServiceIdOptionsTest {
     GetServiceIdOptions getServiceIdOptionsModel = new GetServiceIdOptions.Builder()
       .id("testString")
       .includeHistory(false)
+      .includeActivity(false)
       .build();
     assertEquals(getServiceIdOptionsModel.id(), "testString");
     assertEquals(getServiceIdOptionsModel.includeHistory(), Boolean.valueOf(false));
+    assertEquals(getServiceIdOptionsModel.includeActivity(), Boolean.valueOf(false));
   }
 
   @Test(expectedExceptions = IllegalArgumentException.class)

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ListApiKeysOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ListApiKeysOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ListClaimRulesOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ListClaimRulesOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ListLinksOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ListLinksOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ListProfilesOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ListProfilesOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ListServiceIdsOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ListServiceIdsOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/LockApiKeyOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/LockApiKeyOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/LockServiceIdOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/LockServiceIdOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ProfileClaimRuleConditionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ProfileClaimRuleConditionsTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ProfileClaimRuleListTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ProfileClaimRuleListTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ProfileClaimRuleTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ProfileClaimRuleTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ProfileLinkLinkTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ProfileLinkLinkTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ProfileLinkListTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ProfileLinkListTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ProfileLinkTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ProfileLinkTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ReportReferenceTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ReportReferenceTest.java
@@ -1,0 +1,37 @@
+/*
+ * (C) Copyright IBM Corp. 2022.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import com.ibm.cloud.platform_services.iam_identity.v1.model.ReportReference;
+import com.ibm.cloud.platform_services.iam_identity.v1.utils.TestUtilities;
+import com.ibm.cloud.sdk.core.service.model.FileWithMetadata;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.List;
+import org.testng.annotations.Test;
+import static org.testng.Assert.*;
+
+/**
+ * Unit test class for the ReportReference model.
+ */
+public class ReportReferenceTest {
+  final HashMap<String, InputStream> mockStreamMap = TestUtilities.createMockStreamMap();
+  final List<FileWithMetadata> mockListFileWithMetadata = TestUtilities.creatMockListFileWithMetadata();
+
+  @Test
+  public void testReportReference() throws Throwable {
+    ReportReference reportReferenceModel = new ReportReference();
+    assertNull(reportReferenceModel.getReference());
+  }
+}

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ReportTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ReportTest.java
@@ -1,0 +1,47 @@
+/*
+ * (C) Copyright IBM Corp. 2022.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import com.ibm.cloud.platform_services.iam_identity.v1.model.EntityActivity;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.Report;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.UserActivity;
+import com.ibm.cloud.platform_services.iam_identity.v1.utils.TestUtilities;
+import com.ibm.cloud.sdk.core.service.model.FileWithMetadata;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.List;
+import org.testng.annotations.Test;
+import static org.testng.Assert.*;
+
+/**
+ * Unit test class for the Report model.
+ */
+public class ReportTest {
+  final HashMap<String, InputStream> mockStreamMap = TestUtilities.createMockStreamMap();
+  final List<FileWithMetadata> mockListFileWithMetadata = TestUtilities.creatMockListFileWithMetadata();
+
+  @Test
+  public void testReport() throws Throwable {
+    Report reportModel = new Report();
+    assertNull(reportModel.getCreatedBy());
+    assertNull(reportModel.getReference());
+    assertNull(reportModel.getReportDuration());
+    assertNull(reportModel.getReportStartTime());
+    assertNull(reportModel.getReportEndTime());
+    assertNull(reportModel.getUsers());
+    assertNull(reportModel.getApikeys());
+    assertNull(reportModel.getServiceids());
+    assertNull(reportModel.getProfiles());
+  }
+}

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ResponseContextTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ResponseContextTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ServiceIdListTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ServiceIdListTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -13,6 +13,7 @@
 
 package com.ibm.cloud.platform_services.iam_identity.v1.model;
 
+import com.ibm.cloud.platform_services.iam_identity.v1.model.Activity;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.ApiKey;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.EnityHistoryRecord;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.ResponseContext;

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ServiceIdTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ServiceIdTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -13,6 +13,7 @@
 
 package com.ibm.cloud.platform_services.iam_identity.v1.model;
 
+import com.ibm.cloud.platform_services.iam_identity.v1.model.Activity;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.ApiKey;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.EnityHistoryRecord;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.ResponseContext;
@@ -52,5 +53,6 @@ public class ServiceIdTest {
     assertNull(serviceIdModel.getUniqueInstanceCrns());
     assertNull(serviceIdModel.getHistory());
     assertNull(serviceIdModel.getApikey());
+    assertNull(serviceIdModel.getActivity());
   }
 }

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/TrustedProfileTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/TrustedProfileTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -13,6 +13,7 @@
 
 package com.ibm.cloud.platform_services.iam_identity.v1.model;
 
+import com.ibm.cloud.platform_services.iam_identity.v1.model.Activity;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.EnityHistoryRecord;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.ResponseContext;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.TrustedProfile;
@@ -49,5 +50,6 @@ public class TrustedProfileTest {
     assertNull(trustedProfileModel.getImsAccountId());
     assertNull(trustedProfileModel.getImsUserId());
     assertNull(trustedProfileModel.getHistory());
+    assertNull(trustedProfileModel.getActivity());
   }
 }

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/TrustedProfilesListTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/TrustedProfilesListTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -13,6 +13,7 @@
 
 package com.ibm.cloud.platform_services.iam_identity.v1.model;
 
+import com.ibm.cloud.platform_services.iam_identity.v1.model.Activity;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.EnityHistoryRecord;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.ResponseContext;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.TrustedProfile;

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/UnlockApiKeyOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/UnlockApiKeyOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/UnlockServiceIdOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/UnlockServiceIdOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/UpdateAccountSettingsOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/UpdateAccountSettingsOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/UpdateApiKeyOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/UpdateApiKeyOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/UpdateClaimRuleOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/UpdateClaimRuleOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/UpdateProfileOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/UpdateProfileOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/UpdateServiceIdOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/UpdateServiceIdOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/UserActivityTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/UserActivityTest.java
@@ -1,0 +1,39 @@
+/*
+ * (C) Copyright IBM Corp. 2022.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import com.ibm.cloud.platform_services.iam_identity.v1.model.UserActivity;
+import com.ibm.cloud.platform_services.iam_identity.v1.utils.TestUtilities;
+import com.ibm.cloud.sdk.core.service.model.FileWithMetadata;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.List;
+import org.testng.annotations.Test;
+import static org.testng.Assert.*;
+
+/**
+ * Unit test class for the UserActivity model.
+ */
+public class UserActivityTest {
+  final HashMap<String, InputStream> mockStreamMap = TestUtilities.createMockStreamMap();
+  final List<FileWithMetadata> mockListFileWithMetadata = TestUtilities.creatMockListFileWithMetadata();
+
+  @Test
+  public void testUserActivity() throws Throwable {
+    UserActivity userActivityModel = new UserActivity();
+    assertNull(userActivityModel.getIamId());
+    assertNull(userActivityModel.getUsername());
+    assertNull(userActivityModel.getLastAuthn());
+  }
+}

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/utils/TestUtilities.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/utils/TestUtilities.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at


### PR DESCRIPTION
## PR summary
adding new endpoints: create report, get report
adding new optional query parameter `include_activity` for the existing get calls of apikey/serviceid/profile by id.

## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## Current vs new behavior  
users will now be able to generate report for inactive identities.
create report: will return a reference
get report: this will return a detailed report of inactive identities
existing get apikey/serviceid/profile by id will now include additional optional parameter `include_activity`
if `include_activity` is passed as true the response will include a new section `activity` with last authn time and count.

## Does this PR introduce a breaking change?    
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->
<img width="1056" alt="Screenshot 2022-03-30 at 23 03 57" src="https://user-images.githubusercontent.com/71089502/160938645-63c504d1-bc36-4674-be0e-266ce6b81906.png">
