### PR TITLE
feat(IAM Policy Management): add support for v2/policies

### DIFF
--- a/modules/examples/src/main/java/com/ibm/cloud/platform_services/iam_policy_management/v1/IamPolicyManagementExamples.java
+++ b/modules/examples/src/main/java/com/ibm/cloud/platform_services/iam_policy_management/v1/IamPolicyManagementExamples.java
@@ -34,6 +34,19 @@ import com.ibm.cloud.platform_services.iam_policy_management.v1.model.ResourceTa
 import com.ibm.cloud.platform_services.iam_policy_management.v1.model.SubjectAttribute;
 import com.ibm.cloud.platform_services.iam_policy_management.v1.model.UpdatePolicyOptions;
 import com.ibm.cloud.platform_services.iam_policy_management.v1.model.UpdateRoleOptions;
+import com.ibm.cloud.platform_services.iam_policy_management.v1.model.V2CreatePolicyOptions;
+import com.ibm.cloud.platform_services.iam_policy_management.v1.model.V2DeletePolicyOptions;
+import com.ibm.cloud.platform_services.iam_policy_management.v1.model.V2GetPolicyOptions;
+import com.ibm.cloud.platform_services.iam_policy_management.v1.model.V2ListPoliciesOptions;
+import com.ibm.cloud.platform_services.iam_policy_management.v1.model.V2Policy;
+import com.ibm.cloud.platform_services.iam_policy_management.v1.model.V2PolicyAttribute;
+import com.ibm.cloud.platform_services.iam_policy_management.v1.model.V2PolicyBaseControl;
+import com.ibm.cloud.platform_services.iam_policy_management.v1.model.V2PolicyBaseControlGrant;
+import com.ibm.cloud.platform_services.iam_policy_management.v1.model.V2PolicyBaseResource;
+import com.ibm.cloud.platform_services.iam_policy_management.v1.model.V2PolicyBaseRuleV2RuleWithConditions;
+import com.ibm.cloud.platform_services.iam_policy_management.v1.model.V2PolicyBaseSubject;
+import com.ibm.cloud.platform_services.iam_policy_management.v1.model.V2PolicyList;
+import com.ibm.cloud.platform_services.iam_policy_management.v1.model.V2UpdatePolicyOptions;
 import com.ibm.cloud.sdk.core.http.Response;
 import com.ibm.cloud.sdk.core.service.exception.ServiceResponseException;
 import com.ibm.cloud.sdk.core.util.CredentialUtils;
