### PR TITLE
build: adopt java11 as min JDK for build/test

### DIFF
--- a/.cra/.cveignore
+++ b/.cra/.cveignore
@@ -1,7 +1,2 @@
 [
-    {
-        "cve": "SNYK-JAVA-ORGTESTNG-3040285",
-        "alwaysOmit": true,
-        "comment": "The 'Zip Slip' vulnerability does not apply to this project because we merely use TestNG to execute testcases during our maven build, and we do not deliver a jar containing test classes."
-    }
 ]

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,5 @@ node_modules/
 
 # MacOS specific .DS_Store file
 .DS_Store 
+
+.vscode/

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: java
 dist: bionic
 
 jdk:
-- openjdk8
+- openjdk11
 
 notifications:
   email: true
@@ -35,15 +35,10 @@ before_install:
 jobs:
   include:
     - stage: Build-Test
-      jdk: openjdk8
+      jdk: openjdk11
       install: true
       script:
         - build/setMavenVersion.sh
-        - mvn verify -fae -DskipITs $MVN_ARGS
-
-    - jdk: openjdk11
-      install: true
-      script:
         - mvn verify -fae -DskipITs $MVN_ARGS
 
     - jdk: openjdk17
@@ -60,7 +55,7 @@ jobs:
         - npm run semantic-release
 
     - stage: Publish-Release
-      jdk: openjdk8
+      jdk: openjdk11
       name: Publish-Javadoc
       install: true
       script:
@@ -70,7 +65,7 @@ jobs:
       after_success:
         - echo "Javadocs successfully published to gh-pages!"
 
-    - jdk: openjdk8
+    - jdk: openjdk11
       name: Publish-To-Maven-Central
       install: true
       script:

--- a/modules/case-management/pom.xml
+++ b/modules/case-management/pom.xml
@@ -45,5 +45,10 @@
             <artifactId>mockwebserver</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-jdk14</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/modules/catalog-management/pom.xml
+++ b/modules/catalog-management/pom.xml
@@ -45,6 +45,11 @@
             <artifactId>mockwebserver</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-jdk14</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <developers>

--- a/modules/common/pom.xml
+++ b/modules/common/pom.xml
@@ -1,54 +1,59 @@
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns="http://maven.apache.org/POM/4.0.0"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-	<modelVersion>4.0.0</modelVersion>
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 
-	<!-- Update this section to reflect the correct values for your SDK project -->
-	<parent>
-		<groupId>com.ibm.cloud</groupId>
-		<artifactId>platform-services</artifactId>
-		<version>99-SNAPSHOT</version>
-		<relativePath>../..</relativePath>
-	</parent>
+    <!-- Update this section to reflect the correct values for your SDK project -->
+    <parent>
+        <groupId>com.ibm.cloud</groupId>
+        <artifactId>platform-services</artifactId>
+        <version>99-SNAPSHOT</version>
+        <relativePath>../..</relativePath>
+    </parent>
 
-	<!-- Update this section to reflect your SDK project name, etc. -->
-	<artifactId>platform-services-common</artifactId>
-	<packaging>jar</packaging>
-	<name>IBM Cloud Platform Services SDK Common Library</name>
+    <!-- Update this section to reflect your SDK project name, etc. -->
+    <artifactId>platform-services-common</artifactId>
+    <packaging>jar</packaging>
+    <name>IBM Cloud Platform Services SDK Common Library</name>
 
-	<dependencies>
-		<dependency>
-			<groupId>com.ibm.cloud</groupId>
-			<artifactId>sdk-core</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.testng</groupId>
-			<artifactId>testng</artifactId>
-			<scope>test</scope>
-		</dependency>
-	</dependencies>
-	<build>
-		<resources>
-			<resource>
-				<directory>src/main/resources</directory>
-				<filtering>true</filtering>
-				<includes>
-					<include>${project.parent.artifactId}.properties</include>
-				</includes>
-			</resource>
-		</resources>
-		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-jar-plugin</artifactId>
-				<executions>
-					<execution>
-						<goals>
-							<goal>test-jar</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-		</plugins>
-	</build>
+    <dependencies>
+        <dependency>
+            <groupId>com.ibm.cloud</groupId>
+            <artifactId>sdk-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-jdk14</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+                <includes>
+                    <include>${project.parent.artifactId}.properties</include>
+                </includes>
+            </resource>
+        </resources>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/modules/context-based-restrictions/pom.xml
+++ b/modules/context-based-restrictions/pom.xml
@@ -45,6 +45,11 @@
             <artifactId>mockwebserver</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-jdk14</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <developers>

