### PR TITLE
Fix flaky tests caused by JSON ordering permutations

### DIFF
--- a/modules/configuration-governance/src/test/java/com/ibm/cloud/platform_services/configuration_governance/v1/model/CreateRuleRequestTest.java
+++ b/modules/configuration-governance/src/test/java/com/ibm/cloud/platform_services/configuration_governance/v1/model/CreateRuleRequestTest.java
@@ -13,6 +13,7 @@
 
 package com.ibm.cloud.platform_services.configuration_governance.v1.model;
 
+import com.google.gson.JsonParser;
 import com.ibm.cloud.platform_services.configuration_governance.v1.model.CreateRuleRequest;
 import com.ibm.cloud.platform_services.configuration_governance.v1.model.EnforcementAction;
 import com.ibm.cloud.platform_services.configuration_governance.v1.model.RuleRequest;
@@ -103,7 +104,7 @@ public class CreateRuleRequestTest {
     CreateRuleRequest createRuleRequestModelNew = TestUtilities.deserialize(json, CreateRuleRequest.class);
     assertTrue(createRuleRequestModelNew instanceof CreateRuleRequest);
     assertEquals(createRuleRequestModelNew.requestId(), "3cebc877-58e7-44a5-a292-32114fa73558");
-    assertEquals(createRuleRequestModelNew.rule().toString(), ruleRequestModel.toString());
+    assertEquals(JsonParser.parseString(createRuleRequestModelNew.rule().toString()), JsonParser.parseString(ruleRequestModel.toString()));
   }
 
   @Test(expectedExceptions = IllegalArgumentException.class)

--- a/modules/configuration-governance/src/test/java/com/ibm/cloud/platform_services/configuration_governance/v1/model/RuleRequestTest.java
+++ b/modules/configuration-governance/src/test/java/com/ibm/cloud/platform_services/configuration_governance/v1/model/RuleRequestTest.java
@@ -13,6 +13,7 @@
 
 package com.ibm.cloud.platform_services.configuration_governance.v1.model;
 
+import com.google.gson.JsonParser;
 import com.ibm.cloud.platform_services.configuration_governance.v1.model.EnforcementAction;
 import com.ibm.cloud.platform_services.configuration_governance.v1.model.RuleRequest;
 import com.ibm.cloud.platform_services.configuration_governance.v1.model.RuleRequiredConfigSingleProperty;
@@ -99,7 +100,7 @@ public class RuleRequestTest {
     assertEquals(ruleRequestModelNew.description(), "testString");
     assertEquals(ruleRequestModelNew.ruleType(), "user_defined");
     assertEquals(ruleRequestModelNew.target().toString(), targetResourceModel.toString());
-    assertEquals(ruleRequestModelNew.requiredConfig().toString(), ruleRequiredConfigModel.toString());
+    assertEquals(JsonParser.parseString(ruleRequestModelNew.requiredConfig().toString()), JsonParser.parseString(ruleRequiredConfigModel.toString()));
   }
 
   @Test(expectedExceptions = IllegalArgumentException.class)


### PR DESCRIPTION
## PR summary
The following tests were found to be flaky using the [Nondex](https://github.com/TestingResearchIllinois/NonDex) tool.
com.ibm.cloud.platform_services.configuration_governance.v1.model.CreateRuleRequestTest#testCreateRuleRequest
com.ibm.cloud.platform_services.configuration_governance.v1.model.RuleRequestTest#testRuleRequest

The following assertions failed:
` assertEquals(createRuleRequestModelNew.rule().toString(), ruleRequestModel.toString());`
` assertEquals(ruleRequestModelNew.requiredConfig().toString(), ruleRequiredConfigModel.toString());
`

## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## Current vs new behavior  

The test flakiness is caused by comparing the toString() methods of expected and outcome objects that return `GsonSingleton.getGson().toJson()`. 
However, toJson() string does not guarantee the order of the key value pairs as it is an unordered set of key/value pairs, and internal permutations may occur in the output from toJson(), causing the tests to fail the assertions (assertEquals) due to flakiness.

Since the JSON strings created in the toString methods of the objects to be is compared are created using the gson library, I used the gson `JsonParser.parseString()` method to convert the strings back to JSON Object and compared them for equality.
The JsonParser returns a JsonObject, whose equals implementation is not order-sensitive, and hence makes the test deterministic.

## Does this PR introduce a breaking change?    
- [ ] Yes
- [x] No

## Other information
Command to reproduce the flaky test using Nondex:
`mvn -pl modules/configuration-governance edu.illinois:nondex-maven-plugin:1.1.2:nondex -Dtest=com.ibm.cloud.platform_services.configuration_governance.v1.model.RuleRequestTest#testRuleRequest`