@@ -69,6 +82,8 @@ public class IamPolicyManagementExamples {
   private static String exampleAccountId = null;
   private static String examplePolicyId = null;
   private static String examplePolicyEtag = null;
+  private static String exampleV2PolicyId = null;
+  private static String exampleV2PolicyEtag = null;
   private static String exampleCustomRoleId = null;
   private static String exampleCustomRoleEtag = null;
 
@@ -288,6 +303,247 @@ public class IamPolicyManagementExamples {
       Response<Void> response = service.deletePolicy(options).execute();
 
       // end-delete_policy
+
+      System.out.printf("deletePolicy() response status code: %d%n", response.getStatusCode());
+    } catch (ServiceResponseException e) {
+      logger.error(String.format("Service returned status code %s: %s\nError details: %s",
+              e.getStatusCode(), e.getMessage(), e.getDebuggingInfo()), e);
+    }
+
+    try {
+      System.out.println("v2CreatePolicy() result:");
+
+      // begin-v2_create_policy
+
+      V2PolicyAttribute subjectAttribute = new V2PolicyAttribute.Builder()
+              .key("iam_id")
+              .value(EXAMPLE_USER_ID)
+              .operator("stringEquals")
+              .build();
+
+      V2PolicyBaseSubject policySubject = new V2PolicyBaseSubject.Builder()
+              .addAttributes(subjectAttribute)
+              .build();
+
+      V2PolicyAttribute accountIdResourceAttribute = new V2PolicyAttribute.Builder()
+              .key("accountId")
+              .value(exampleAccountId)
+              .operator("stringEquals")
+              .build();
+
+      V2PolicyAttribute serviceNameResourceAttribute = new V2PolicyAttribute.Builder()
+              .key("serviceType")
+              .value("service")
+              .operator("stringEquals")
+              .build();
+
+      V2PolicyBaseResource policyResource = new V2PolicyBaseResource.Builder()
+              .addAttributes(accountIdResourceAttribute)
+              .addAttributes(serviceNameResourceAttribute)
+              .build();
+
+      PolicyRole policyRoles = new PolicyRole.Builder()
+              .roleId("crn:v1:bluemix:public:iam::::role:Viewer")
+              .build();
+
+      V2PolicyBaseControlGrant policyGrant = new V2PolicyBaseControlGrant.Builder()
+              .roles(Arrays.asList(policyRoles))
+              .build();
+
+      V2PolicyBaseControl policyControl = new V2PolicyBaseControl.Builder()
+              .grant(policyGrant)
+              .build();
+
+      V2PolicyAttribute weeklyConditionAttribute = new V2PolicyAttribute.Builder()
+              .key("{{environment.attributes.day_of_week}}")
+              .value(new ArrayList<Integer>(Arrays.asList(1, 2, 3, 4, 5)))
+              .operator("dayOfWeekAnyOf")
+              .build();
+
+      V2PolicyAttribute startConditionAttribute = new V2PolicyAttribute.Builder()
+              .key("{{environment.attributes.current_time}}")
+              .value("09:00:00+00:00")
+              .operator("timeGreaterThanOrEquals")
+              .build();
+
+      V2PolicyAttribute endConditionAttribute = new V2PolicyAttribute.Builder()
+              .key("{{environment.attributes.current_time}}")
+              .value("17:00:00+00:00")
+              .operator("timeLessThanOrEquals")
+              .build();
+
+      V2PolicyBaseRuleV2RuleWithConditions policyRule = new V2PolicyBaseRuleV2RuleWithConditions.Builder()
+              .operator("and")
+              .conditions(new ArrayList<V2PolicyAttribute>(Arrays.asList(weeklyConditionAttribute, startConditionAttribute, endConditionAttribute)))
+              .build();
+
+      V2CreatePolicyOptions options = new V2CreatePolicyOptions.Builder()
+              .type("access")
+              .subject(policySubject)
+              .control(policyControl)
+              .resource(policyResource)
+              .rule(policyRule)
+              .pattern("time-based-restrictions:weekly")
+              .build();
+
+      Response<V2Policy> response = service.v2CreatePolicy(options).execute();
+      V2Policy policy = response.getResult();
+
+      System.out.println(policy);
+
+      // end-v2_create_policy
+
+      exampleV2PolicyId = policy.getId();
+    } catch (ServiceResponseException e) {
+      logger.error(String.format("Service returned status code %s: %s\nError details: %s",
+              e.getStatusCode(), e.getMessage(), e.getDebuggingInfo()), e);
+    }
+
+    try {
+      System.out.println("v2GetPolicy() result:");
+
+      // begin-v2_get_policy
+
+      V2GetPolicyOptions options = new V2GetPolicyOptions.Builder()
+              .policyId(exampleV2PolicyId)
+              .build();
+
+      Response<V2Policy> response = service.v2GetPolicy(options).execute();
+      V2Policy policy = response.getResult();
+
+      System.out.println(policy);
+
+      // end-v2_get_policy
+
+      exampleV2PolicyEtag = response.getHeaders().values("Etag").get(0);
+    } catch (ServiceResponseException e) {
+      logger.error(String.format("Service returned status code %s: %s\nError details: %s",
+              e.getStatusCode(), e.getMessage(), e.getDebuggingInfo()), e);
+    }
+
+    try {
+      System.out.println("v2UpdatePolicy() result:");
+
+      // begin-v2_update_policy
+
+      V2PolicyAttribute subjectAttribute = new V2PolicyAttribute.Builder()
+              .key("iam_id")
+              .value(EXAMPLE_USER_ID)
+              .operator("stringEquals")
+              .build();
+
+      V2PolicyBaseSubject policySubject = new V2PolicyBaseSubject.Builder()
+              .addAttributes(subjectAttribute)
+              .build();
+
+      V2PolicyAttribute accountIdResourceAttribute = new V2PolicyAttribute.Builder()
+              .key("accountId")
+              .value(exampleAccountId)
+              .operator("stringEquals")
+              .build();
+
+      V2PolicyAttribute serviceNameResourceAttribute = new V2PolicyAttribute.Builder()
+              .key("serviceType")
+              .value("service")
+              .operator("stringEquals")
+              .build();
+
+      V2PolicyBaseResource policyResource = new V2PolicyBaseResource.Builder()
+              .addAttributes(accountIdResourceAttribute)
+              .addAttributes(serviceNameResourceAttribute)
+              .build();
+
+      PolicyRole updatedPolicyRole = new PolicyRole.Builder()
+              .roleId("crn:v1:bluemix:public:iam::::role:Editor")
+              .build();
+      V2PolicyBaseControlGrant policyGrant = new V2PolicyBaseControlGrant.Builder()
+              .roles(Arrays.asList(updatedPolicyRole))
+              .build();
+
+      V2PolicyBaseControl policyControl = new V2PolicyBaseControl.Builder()
+              .grant(policyGrant)
+              .build();
+
+      V2PolicyAttribute weeklyConditionAttribute = new V2PolicyAttribute.Builder()
+              .key("{{environment.attributes.day_of_week}}")
+              .value(new ArrayList<Integer>(Arrays.asList(1, 2, 3, 4, 5)))
+              .operator("dayOfWeekAnyOf")
+              .build();
+
+      V2PolicyAttribute startConditionAttribute = new V2PolicyAttribute.Builder()
+              .key("{{environment.attributes.current_time}}")
+              .value("09:00:00+00:00")
+              .operator("timeGreaterThanOrEquals")
+              .build();
+
+      V2PolicyAttribute endConditionAttribute = new V2PolicyAttribute.Builder()
+              .key("{{environment.attributes.current_time}}")
+              .value("17:00:00+00:00")
+              .operator("timeLessThanOrEquals")
+              .build();
+
+      V2PolicyBaseRuleV2RuleWithConditions policyRule = new V2PolicyBaseRuleV2RuleWithConditions.Builder()
+              .operator("and")
+              .conditions(new ArrayList<V2PolicyAttribute>(Arrays.asList(weeklyConditionAttribute, startConditionAttribute, endConditionAttribute)))
+              .build();
+
+      V2UpdatePolicyOptions options = new V2UpdatePolicyOptions.Builder()
+              .type("access")
+              .policyId(exampleV2PolicyId)
+              .ifMatch(exampleV2PolicyEtag)
+              .subject(policySubject)
+              .control(policyControl)
+              .resource(policyResource)
+              .rule(policyRule)
+              .pattern("time-based-restrictions:weekly")
+              .build();
+
+      Response<V2Policy> response = service.v2UpdatePolicy(options).execute();
+      V2Policy policy = response.getResult();
+
+      System.out.println(policy);
+
+      // end-v2_update_policy
+
+      exampleV2PolicyEtag = response.getHeaders().values("Etag").get(0);
+    } catch (ServiceResponseException e) {
+      logger.error(String.format("Service returned status code %s: %s\nError details: %s",
+              e.getStatusCode(), e.getMessage(), e.getDebuggingInfo()), e);
+    }
+
+    try {
+      System.out.println("v2ListPolicies() result:");
+
+      // begin-v2_list_policies
+
+      V2ListPoliciesOptions options = new V2ListPoliciesOptions.Builder()
+              .accountId(exampleAccountId)
+              .iamId(EXAMPLE_USER_ID)
+              .format("include_last_permit")
+              .build();
+
+      Response<V2PolicyList> response = service.v2ListPolicies(options).execute();
+      V2PolicyList policyList = response.getResult();
+
+      System.out.println(policyList);
+
+      // end-v2_list_policies
+
+    } catch (ServiceResponseException e) {
+        logger.error(String.format("Service returned status code %s: %s\nError details: %s",
+          e.getStatusCode(), e.getMessage(), e.getDebuggingInfo()), e);
+    }
+
+    try {
+      // begin-v2_delete_policy
+
+      V2DeletePolicyOptions options = new V2DeletePolicyOptions.Builder()
+              .policyId(examplePolicyId)
+              .build();
+
+      Response<Void> response = service.v2DeletePolicy(options).execute();
+
+      // end-v2_delete_policy
 
       System.out.printf("deletePolicy() response status code: %d%n", response.getStatusCode());
     } catch (ServiceResponseException e) {

--- a/modules/iam-policy-management/src/main/java/com/ibm/cloud/platform_services/iam_policy_management/v1/IamPolicyManagement.java
+++ b/modules/iam-policy-management/src/main/java/com/ibm/cloud/platform_services/iam_policy_management/v1/IamPolicyManagement.java
@@ -34,6 +34,13 @@ import com.ibm.cloud.platform_services.iam_policy_management.v1.model.PolicyList
 import com.ibm.cloud.platform_services.iam_policy_management.v1.model.RoleList;
 import com.ibm.cloud.platform_services.iam_policy_management.v1.model.UpdatePolicyOptions;
 import com.ibm.cloud.platform_services.iam_policy_management.v1.model.UpdateRoleOptions;
+import com.ibm.cloud.platform_services.iam_policy_management.v1.model.V2CreatePolicyOptions;
+import com.ibm.cloud.platform_services.iam_policy_management.v1.model.V2DeletePolicyOptions;
+import com.ibm.cloud.platform_services.iam_policy_management.v1.model.V2GetPolicyOptions;
+import com.ibm.cloud.platform_services.iam_policy_management.v1.model.V2ListPoliciesOptions;
+import com.ibm.cloud.platform_services.iam_policy_management.v1.model.V2Policy;
+import com.ibm.cloud.platform_services.iam_policy_management.v1.model.V2PolicyList;
+import com.ibm.cloud.platform_services.iam_policy_management.v1.model.V2UpdatePolicyOptions;
 import com.ibm.cloud.sdk.core.http.RequestBuilder;
 import com.ibm.cloud.sdk.core.http.ResponseConverter;
 import com.ibm.cloud.sdk.core.http.ServiceCall;
@@ -543,6 +550,307 @@ public class IamPolicyManagement extends BaseService {
     pathParamsMap.put("role_id", deleteRoleOptions.roleId());
     RequestBuilder builder = RequestBuilder.delete(RequestBuilder.resolveRequestUrl(getServiceUrl(), "/v2/roles/{role_id}", pathParamsMap));
     Map<String, String> sdkHeaders = SdkCommon.getSdkHeaders("iam_policy_management", "v1", "deleteRole");
+    for (Entry<String, String> header : sdkHeaders.entrySet()) {
+      builder.header(header.getKey(), header.getValue());
+    }
+    ResponseConverter<Void> responseConverter = ResponseConverterUtils.getVoid();
+    return createServiceCall(builder.build(), responseConverter);
+  }
+
+  /**
+   * Get policies by attributes.
+   *
+   * Get policies and filter by attributes. While managing policies, you may want to retrieve policies in the account
+   * and filter by attribute values. This can be done through query parameters. Currently, only the following attributes
+   * are supported: account_id, iam_id, access_group_id, type, service_type, sort, format and state. account_id is a
+   * required query parameter. Only policies that have the specified attributes and that the caller has read access to
+   * are returned. If the caller does not have read access to any policies an empty array is returned.
+   *
+   * @param v2ListPoliciesOptions the {@link V2ListPoliciesOptions} containing the options for the call
+   * @return a {@link ServiceCall} with a result of type {@link V2PolicyList}
+   */
+  public ServiceCall<V2PolicyList> v2ListPolicies(V2ListPoliciesOptions v2ListPoliciesOptions) {
+    com.ibm.cloud.sdk.core.util.Validator.notNull(v2ListPoliciesOptions,
+      "v2ListPoliciesOptions cannot be null");
+    RequestBuilder builder = RequestBuilder.get(RequestBuilder.resolveRequestUrl(getServiceUrl(), "/v2/policies"));
+    Map<String, String> sdkHeaders = SdkCommon.getSdkHeaders("iam_policy_management", "v1", "v2ListPolicies");
+    for (Entry<String, String> header : sdkHeaders.entrySet()) {
+      builder.header(header.getKey(), header.getValue());
+    }
+    builder.header("Accept", "application/json");
+    if (v2ListPoliciesOptions.acceptLanguage() != null) {
+      builder.header("Accept-Language", v2ListPoliciesOptions.acceptLanguage());
+    }
+    builder.query("account_id", String.valueOf(v2ListPoliciesOptions.accountId()));
+    if (v2ListPoliciesOptions.iamId() != null) {
+      builder.query("iam_id", String.valueOf(v2ListPoliciesOptions.iamId()));
+    }
+    if (v2ListPoliciesOptions.accessGroupId() != null) {
+      builder.query("access_group_id", String.valueOf(v2ListPoliciesOptions.accessGroupId()));
+    }
+    if (v2ListPoliciesOptions.type() != null) {
+      builder.query("type", String.valueOf(v2ListPoliciesOptions.type()));
+    }
+    if (v2ListPoliciesOptions.serviceType() != null) {
+      builder.query("service_type", String.valueOf(v2ListPoliciesOptions.serviceType()));
+    }
+    if (v2ListPoliciesOptions.serviceName() != null) {
+      builder.query("service_name", String.valueOf(v2ListPoliciesOptions.serviceName()));
+    }
+    if (v2ListPoliciesOptions.serviceGroupId() != null) {
+      builder.query("service_group_id", String.valueOf(v2ListPoliciesOptions.serviceGroupId()));
+    }
+    if (v2ListPoliciesOptions.format() != null) {
+      builder.query("format", String.valueOf(v2ListPoliciesOptions.format()));
+    }
+    if (v2ListPoliciesOptions.state() != null) {
+      builder.query("state", String.valueOf(v2ListPoliciesOptions.state()));
+    }
+    ResponseConverter<V2PolicyList> responseConverter =
+      ResponseConverterUtils.getValue(new com.google.gson.reflect.TypeToken<V2PolicyList>() { }.getType());
+    return createServiceCall(builder.build(), responseConverter);
+  }
+
+  /**
+   * Create a policy.
+   *
+   * Creates a policy to grant access between a subject and a resource. Currently, there is one type of a v2/policy:
+   * **access**. A policy administrator might want to create an access policy which grants access to a user, service-id,
+   * or an access group.
+   *
+   * ### Access
+   *
+   * To create an access policy, use **`"type": "access"`** in the body. The possible subject attributes are
+   * **`iam_id`** and **`access_group_id`**. Use the **`iam_id`** subject attribute for assigning access for a user or
+   * service-id. Use the **`access_group_id`** subject attribute for assigning access for an access group. The roles
+   * must be a subset of a service's or the platform's supported roles. The resource attributes must be a subset of a
+   * service's or the platform's supported attributes. The policy resource must include either the **`serviceType`**,
+   * **`serviceName`**, **`resourceGroupId`** or **`service_group_id`** attribute and the **`accountId`** attribute.`
+   * The rule field can either specify single **`key`**, **`value`**, and **`operator`** or be set of **`conditions`**
+   * with a combination **`operator`**.  The possible combination operator are **`and`** and **`or`**. The rule field
+   * has a maximum of 2 levels of nested **`conditions`**. The operator for a rule can be used to specify a time based
+   * restriction (e.g., access only during business hours, during the Monday-Friday work week). For example, a policy
+   * can grant access Monday-Friday, 9:00am-5:00pm using the following rule:
+   * ```json
+   *   "rule": {
+   *     "operator": "and",
+   *     "conditions": [{
+   *       "key": "{{environment.attributes.day_of_week}}",
+   *       "operator": "dayOfWeekAnyOf",
+   *       "value": [1, 2, 3, 4, 5]
+   *     },
+   *       "key": "{{environment.attributes.current_time}}",
+   *       "operator": "timeGreaterThanOrEquals",
+   *       "value": "09:00:00+00:00"
+   *     },
+   *       "key": "{{environment.attributes.current_time}}",
+   *       "operator": "timeLessThanOrEquals",
+   *       "value": "17:00:00+00:00"
+   *     }]
+   *   }
+   * ``` Rules and conditions allow the following operators with **`key`**, **`value`** :
+   * ```
+   *   'timeLessThan', 'timeLessThanOrEquals', 'timeGreaterThan', 'timeGreaterThanOrEquals',
+   *   'dateLessThan', 'dateLessThanOrEquals', 'dateGreaterThan', 'dateGreaterThanOrEquals',
+   *   'dateTimeLessThan', 'dateTimeLessThanOrEquals', 'dateTimeGreaterThan', 'dateTimeGreaterThanOrEquals',
+   *   'dayOfWeekEquals', 'dayOfWeekAnyOf',
+   *   'monthEquals', 'monthAnyOf',
+   *   'dayOfMonthEquals', 'dayOfMonthAnyOf'
+   * ``` The pattern field can be coupled with a rule that matches the pattern. For the business hour rule example
+   * above, the **`pattern`** is **`"time-based-restrictions:weekly"`**. The IAM Services group (`IAM`) is a subset of
+   * account management services that includes the IAM platform services IAM Identity, IAM Access Management, IAM Users
+   * Management, IAM Groups, and future IAM services. If the subject is a locked service-id, the request will fail.
+   *
+   * ### Attribute Operators
+   *
+   * Currently, only the `stringEquals`, `stringMatch`, and `stringEquals` operators are available. For more
+   * information, see [how to assign access by using wildcards
+   * policies](https://cloud.ibm.com/docs/account?topic=account-wildcard).
+   *
+   * ### Attribute Validations
+   *
+   * Policy attribute values must be between 1 and 1,000 characters in length. If location related attributes like
+   * geography, country, metro, region, satellite, and locationvalues are supported by the service, they are validated
+   * against Global Catalog locations.
+   *
+   * @param v2CreatePolicyOptions the {@link V2CreatePolicyOptions} containing the options for the call
+   * @return a {@link ServiceCall} with a result of type {@link V2Policy}
+   */
+  public ServiceCall<V2Policy> v2CreatePolicy(V2CreatePolicyOptions v2CreatePolicyOptions) {
+    com.ibm.cloud.sdk.core.util.Validator.notNull(v2CreatePolicyOptions,
+      "v2CreatePolicyOptions cannot be null");
+    RequestBuilder builder = RequestBuilder.post(RequestBuilder.resolveRequestUrl(getServiceUrl(), "/v2/policies"));
+    Map<String, String> sdkHeaders = SdkCommon.getSdkHeaders("iam_policy_management", "v1", "v2CreatePolicy");
+    for (Entry<String, String> header : sdkHeaders.entrySet()) {
+      builder.header(header.getKey(), header.getValue());
+    }
+    builder.header("Accept", "application/json");
+    if (v2CreatePolicyOptions.acceptLanguage() != null) {
+      builder.header("Accept-Language", v2CreatePolicyOptions.acceptLanguage());
+    }
+    final JsonObject contentJson = new JsonObject();
+    contentJson.addProperty("type", v2CreatePolicyOptions.type());
+    contentJson.add("control", com.ibm.cloud.sdk.core.util.GsonSingleton.getGson().toJsonTree(v2CreatePolicyOptions.control()));
+    if (v2CreatePolicyOptions.description() != null) {
+      contentJson.addProperty("description", v2CreatePolicyOptions.description());
+    }
+    if (v2CreatePolicyOptions.subject() != null) {
+      contentJson.add("subject", com.ibm.cloud.sdk.core.util.GsonSingleton.getGson().toJsonTree(v2CreatePolicyOptions.subject()));
+    }
+    if (v2CreatePolicyOptions.resource() != null) {
+      contentJson.add("resource", com.ibm.cloud.sdk.core.util.GsonSingleton.getGson().toJsonTree(v2CreatePolicyOptions.resource()));
+    }
+    if (v2CreatePolicyOptions.pattern() != null) {
+      contentJson.addProperty("pattern", v2CreatePolicyOptions.pattern());
+    }
+    if (v2CreatePolicyOptions.rule() != null) {
+      contentJson.add("rule", com.ibm.cloud.sdk.core.util.GsonSingleton.getGson().toJsonTree(v2CreatePolicyOptions.rule()));
+    }
+    builder.bodyJson(contentJson);
+    ResponseConverter<V2Policy> responseConverter =
+      ResponseConverterUtils.getValue(new com.google.gson.reflect.TypeToken<V2Policy>() { }.getType());
+    return createServiceCall(builder.build(), responseConverter);
+  }
+
+  /**
+   * Update a policy.
+   *
+   * Update a policy to grant access between a subject and a resource. A policy administrator might want to update an
+   * existing policy.
+   *
+   * ### Access
+   *
+   * To update an access policy, use **`"type": "access"`** in the body. The possible subject attributes are
+   * **`iam_id`** and **`access_group_id`**. Use the **`iam_id`** subject attribute for assigning access for a user or
+   * service-id. Use the **`access_group_id`** subject attribute for assigning access for an access group. The roles
+   * must be a subset of a service's or the platform's supported roles. The resource attributes must be a subset of a
+   * service's or the platform's supported attributes. The policy resource must include either the **`serviceType`**,
+   * **`serviceName`**,  or **`resourceGroupId`** attribute and the **`accountId`** attribute.` The rule field can
+   * either specify single **`key`**, **`value`**, and **`operator`** or be set of **`conditions`** with a combination
+   * **`operator`**.  The possible combination operator are **`and`** and **`or`**. The rule field has a maximum of 2
+   * levels of nested **`conditions`**. The operator for a rule can be used to specify a time based restriction (e.g.,
+   * access only during business hours, during the Monday-Friday work week). For example, a policy can grant access
+   * Monday-Friday, 9:00am-5:00pm using the following rule:
+   * ```json
+   *   "rule": {
+   *     "operator": "and",
+   *     "conditions": [{
+   *       "key": "{{environment.attributes.day_of_week}}",
+   *       "operator": "dayOfWeekAnyOf",
+   *       "value": [1, 2, 3, 4, 5]
+   *     },
+   *       "key": "{{environment.attributes.current_time}}",
+   *       "operator": "timeGreaterThanOrEquals",
+   *       "value": "09:00:00+00:00"
+   *     },
+   *       "key": "{{environment.attributes.current_time}}",
+   *       "operator": "timeLessThanOrEquals",
+   *       "value": "17:00:00+00:00"
+   *     }]
+   *   }
+   * ``` Rules and conditions allow the following operators with **`key`**, **`value`** :
+   * ```
+   *   'timeLessThan', 'timeLessThanOrEquals', 'timeGreaterThan', 'timeGreaterThanOrEquals',
+   *   'dateLessThan', 'dateLessThanOrEquals', 'dateGreaterThan', 'dateGreaterThanOrEquals',
+   *   'dateTimeLessThan', 'dateTimeLessThanOrEquals', 'dateTimeGreaterThan', 'dateTimeGreaterThanOrEquals',
+   *   'dayOfWeekEquals', 'dayOfWeekAnyOf',
+   *   'monthEquals', 'monthAnyOf',
+   *   'dayOfMonthEquals', 'dayOfMonthAnyOf'
+   * ``` The pattern field can be coupled with a rule that matches the pattern. For the business hour rule example
+   * above, the **`pattern`** is **`"time-based-restrictions:weekly"`**. If the subject is a locked service-id, the
+   * request will fail.
+   *
+   * ### Attribute Operators
+   *
+   * Currently, only the `stringEquals`, `stringMatch`, and `stringEquals` operators are available. For more
+   * information, see [how to assign access by using wildcards
+   * policies](https://cloud.ibm.com/docs/account?topic=account-wildcard).
+   *
+   * ### Attribute Validations
+   *
+   * Policy attribute values must be between 1 and 1,000 characters in length. If location related attributes like
+   * geography, country, metro, region, satellite, and locationvalues are supported by the service, they are validated
+   * against Global Catalog locations.
+   *
+   * @param v2UpdatePolicyOptions the {@link V2UpdatePolicyOptions} containing the options for the call
+   * @return a {@link ServiceCall} with a result of type {@link V2Policy}
+   */
+  public ServiceCall<V2Policy> v2UpdatePolicy(V2UpdatePolicyOptions v2UpdatePolicyOptions) {
+    com.ibm.cloud.sdk.core.util.Validator.notNull(v2UpdatePolicyOptions,
+      "v2UpdatePolicyOptions cannot be null");
+    Map<String, String> pathParamsMap = new HashMap<String, String>();
+    pathParamsMap.put("policy_id", v2UpdatePolicyOptions.policyId());
+    RequestBuilder builder = RequestBuilder.put(RequestBuilder.resolveRequestUrl(getServiceUrl(), "/v2/policies/{policy_id}", pathParamsMap));
+    Map<String, String> sdkHeaders = SdkCommon.getSdkHeaders("iam_policy_management", "v1", "v2UpdatePolicy");
+    for (Entry<String, String> header : sdkHeaders.entrySet()) {
+      builder.header(header.getKey(), header.getValue());
+    }
+    builder.header("Accept", "application/json");
+    builder.header("If-Match", v2UpdatePolicyOptions.ifMatch());
+    final JsonObject contentJson = new JsonObject();
+    contentJson.addProperty("type", v2UpdatePolicyOptions.type());
+    contentJson.add("control", com.ibm.cloud.sdk.core.util.GsonSingleton.getGson().toJsonTree(v2UpdatePolicyOptions.control()));
+    if (v2UpdatePolicyOptions.description() != null) {
+      contentJson.addProperty("description", v2UpdatePolicyOptions.description());
+    }
+    if (v2UpdatePolicyOptions.subject() != null) {
+      contentJson.add("subject", com.ibm.cloud.sdk.core.util.GsonSingleton.getGson().toJsonTree(v2UpdatePolicyOptions.subject()));
+    }
+    if (v2UpdatePolicyOptions.resource() != null) {
+      contentJson.add("resource", com.ibm.cloud.sdk.core.util.GsonSingleton.getGson().toJsonTree(v2UpdatePolicyOptions.resource()));
+    }
+    if (v2UpdatePolicyOptions.pattern() != null) {
+      contentJson.addProperty("pattern", v2UpdatePolicyOptions.pattern());
+    }
+    if (v2UpdatePolicyOptions.rule() != null) {
+      contentJson.add("rule", com.ibm.cloud.sdk.core.util.GsonSingleton.getGson().toJsonTree(v2UpdatePolicyOptions.rule()));
+    }
+    builder.bodyJson(contentJson);
+    ResponseConverter<V2Policy> responseConverter =
+      ResponseConverterUtils.getValue(new com.google.gson.reflect.TypeToken<V2Policy>() { }.getType());
+    return createServiceCall(builder.build(), responseConverter);
+  }
+
+  /**
+   * Retrieve a policy by ID.
+   *
+   * Retrieve a policy by providing a policy ID.
+   *
+   * @param v2GetPolicyOptions the {@link V2GetPolicyOptions} containing the options for the call
+   * @return a {@link ServiceCall} with a result of type {@link V2Policy}
+   */
+  public ServiceCall<V2Policy> v2GetPolicy(V2GetPolicyOptions v2GetPolicyOptions) {
+    com.ibm.cloud.sdk.core.util.Validator.notNull(v2GetPolicyOptions,
+      "v2GetPolicyOptions cannot be null");
+    Map<String, String> pathParamsMap = new HashMap<String, String>();
+    pathParamsMap.put("policy_id", v2GetPolicyOptions.policyId());
+    RequestBuilder builder = RequestBuilder.get(RequestBuilder.resolveRequestUrl(getServiceUrl(), "/v2/policies/{policy_id}", pathParamsMap));
+    Map<String, String> sdkHeaders = SdkCommon.getSdkHeaders("iam_policy_management", "v1", "v2GetPolicy");
+    for (Entry<String, String> header : sdkHeaders.entrySet()) {
+      builder.header(header.getKey(), header.getValue());
+    }
+    builder.header("Accept", "application/json");
+    ResponseConverter<V2Policy> responseConverter =
+      ResponseConverterUtils.getValue(new com.google.gson.reflect.TypeToken<V2Policy>() { }.getType());
+    return createServiceCall(builder.build(), responseConverter);
+  }
+
+  /**
+   * Delete a policy by ID.
+   *
+   * Delete a policy by providing a policy ID. A policy cannot be deleted if the subject ID contains a locked service
+   * ID. If the subject of the policy is a locked service-id, the request will fail.
+   *
+   * @param v2DeletePolicyOptions the {@link V2DeletePolicyOptions} containing the options for the call
+   * @return a {@link ServiceCall} with a void result
+   */
+  public ServiceCall<Void> v2DeletePolicy(V2DeletePolicyOptions v2DeletePolicyOptions) {
+    com.ibm.cloud.sdk.core.util.Validator.notNull(v2DeletePolicyOptions,
+      "v2DeletePolicyOptions cannot be null");
+    Map<String, String> pathParamsMap = new HashMap<String, String>();
+    pathParamsMap.put("policy_id", v2DeletePolicyOptions.policyId());
+    RequestBuilder builder = RequestBuilder.delete(RequestBuilder.resolveRequestUrl(getServiceUrl(), "/v2/policies/{policy_id}", pathParamsMap));
+    Map<String, String> sdkHeaders = SdkCommon.getSdkHeaders("iam_policy_management", "v1", "v2DeletePolicy");
     for (Entry<String, String> header : sdkHeaders.entrySet()) {
       builder.header(header.getKey(), header.getValue());
     }

--- a/modules/iam-policy-management/src/test/java/com/ibm/cloud/platform_services/iam_policy_management/v1/IamPolicyManagementIT.java
+++ b/modules/iam-policy-management/src/test/java/com/ibm/cloud/platform_services/iam_policy_management/v1/IamPolicyManagementIT.java
@@ -298,6 +298,244 @@ public class IamPolicyManagementIT extends SdkIntegrationTestBase {
     }
 
     @Test
+    public void testCreateV2AccessPolicy() {
+
+        V2PolicyAttribute resourceAttributeAccount = new V2PolicyAttribute.Builder()
+          .key("accountId")
+          .value(testAccountId)
+          .operator("stringEquals")
+          .build();
+
+        V2PolicyAttribute resourceAttributeService = new V2PolicyAttribute.Builder()
+          .key("serviceType")
+          .value("service")
+          .operator("stringEquals")
+          .build();
+
+        V2PolicyAttribute subjectAttributeModel = new V2PolicyAttribute.Builder()
+          .key("iam_id")
+          .value(TEST_USER_ID)
+          .operator("stringEquals")
+          .build();
+
+        V2PolicyBaseResource policyResourceModel = new V2PolicyBaseResource.Builder()
+          .attributes(new ArrayList<V2PolicyAttribute>(Arrays.asList(resourceAttributeAccount,
+            resourceAttributeService)))
+          .build();
+
+        V2PolicyBaseSubject policySubjectModel = new V2PolicyBaseSubject.Builder()
+          .attributes(new ArrayList<V2PolicyAttribute>(Arrays.asList(subjectAttributeModel)))
+          .build();
+
+        PolicyRole policyRoleModel = new PolicyRole.Builder()
+          .roleId(TEST_VIEW_ROLE_CRN)
+          .build();
+        
+        V2PolicyBaseControlGrant policyGrantModel = new V2PolicyBaseControlGrant.Builder()
+          .roles(Arrays.asList(policyRoleModel))
+          .build();
+
+        V2PolicyBaseControl policyControlModel = new V2PolicyBaseControl.Builder()
+          .grant(policyGrantModel)
+          .build();
+
+        V2PolicyAttribute weeklyConditionAttributeModel = new V2PolicyAttribute.Builder()
+          .key("{{environment.attributes.day_of_week}}")
+          .value(new ArrayList<Integer>(Arrays.asList(1, 2, 3, 4, 5)))
+          .operator("dayOfWeekAnyOf")
+          .build();
+        
+
+        V2PolicyAttribute startConditionAttributeModel = new V2PolicyAttribute.Builder()
+          .key("{{environment.attributes.current_time}}")
+          .value("09:00:00+00:00")
+          .operator("timeGreaterThanOrEquals")
+          .build();
+
+        V2PolicyAttribute endConditionAttributeModel = new V2PolicyAttribute.Builder()
+          .key("{{environment.attributes.current_time}}")
+          .value("17:00:00+00:00")
+          .operator("timeLessThanOrEquals")
+          .build();
+
+        V2PolicyBaseRuleV2RuleWithConditions policyRuleModel = new V2PolicyBaseRuleV2RuleWithConditions.Builder()
+          .operator("and")
+          .conditions(new ArrayList<V2PolicyAttribute>(Arrays.asList(weeklyConditionAttributeModel,
+            startConditionAttributeModel, endConditionAttributeModel)))
+          .build();
+
+        V2CreatePolicyOptions options = new V2CreatePolicyOptions.Builder()
+          .type(POLICY_TYPE)
+          .subject(policySubjectModel)
+          .control(policyControlModel)
+          .resource(policyResourceModel)
+          .rule(policyRuleModel)
+          .pattern("time-based-restrictions:weekly")
+          .build();
+
+        Response<V2Policy> response = service.v2CreatePolicy(options).execute();
+        assertNotNull(response);
+        assertEquals(response.getStatusCode(), 201);
+
+        V2Policy result = response.getResult();
+        assertNotNull(result);
+        assertEquals(result.getType(), POLICY_TYPE);
+        assertEquals(result.getSubject(), policySubjectModel);
+        assertEquals(result.getResource(), policyResourceModel);
+        assertEquals(result.getControl(), policyControlModel);
+        assertEquals(result.getRule().operator(), policyRuleModel.operator());
+        assertEquals(result.getPattern(), "time-based-restrictions:weekly");
+
+        testV2PolicyId = result.getId();
+    }
+
+    @Test(dependsOnMethods = {"testCreateV2AccessPolicy"})
+    public void testGetV2AccessPolicy() {
+        assertNotNull(testV2PolicyId);
+
+        V2GetPolicyOptions options = new V2GetPolicyOptions.Builder()
+                .policyId(testV2PolicyId)
+                .build();
+
+        Response<V2Policy> response = service.v2GetPolicy(options).execute();
+        assertNotNull(response);
+        assertEquals(response.getStatusCode(), 200);
+
+        V2Policy result = response.getResult();
+        assertNotNull(result);
+        assertEquals(result.getId(), testV2PolicyId);
+
+
+        List<String> values = response.getHeaders().values(HEADER_ETAG);
+        assertNotNull(values);
+        testV2PolicyEtag = values.get(0);
+    }
+
+    @Test(dependsOnMethods = {"testGetV2AccessPolicy"})
+    public void testUpdateV2AccessPolicy() {
+        assertNotNull(testV2PolicyId);
+        assertNotNull(testV2PolicyEtag);
+
+        V2PolicyAttribute resourceAttributeAccount = new V2PolicyAttribute.Builder()
+          .key("accountId")
+          .value(testAccountId)
+          .operator("stringEquals")
+          .build();
+
+        V2PolicyAttribute resourceAttributeService = new V2PolicyAttribute.Builder()
+          .key("serviceName")
+          .value(TEST_SERVICE_NAME)
+          .operator("stringEquals")
+          .build();
+
+        V2PolicyAttribute subjectAttributeModel = new V2PolicyAttribute.Builder()
+          .key("iam_id")
+          .value(TEST_USER_ID)
+          .operator("stringEquals")
+          .build();
+
+        V2PolicyBaseResource policyResourceModel = new V2PolicyBaseResource.Builder()
+          .attributes(new ArrayList<V2PolicyAttribute>(Arrays.asList(resourceAttributeAccount,
+            resourceAttributeService)))
+          .build();
+
+        V2PolicyBaseSubject policySubjectModel = new V2PolicyBaseSubject.Builder()
+          .attributes(new ArrayList<V2PolicyAttribute>(Arrays.asList(subjectAttributeModel)))
+          .build();
+        
+        PolicyRole policyRoleModel = new PolicyRole.Builder()
+          .roleId(TEST_EDITOR_ROLE_CRN)
+          .build();
+
+        V2PolicyBaseControlGrant policyGrantModel = new V2PolicyBaseControlGrant.Builder()
+          .roles(Arrays.asList(policyRoleModel))
+          .build();
+
+        V2PolicyBaseControl policyControlModel = new V2PolicyBaseControl.Builder()
+          .grant(policyGrantModel)
+          .build();
+        V2PolicyAttribute weeklyConditionAttributeModel = new V2PolicyAttribute.Builder()
+          .key("{{environment.attributes.day_of_week}}")
+          .value(new ArrayList<Integer>(Arrays.asList(1, 2, 3, 4, 5)))
+          .operator("dayOfWeekAnyOf")
+          .build();
+        
+
+        V2PolicyAttribute startConditionAttributeModel = new V2PolicyAttribute.Builder()
+          .key("{{environment.attributes.current_time}}")
+          .value("09:00:00+00:00")
+          .operator("timeGreaterThanOrEquals")
+          .build();
+
+        V2PolicyAttribute endConditionAttributeModel = new V2PolicyAttribute.Builder()
+          .key("{{environment.attributes.current_time}}")
+          .value("17:00:00+00:00")
+          .operator("timeLessThanOrEquals")
+          .build();
+
+        V2PolicyBaseRuleV2RuleWithConditions policyRuleModel = new V2PolicyBaseRuleV2RuleWithConditions.Builder()
+          .operator("and")
+          .conditions(new ArrayList<V2PolicyAttribute>(Arrays.asList(weeklyConditionAttributeModel,
+            startConditionAttributeModel, endConditionAttributeModel)))
+          .build();
+
+        V2UpdatePolicyOptions options = new V2UpdatePolicyOptions.Builder()
+                .policyId(testV2PolicyId)
+                .ifMatch(testV2PolicyEtag)
+                .type(POLICY_TYPE)
+                .subject(policySubjectModel)
+                .control(policyControlModel)
+                .resource(policyResourceModel)
+                .rule(policyRuleModel)
+                .pattern("time-based-restrictions:weekly")
+                .build();
+
+        Response<V2Policy> response = service.v2UpdatePolicy(options).execute();
+        assertNotNull(response);
+        assertEquals(response.getStatusCode(), 200);
+
+        V2Policy result = response.getResult();
+        assertNotNull(result);
+        assertEquals(result.getId(), testV2PolicyId);
+        assertEquals(result.getType(), POLICY_TYPE);
+        assertEquals(result.getSubject(), policySubjectModel);
+        assertEquals(result.getResource(), policyResourceModel);
+        assertEquals(result.getControl(), policyControlModel);
+        assertEquals(result.getRule().operator(), policyRuleModel.operator());
+        assertEquals(result.getPattern(), "time-based-restrictions:weekly");
+
+        List<String> values = response.getHeaders().values(HEADER_ETAG);
+        assertNotNull(values);
+        testV2PolicyEtag = values.get(0);
+    }
+
+    @Test(dependsOnMethods = {"testUpdateV2AccessPolicy"})
+    public void testListV2AccessPolicies() throws Exception, InterruptedException {
+        assertNotNull(testV2PolicyId);
+
+        V2ListPoliciesOptions options = new V2ListPoliciesOptions.Builder()
+                .accountId(testAccountId)
+                .build();
+
+        Response<V2PolicyList> response = service.v2ListPolicies(options).execute();
+        assertNotNull(response);
+        assertEquals(response.getStatusCode(), 200);
+
+        V2PolicyList result = response.getResult();
+        assertNotNull(result);
+
+        // Confirm the test policy is present
+        boolean foundTestPolicy = false;
+        for (V2Policy policy : result.getPolicies()) {
+            if (testV2PolicyId.equals(policy.getId())) {
+                foundTestPolicy = true;
+                break;
+            }
+        }
+        assertTrue(foundTestPolicy);
+    }
+
+    @Test
     public void testCreateCustomRole() {
 
         CreateRoleOptions options = new CreateRoleOptions.Builder()
@@ -433,13 +671,27 @@ public class IamPolicyManagementIT extends SdkIntegrationTestBase {
             // Delete the test policy or any test polcies older than 5 minutes
             if (policy.getSubjects().get(0).attributes().get(0).value().contains(TEST_USER_PREFIX)) {
                 long createdAt = policy.getCreatedAt().getTime();
-                if ((testPolicyId != null || testPolicyId.equals(policy.getId())) || createdAt < fiveMinutesAgo) {
-                    DeletePolicyOptions deleteOptions = new DeletePolicyOptions.Builder()
-                            .policyId(policy.getId()).build();
-                    Response<Void> deleteResponse = service.deletePolicy(deleteOptions).execute();
-                    assertNotNull(deleteResponse);
-                    assertEquals(deleteResponse.getStatusCode(), 204);
-                    log("Cleanup test policy id: " + policy.getId());
+
+                // Delete v2 policy
+                if (policy.getHref().contains("v2/policies")) {
+                  if ((testV2PolicyId != null || testV2PolicyId.equals(policy.getId())) || createdAt < fiveMinutesAgo) {
+                      V2DeletePolicyOptions deleteOptions = new V2DeletePolicyOptions.Builder()
+                              .policyId(policy.getId()).build();
+                      Response<Void> deleteResponse = service.v2DeletePolicy(deleteOptions).execute();
+                      assertNotNull(deleteResponse);
+                      assertEquals(deleteResponse.getStatusCode(), 204);
+                      log("Cleanup test policy id: " + policy.getId());
+                  }
+                } else {
+                  // Delete v1 policy
+                  if ((testPolicyId != null || testPolicyId.equals(policy.getId())) || createdAt < fiveMinutesAgo) {
+                      DeletePolicyOptions deleteOptions = new DeletePolicyOptions.Builder()
+                              .policyId(policy.getId()).build();
+                      Response<Void> deleteResponse = service.deletePolicy(deleteOptions).execute();
+                      assertNotNull(deleteResponse);
+                      assertEquals(deleteResponse.getStatusCode(), 204);
+                      log("Cleanup test policy id: " + policy.getId());
+                  }
                 }
             }
         }

--- a/modules/iam-policy-management/src/test/java/com/ibm/cloud/platform_services/iam_policy_management/v1/IamPolicyManagementTest.java
+++ b/modules/iam-policy-management/src/test/java/com/ibm/cloud/platform_services/iam_policy_management/v1/IamPolicyManagementTest.java
@@ -35,6 +35,21 @@ import com.ibm.cloud.platform_services.iam_policy_management.v1.model.RoleList;
 import com.ibm.cloud.platform_services.iam_policy_management.v1.model.SubjectAttribute;
 import com.ibm.cloud.platform_services.iam_policy_management.v1.model.UpdatePolicyOptions;
 import com.ibm.cloud.platform_services.iam_policy_management.v1.model.UpdateRoleOptions;
+import com.ibm.cloud.platform_services.iam_policy_management.v1.model.V2CreatePolicyOptions;
+import com.ibm.cloud.platform_services.iam_policy_management.v1.model.V2DeletePolicyOptions;
+import com.ibm.cloud.platform_services.iam_policy_management.v1.model.V2GetPolicyOptions;
+import com.ibm.cloud.platform_services.iam_policy_management.v1.model.V2ListPoliciesOptions;
+import com.ibm.cloud.platform_services.iam_policy_management.v1.model.V2Policy;
+import com.ibm.cloud.platform_services.iam_policy_management.v1.model.V2PolicyAttribute;
+import com.ibm.cloud.platform_services.iam_policy_management.v1.model.V2PolicyBaseControl;
+import com.ibm.cloud.platform_services.iam_policy_management.v1.model.V2PolicyBaseControlGrant;
+import com.ibm.cloud.platform_services.iam_policy_management.v1.model.V2PolicyBaseResource;
+import com.ibm.cloud.platform_services.iam_policy_management.v1.model.V2PolicyBaseRule;
+import com.ibm.cloud.platform_services.iam_policy_management.v1.model.V2PolicyBaseRuleV2PolicyAttribute;
+import com.ibm.cloud.platform_services.iam_policy_management.v1.model.V2PolicyBaseRuleV2RuleWithConditions;
+import com.ibm.cloud.platform_services.iam_policy_management.v1.model.V2PolicyBaseSubject;
+import com.ibm.cloud.platform_services.iam_policy_management.v1.model.V2PolicyList;
+import com.ibm.cloud.platform_services.iam_policy_management.v1.model.V2UpdatePolicyOptions;
 import com.ibm.cloud.platform_services.iam_policy_management.v1.utils.TestUtilities;
 import com.ibm.cloud.sdk.core.http.Response;
 import com.ibm.cloud.sdk.core.security.Authenticator;
@@ -757,6 +772,373 @@ public class IamPolicyManagementTest extends PowerMockTestCase {
   public void testDeleteRoleNoOptions() throws Throwable {
     server.enqueue(new MockResponse());
     iamPolicyManagementService.deleteRole(null).execute();
+  }
+
+  // Test the v2ListPolicies operation with a valid options model parameter
+  @Test
+  public void testV2ListPoliciesWOptions() throws Throwable {
+    // Register a mock response
+    String mockResponseBody = "{\"policies\": [{\"id\": \"id\", \"type\": \"type\", \"description\": \"description\", \"subject\": {\"attributes\": [{\"key\": \"key\", \"operator\": \"operator\", \"value\": \"anyValue\"}]}, \"control\": {\"grant\": {\"roles\": [{\"role_id\": \"roleId\", \"display_name\": \"displayName\", \"description\": \"description\"}]}}, \"resource\": {\"attributes\": [{\"key\": \"key\", \"operator\": \"operator\", \"value\": \"anyValue\"}]}, \"pattern\": \"pattern\", \"rule\": {\"key\": \"key\", \"operator\": \"operator\", \"value\": \"anyValue\"}, \"href\": \"href\", \"created_at\": \"2019-01-01T12:00:00.000Z\", \"created_by_id\": \"createdById\", \"last_modified_at\": \"2019-01-01T12:00:00.000Z\", \"last_modified_by_id\": \"lastModifiedById\", \"state\": \"active\"}]}";
+    String v2ListPoliciesPath = "/v2/policies";
+    server.enqueue(new MockResponse()
+      .setHeader("Content-type", "application/json")
+      .setResponseCode(200)
+      .setBody(mockResponseBody));
+
+    // Construct an instance of the V2ListPoliciesOptions model
+    V2ListPoliciesOptions v2ListPoliciesOptionsModel = new V2ListPoliciesOptions.Builder()
+      .accountId("testString")
+      .acceptLanguage("default")
+      .iamId("testString")
+      .accessGroupId("testString")
+      .type("access")
+      .serviceType("service")
+      .serviceName("testString")
+      .serviceGroupId("testString")
+      .format("include_last_permit")
+      .state("active")
+      .build();
+
+    // Invoke v2ListPolicies() with a valid options model and verify the result
+    Response<V2PolicyList> response = iamPolicyManagementService.v2ListPolicies(v2ListPoliciesOptionsModel).execute();
+    assertNotNull(response);
+    V2PolicyList responseObj = response.getResult();
+    assertNotNull(responseObj);
+
+    // Verify the contents of the request sent to the mock server
+    RecordedRequest request = server.takeRequest();
+    assertNotNull(request);
+    assertEquals(request.getMethod(), "GET");
+    // Verify request path
+    String parsedPath = TestUtilities.parseReqPath(request);
+    assertEquals(parsedPath, v2ListPoliciesPath);
+    // Verify query params
+    Map<String, String> query = TestUtilities.parseQueryString(request);
+    assertNotNull(query);
+    assertEquals(query.get("account_id"), "testString");
+    assertEquals(query.get("iam_id"), "testString");
+    assertEquals(query.get("access_group_id"), "testString");
+    assertEquals(query.get("type"), "access");
+    assertEquals(query.get("service_type"), "service");
+    assertEquals(query.get("service_name"), "testString");
+    assertEquals(query.get("service_group_id"), "testString");
+    assertEquals(query.get("format"), "include_last_permit");
+    assertEquals(query.get("state"), "active");
+  }
+
+  // Test the v2ListPolicies operation with and without retries enabled
+  @Test
+  public void testV2ListPoliciesWRetries() throws Throwable {
+    iamPolicyManagementService.enableRetries(4, 30);
+    testV2ListPoliciesWOptions();
+
+    iamPolicyManagementService.disableRetries();
+    testV2ListPoliciesWOptions();
+  }
+
+  // Test the v2ListPolicies operation with a null options model (negative test)
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testV2ListPoliciesNoOptions() throws Throwable {
+    server.enqueue(new MockResponse());
+    iamPolicyManagementService.v2ListPolicies(null).execute();
+  }
+
+  // Test the v2CreatePolicy operation with a valid options model parameter
+  @Test
+  public void testV2CreatePolicyWOptions() throws Throwable {
+    // Register a mock response
+    String mockResponseBody = "{\"id\": \"id\", \"type\": \"type\", \"description\": \"description\", \"subject\": {\"attributes\": [{\"key\": \"key\", \"operator\": \"operator\", \"value\": \"anyValue\"}]}, \"control\": {\"grant\": {\"roles\": [{\"role_id\": \"roleId\", \"display_name\": \"displayName\", \"description\": \"description\"}]}}, \"resource\": {\"attributes\": [{\"key\": \"key\", \"operator\": \"operator\", \"value\": \"anyValue\"}]}, \"pattern\": \"pattern\", \"rule\": {\"key\": \"key\", \"operator\": \"operator\", \"value\": \"anyValue\"}, \"href\": \"href\", \"created_at\": \"2019-01-01T12:00:00.000Z\", \"created_by_id\": \"createdById\", \"last_modified_at\": \"2019-01-01T12:00:00.000Z\", \"last_modified_by_id\": \"lastModifiedById\", \"state\": \"active\"}";
+    String v2CreatePolicyPath = "/v2/policies";
+    server.enqueue(new MockResponse()
+      .setHeader("Content-type", "application/json")
+      .setResponseCode(201)
+      .setBody(mockResponseBody));
+
+    // Construct an instance of the PolicyRole model
+    PolicyRole policyRoleModel = new PolicyRole.Builder()
+      .roleId("testString")
+      .build();
+
+    // Construct an instance of the V2PolicyBaseControlGrant model
+    V2PolicyBaseControlGrant v2PolicyBaseControlGrantModel = new V2PolicyBaseControlGrant.Builder()
+      .roles(java.util.Arrays.asList(policyRoleModel))
+      .build();
+
+    // Construct an instance of the V2PolicyBaseControl model
+    V2PolicyBaseControl v2PolicyBaseControlModel = new V2PolicyBaseControl.Builder()
+      .grant(v2PolicyBaseControlGrantModel)
+      .build();
+
+    // Construct an instance of the V2PolicyAttribute model
+    V2PolicyAttribute v2PolicyAttributeModel = new V2PolicyAttribute.Builder()
+      .key("testString")
+      .operator("testString")
+      .value("testString")
+      .build();
+
+    // Construct an instance of the V2PolicyBaseSubject model
+    V2PolicyBaseSubject v2PolicyBaseSubjectModel = new V2PolicyBaseSubject.Builder()
+      .attributes(java.util.Arrays.asList(v2PolicyAttributeModel))
+      .build();
+
+    // Construct an instance of the V2PolicyBaseResource model
+    V2PolicyBaseResource v2PolicyBaseResourceModel = new V2PolicyBaseResource.Builder()
+      .attributes(java.util.Arrays.asList(v2PolicyAttributeModel))
+      .build();
+
+    // Construct an instance of the V2PolicyBaseRuleV2PolicyAttribute model
+    V2PolicyBaseRuleV2PolicyAttribute v2PolicyBaseRuleModel = new V2PolicyBaseRuleV2PolicyAttribute.Builder()
+      .key("testString")
+      .operator("testString")
+      .value("testString")
+      .build();
+
+    // Construct an instance of the V2CreatePolicyOptions model
+    V2CreatePolicyOptions v2CreatePolicyOptionsModel = new V2CreatePolicyOptions.Builder()
+      .type("testString")
+      .control(v2PolicyBaseControlModel)
+      .description("testString")
+      .subject(v2PolicyBaseSubjectModel)
+      .resource(v2PolicyBaseResourceModel)
+      .pattern("testString")
+      .rule(v2PolicyBaseRuleModel)
+      .acceptLanguage("default")
+      .build();
+
+    // Invoke v2CreatePolicy() with a valid options model and verify the result
+    Response<V2Policy> response = iamPolicyManagementService.v2CreatePolicy(v2CreatePolicyOptionsModel).execute();
+    assertNotNull(response);
+    V2Policy responseObj = response.getResult();
+    assertNotNull(responseObj);
+
+    // Verify the contents of the request sent to the mock server
+    RecordedRequest request = server.takeRequest();
+    assertNotNull(request);
+    assertEquals(request.getMethod(), "POST");
+    // Verify request path
+    String parsedPath = TestUtilities.parseReqPath(request);
+    assertEquals(parsedPath, v2CreatePolicyPath);
+    // Verify that there is no query string
+    Map<String, String> query = TestUtilities.parseQueryString(request);
+    assertNull(query);
+  }
+
+  // Test the v2CreatePolicy operation with and without retries enabled
+  @Test
+  public void testV2CreatePolicyWRetries() throws Throwable {
+    iamPolicyManagementService.enableRetries(4, 30);
+    testV2CreatePolicyWOptions();
+
+    iamPolicyManagementService.disableRetries();
+    testV2CreatePolicyWOptions();
+  }
+
+  // Test the v2CreatePolicy operation with a null options model (negative test)
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testV2CreatePolicyNoOptions() throws Throwable {
+    server.enqueue(new MockResponse());
+    iamPolicyManagementService.v2CreatePolicy(null).execute();
+  }
+
+  // Test the v2UpdatePolicy operation with a valid options model parameter
+  @Test
+  public void testV2UpdatePolicyWOptions() throws Throwable {
+    // Register a mock response
+    String mockResponseBody = "{\"id\": \"id\", \"type\": \"type\", \"description\": \"description\", \"subject\": {\"attributes\": [{\"key\": \"key\", \"operator\": \"operator\", \"value\": \"anyValue\"}]}, \"control\": {\"grant\": {\"roles\": [{\"role_id\": \"roleId\", \"display_name\": \"displayName\", \"description\": \"description\"}]}}, \"resource\": {\"attributes\": [{\"key\": \"key\", \"operator\": \"operator\", \"value\": \"anyValue\"}]}, \"pattern\": \"pattern\", \"rule\": {\"key\": \"key\", \"operator\": \"operator\", \"value\": \"anyValue\"}, \"href\": \"href\", \"created_at\": \"2019-01-01T12:00:00.000Z\", \"created_by_id\": \"createdById\", \"last_modified_at\": \"2019-01-01T12:00:00.000Z\", \"last_modified_by_id\": \"lastModifiedById\", \"state\": \"active\"}";
+    String v2UpdatePolicyPath = "/v2/policies/testString";
+    server.enqueue(new MockResponse()
+      .setHeader("Content-type", "application/json")
+      .setResponseCode(200)
+      .setBody(mockResponseBody));
+
+    // Construct an instance of the PolicyRole model
+    PolicyRole policyRoleModel = new PolicyRole.Builder()
+      .roleId("testString")
+      .build();
+
+    // Construct an instance of the V2PolicyBaseControlGrant model
+    V2PolicyBaseControlGrant v2PolicyBaseControlGrantModel = new V2PolicyBaseControlGrant.Builder()
+      .roles(java.util.Arrays.asList(policyRoleModel))
+      .build();
+
+    // Construct an instance of the V2PolicyBaseControl model
+    V2PolicyBaseControl v2PolicyBaseControlModel = new V2PolicyBaseControl.Builder()
+      .grant(v2PolicyBaseControlGrantModel)
+      .build();
+
+    // Construct an instance of the V2PolicyAttribute model
+    V2PolicyAttribute v2PolicyAttributeModel = new V2PolicyAttribute.Builder()
+      .key("testString")
+      .operator("testString")
+      .value("testString")
+      .build();
+
+    // Construct an instance of the V2PolicyBaseSubject model
+    V2PolicyBaseSubject v2PolicyBaseSubjectModel = new V2PolicyBaseSubject.Builder()
+      .attributes(java.util.Arrays.asList(v2PolicyAttributeModel))
+      .build();
+
+    // Construct an instance of the V2PolicyBaseResource model
+    V2PolicyBaseResource v2PolicyBaseResourceModel = new V2PolicyBaseResource.Builder()
+      .attributes(java.util.Arrays.asList(v2PolicyAttributeModel))
+      .build();
+
+    // Construct an instance of the V2PolicyBaseRuleV2PolicyAttribute model
+    V2PolicyBaseRuleV2PolicyAttribute v2PolicyBaseRuleModel = new V2PolicyBaseRuleV2PolicyAttribute.Builder()
+      .key("testString")
+      .operator("testString")
+      .value("testString")
+      .build();
+
+    // Construct an instance of the V2UpdatePolicyOptions model
+    V2UpdatePolicyOptions v2UpdatePolicyOptionsModel = new V2UpdatePolicyOptions.Builder()
+      .policyId("testString")
+      .ifMatch("testString")
+      .type("testString")
+      .control(v2PolicyBaseControlModel)
+      .description("testString")
+      .subject(v2PolicyBaseSubjectModel)
+      .resource(v2PolicyBaseResourceModel)
+      .pattern("testString")
+      .rule(v2PolicyBaseRuleModel)
+      .build();
+
+    // Invoke v2UpdatePolicy() with a valid options model and verify the result
+    Response<V2Policy> response = iamPolicyManagementService.v2UpdatePolicy(v2UpdatePolicyOptionsModel).execute();
+    assertNotNull(response);
+    V2Policy responseObj = response.getResult();
+    assertNotNull(responseObj);
+
+    // Verify the contents of the request sent to the mock server
+    RecordedRequest request = server.takeRequest();
+    assertNotNull(request);
+    assertEquals(request.getMethod(), "PUT");
+    // Verify request path
+    String parsedPath = TestUtilities.parseReqPath(request);
+    assertEquals(parsedPath, v2UpdatePolicyPath);
+    // Verify header parameters
+    assertEquals(request.getHeader("If-Match"), "testString");
+    // Verify that there is no query string
+    Map<String, String> query = TestUtilities.parseQueryString(request);
+    assertNull(query);
+  }
+
+  // Test the v2UpdatePolicy operation with and without retries enabled
+  @Test
+  public void testV2UpdatePolicyWRetries() throws Throwable {
+    iamPolicyManagementService.enableRetries(4, 30);
+    testV2UpdatePolicyWOptions();
+
+    iamPolicyManagementService.disableRetries();
+    testV2UpdatePolicyWOptions();
+  }
+
+  // Test the v2UpdatePolicy operation with a null options model (negative test)
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testV2UpdatePolicyNoOptions() throws Throwable {
+    server.enqueue(new MockResponse());
+    iamPolicyManagementService.v2UpdatePolicy(null).execute();
+  }
+
+  // Test the v2GetPolicy operation with a valid options model parameter
+  @Test
+  public void testV2GetPolicyWOptions() throws Throwable {
+    // Register a mock response
+    String mockResponseBody = "{\"id\": \"id\", \"type\": \"type\", \"description\": \"description\", \"subject\": {\"attributes\": [{\"key\": \"key\", \"operator\": \"operator\", \"value\": \"anyValue\"}]}, \"control\": {\"grant\": {\"roles\": [{\"role_id\": \"roleId\", \"display_name\": \"displayName\", \"description\": \"description\"}]}}, \"resource\": {\"attributes\": [{\"key\": \"key\", \"operator\": \"operator\", \"value\": \"anyValue\"}]}, \"pattern\": \"pattern\", \"rule\": {\"key\": \"key\", \"operator\": \"operator\", \"value\": \"anyValue\"}, \"href\": \"href\", \"created_at\": \"2019-01-01T12:00:00.000Z\", \"created_by_id\": \"createdById\", \"last_modified_at\": \"2019-01-01T12:00:00.000Z\", \"last_modified_by_id\": \"lastModifiedById\", \"state\": \"active\"}";
+    String v2GetPolicyPath = "/v2/policies/testString";
+    server.enqueue(new MockResponse()
+      .setHeader("Content-type", "application/json")
+      .setResponseCode(200)
+      .setBody(mockResponseBody));
+
+    // Construct an instance of the V2GetPolicyOptions model
+    V2GetPolicyOptions v2GetPolicyOptionsModel = new V2GetPolicyOptions.Builder()
+      .policyId("testString")
+      .build();
+
+    // Invoke v2GetPolicy() with a valid options model and verify the result
+    Response<V2Policy> response = iamPolicyManagementService.v2GetPolicy(v2GetPolicyOptionsModel).execute();
+    assertNotNull(response);
+    V2Policy responseObj = response.getResult();
+    assertNotNull(responseObj);
+
+    // Verify the contents of the request sent to the mock server
+    RecordedRequest request = server.takeRequest();
+    assertNotNull(request);
+    assertEquals(request.getMethod(), "GET");
+    // Verify request path
+    String parsedPath = TestUtilities.parseReqPath(request);
+    assertEquals(parsedPath, v2GetPolicyPath);
+    // Verify that there is no query string
+    Map<String, String> query = TestUtilities.parseQueryString(request);
+    assertNull(query);
+  }
+
+  // Test the v2GetPolicy operation with and without retries enabled
+  @Test
+  public void testV2GetPolicyWRetries() throws Throwable {
+    iamPolicyManagementService.enableRetries(4, 30);
+    testV2GetPolicyWOptions();
+
+    iamPolicyManagementService.disableRetries();
+    testV2GetPolicyWOptions();
+  }
+
+  // Test the v2GetPolicy operation with a null options model (negative test)
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testV2GetPolicyNoOptions() throws Throwable {
+    server.enqueue(new MockResponse());
+    iamPolicyManagementService.v2GetPolicy(null).execute();
+  }
+
+  // Test the v2DeletePolicy operation with a valid options model parameter
+  @Test
+  public void testV2DeletePolicyWOptions() throws Throwable {
+    // Register a mock response
+    String mockResponseBody = "";
+    String v2DeletePolicyPath = "/v2/policies/testString";
+    server.enqueue(new MockResponse()
+      .setResponseCode(204)
+      .setBody(mockResponseBody));
+
+    // Construct an instance of the V2DeletePolicyOptions model
+    V2DeletePolicyOptions v2DeletePolicyOptionsModel = new V2DeletePolicyOptions.Builder()
+      .policyId("testString")
+      .build();
+
+    // Invoke v2DeletePolicy() with a valid options model and verify the result
+    Response<Void> response = iamPolicyManagementService.v2DeletePolicy(v2DeletePolicyOptionsModel).execute();
+    assertNotNull(response);
+    Void responseObj = response.getResult();
+    assertNull(responseObj);
+
+    // Verify the contents of the request sent to the mock server
+    RecordedRequest request = server.takeRequest();
+    assertNotNull(request);
+    assertEquals(request.getMethod(), "DELETE");
+    // Verify request path
+    String parsedPath = TestUtilities.parseReqPath(request);
+    assertEquals(parsedPath, v2DeletePolicyPath);
+    // Verify that there is no query string
+    Map<String, String> query = TestUtilities.parseQueryString(request);
+    assertNull(query);
+  }
+
+  // Test the v2DeletePolicy operation with and without retries enabled
+  @Test
+  public void testV2DeletePolicyWRetries() throws Throwable {
+    iamPolicyManagementService.enableRetries(4, 30);
+    testV2DeletePolicyWOptions();
+
+    iamPolicyManagementService.disableRetries();
+    testV2DeletePolicyWOptions();
+  }
+
+  // Test the v2DeletePolicy operation with a null options model (negative test)
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testV2DeletePolicyNoOptions() throws Throwable {
+    server.enqueue(new MockResponse());
+    iamPolicyManagementService.v2DeletePolicy(null).execute();
   }
 
   // Perform setup needed before each test method


### PR DESCRIPTION
## PR summary
<!-- please include a brief summary of the changes in this PR -->
Code to support new v2/policies API has been introduced. The new v2/policies API will have new JSON fields and existing v1/fields have been changed.

v1/policies API will continue to be supported.


## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
PR's are currently open for staging and production docs. They are not currently merged:
Staging: https://github.ibm.com/cloud-api-docs/iam-access-management/pull/139
Production: https://github.ibm.com/cloud-api-docs/iam-access-management/pull/140

## Current vs new behavior  
Current behavior will remain same (v1 will continue to be supported). New behavior is v2/policies support which allows for time based restriction policies using new rule field (an integration test has been added of this example).

## Does this PR introduce a breaking change?    
- [ ] Yes
- [x] No


## Other information
See:
Issue: https://github.ibm.com/IAM/AM-issues/issues/925
TRI: https://github.ibm.com/IAM/architecture/blob/master/TRIDocs/Access-Management/Smart-Policies/smart_policies.md