--- a/modules/enterprise-billing-units/pom.xml
+++ b/modules/enterprise-billing-units/pom.xml
@@ -45,6 +45,11 @@
             <artifactId>mockwebserver</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-jdk14</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <developers>

--- a/modules/enterprise-management/pom.xml
+++ b/modules/enterprise-management/pom.xml
@@ -46,6 +46,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-jdk14</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
             <version>20180130</version>

--- a/modules/enterprise-usage-reports/pom.xml
+++ b/modules/enterprise-usage-reports/pom.xml
@@ -45,6 +45,11 @@
             <artifactId>mockwebserver</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-jdk14</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <developers>

--- a/modules/examples/pom.xml
+++ b/modules/examples/pom.xml
@@ -114,6 +114,10 @@
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
             <artifactId>slf4j-jdk14</artifactId>
         </dependency>
     </dependencies>

--- a/modules/global-catalog/pom.xml
+++ b/modules/global-catalog/pom.xml
@@ -45,5 +45,10 @@
             <artifactId>mockwebserver</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-jdk14</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/modules/global-search/pom.xml
+++ b/modules/global-search/pom.xml
@@ -45,5 +45,10 @@
             <artifactId>mockwebserver</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-jdk14</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/modules/global-tagging/pom.xml
+++ b/modules/global-tagging/pom.xml
@@ -45,5 +45,10 @@
             <artifactId>mockwebserver</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-jdk14</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/modules/iam-access-groups/pom.xml
+++ b/modules/iam-access-groups/pom.xml
@@ -45,5 +45,10 @@
             <artifactId>mockwebserver</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-jdk14</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/modules/iam-identity/pom.xml
+++ b/modules/iam-identity/pom.xml
@@ -45,6 +45,11 @@
             <artifactId>mockwebserver</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-jdk14</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <developers>

--- a/modules/iam-policy-management/pom.xml
+++ b/modules/iam-policy-management/pom.xml
@@ -45,6 +45,11 @@
             <artifactId>mockwebserver</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-jdk14</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <developers>

--- a/modules/ibm-cloud-shell/pom.xml
+++ b/modules/ibm-cloud-shell/pom.xml
@@ -45,6 +45,11 @@
             <artifactId>mockwebserver</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-jdk14</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <developers>

--- a/modules/open-service-broker/pom.xml
+++ b/modules/open-service-broker/pom.xml
@@ -45,6 +45,11 @@
             <artifactId>mockwebserver</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-jdk14</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <developers>

--- a/modules/resource-controller/pom.xml
+++ b/modules/resource-controller/pom.xml
@@ -45,6 +45,11 @@
             <artifactId>mockwebserver</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-jdk14</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <developers>

--- a/modules/resource-manager/pom.xml
+++ b/modules/resource-manager/pom.xml
@@ -45,5 +45,10 @@
             <artifactId>mockwebserver</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-jdk14</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/modules/usage-metering/pom.xml
+++ b/modules/usage-metering/pom.xml
@@ -45,6 +45,11 @@
             <artifactId>mockwebserver</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-jdk14</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <developers>

--- a/modules/usage-reports/pom.xml
+++ b/modules/usage-reports/pom.xml
@@ -45,6 +45,11 @@
             <artifactId>mockwebserver</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-jdk14</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <developers>

--- a/modules/user-management/pom.xml
+++ b/modules/user-management/pom.xml
@@ -46,6 +46,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-jdk14</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
             <version>20180130</version>

--- a/pom.xml
+++ b/pom.xml
@@ -14,9 +14,9 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- This is the version associated with the Java core. -->
-        <sdk-core-version>9.17.4</sdk-core-version>
+        <sdk-core-version>9.17.5</sdk-core-version>
 
-        <testng-version>7.4.0</testng-version>
+        <testng-version>7.7.1</testng-version>
         <okhttp3-version>4.10.0</okhttp3-version>
         <surefire-version>3.0.0-M7</surefire-version>
         <jacoco-plugin-version>0.8.8</jacoco-plugin-version>
@@ -27,15 +27,23 @@
         <maven-shade-plugin-version>3.3.0</maven-shade-plugin-version>
         <maven-jar-plugin-version>3.2.2</maven-jar-plugin-version>
         <maven-javadoc-plugin-version>3.4.1</maven-javadoc-plugin-version>
-        <maven-compiler-plugin-version>3.10.1</maven-compiler-plugin-version>
         <maven-site-plugin-version>3.12.1</maven-site-plugin-version>
         <maven-checkstyle-plugin-version>3.2.0</maven-checkstyle-plugin-version>
         <checkstyle-version>8.41</checkstyle-version>
         <maven-reports-plugin-version>3.4.1</maven-reports-plugin-version>
         <maven-failsafe-plugin-version>3.0.0-M7</maven-failsafe-plugin-version>
         <maven-buildnumber-plugin-version>3.0.0</maven-buildnumber-plugin-version>
-        <slf4j-version>2.0.0</slf4j-version>
-        
+        <slf4j-version>2.0.6</slf4j-version>
+
+        <maven-enforcer-version>3.1.0</maven-enforcer-version>
+        <min-jdk-version>11</min-jdk-version>
+        <min-maven-version>3.5.0</min-maven-version>
+
+        <maven-compiler-plugin-version>3.10.1</maven-compiler-plugin-version>
+        <java-source-version>1.8</java-source-version>
+        <java-target-version>1.8</java-target-version>
+
+
         <!-- versions of transitive dependencies we need to override to avoid vulnerability alerts -->
         <junit-version>4.13.2</junit-version>
     </properties>
@@ -115,15 +123,15 @@
 
             <!-- Each module (except "common") should depend on this artifact -->
             <dependency>
-                <groupId>${project.groupId}</groupId>
                 <!-- >>> Replace this with the "common" module's artifactId (e.g. my-services-common) -->
                 <artifactId>platform-services-common</artifactId>
+                <groupId>${project.groupId}</groupId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
-                <groupId>${project.groupId}</groupId>
                 <!-- >>> Replace this with the "common" module's artifactId (e.g. my-services-common) -->
                 <artifactId>platform-services-common</artifactId>
+                <groupId>${project.groupId}</groupId>
                 <version>${project.version}</version>
                 <type>test-jar</type>
                 <classifier>tests</classifier>
@@ -154,7 +162,11 @@
                 <version>${okhttp3-version}</version>
                 <scope>test</scope>
             </dependency>
-            <!-- Depedency needed to build examples -->
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>${slf4j-version}</version>
+            </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-jdk14</artifactId>
@@ -166,6 +178,31 @@
     <build>
         <pluginManagement>
             <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-enforcer-plugin</artifactId>
+                    <version>${maven-enforcer-version}</version>
+                    <executions>
+                        <execution>
+                            <id>enforce-versions</id>
+                            <goals>
+                                <goal>enforce</goal>
+                            </goals>
+                            <configuration>
+                                <rules>
+                                    <requireMavenVersion>
+                                        <version>${min-maven-version}</version>
+                                        <message>Apache Maven ${min-maven-version}+ is required to build this project.</message>
+                                    </requireMavenVersion>
+                                    <requireJavaVersion>
+                                        <version>${min-jdk-version}</version>
+                                        <message>Java ${min-jdk-version}+ is required to build this project.</message>
+                                    </requireJavaVersion>
+                                </rules>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-deploy-plugin</artifactId>
@@ -215,8 +252,8 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>${maven-compiler-plugin-version}</version>
                     <configuration>
-                        <source>1.8</source>
-                        <target>1.8</target>
+                        <source>${java-source-version}</source>
+                        <target>${java-target-version}</target>
                     </configuration>
                 </plugin>
                 <plugin>
@@ -341,10 +378,34 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-shade-plugin</artifactId>
                     <version>${maven-shade-plugin-version}</version>
+                    <executions>
+                        <execution>
+                            <phase>package</phase>
+                            <goals>
+                                <goal>shade</goal>
+                            </goals>
+                        </execution>
+                    </executions>
                 </plugin>
             </plugins>
         </pluginManagement>
         <plugins>
+            <!-- Disable default maven-deploy-plugin -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
@@ -373,6 +434,14 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${surefire-version}</version>
+                <configuration>
+                    <skipTests>${skip.unit.tests}</skipTests>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
## PR summary
This commit modifies the project so that java 11 is the minimum version of the JDK for building/testing the project. We still produce java 8-compatible classes, but using java11 will allow us to bump test-related dependencies if needed to address security vulnerabilities.

Signed-off-by: Phil Adams <phil_adams@us.ibm.com>

## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [ ] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## Current vs new behavior  
<!-- Please describe the current behavior that you are modifying and the new behavior. -->

## Does this PR introduce a breaking change?    
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->