### PR TITLE
fix: remove 'latest' link from gh-pages

### DIFF
--- a/build/generateJavadocIndex.sh
+++ b/build/generateJavadocIndex.sh
@@ -21,9 +21,10 @@ echo '<!DOCTYPE html>
         | <a href="https://github.com/IBM/platform-services-java-sdk">GitHub</a>
     </p>
 
-    <p>Javadoc by branch/release:</p>
-    <ul><li><a href="docs/latest">Latest</a></li>'
-ls docs | grep --invert-match index.html | sed 's/^.*/<li><a href="docs\/&">&<\/a><\/li>/'
+    <p>Javadoc by release:</p>
+    <ul>'
+echo ${TRAVIS_BRANCH} | sed 's/^.*/        <li><a href="docs\/&">Latest release<\/a><\/li>/'
+ls docs | grep --invert-match index.html | sed 's/^.*/        <li><a href="docs\/&">&<\/a><\/li>/'
 echo '    </ul>
 </div>
 </body>

--- a/build/publishJavadoc.sh
+++ b/build/publishJavadoc.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-# Avoid publishing javadocs for a PR build
-if [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_BRANCH" ]; then
+# Publish javadocs only for a tagged-release.
+if [[ -n "${TRAVIS_TAG}" ]]; then
 
     printf "\n>>>>> Publishing javadoc for release build: repo=%s branch=%s build_num=%s job_num=%s\n" ${TRAVIS_REPO_SLUG} ${TRAVIS_BRANCH} ${TRAVIS_BUILD_NUMBER} ${TRAVIS_JOB_NUMBER} 
 
@@ -11,11 +11,10 @@ if [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_BRANCH" ]; then
 
     printf "\n>>>>> Finished cloning...\n"
 
-    
     pushd gh-pages
     
-    # Create a new directory for this branch/tag and copy the aggregated javadocs there.
-    printf "\n>>>>> Copying aggregated javadocs to new tagged-release directory: %s\n" ${TRAVIS_BRANCH}
+    # Create a new directory for this branch/tag and copy the javadocs there.
+    printf "\n>>>>> Copying javadocs to new directory: docs/%s\n" ${TRAVIS_BRANCH}
     rm -rf docs/${TRAVIS_BRANCH}
     mkdir -p docs/${TRAVIS_BRANCH}
     cp -rf ../target/site/apidocs/* docs/${TRAVIS_BRANCH}
@@ -23,19 +22,9 @@ if [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_BRANCH" ]; then
     printf "\n>>>>> Generating gh-pages index.html...\n"
     ../build/generateJavadocIndex.sh > index.html
 
-    # Update the 'latest' symlink to point to this branch if it's a tagged release.
-    if [ -n "$TRAVIS_TAG" ]; then
-	pushd docs
-	rm latest
-	ln -s ./${TRAVIS_TAG} latest
-	printf "\n>>>>> Updated 'docs/latest' symlink:\n"
-	ls -l latest
-	popd
-    fi
-
     printf "\n>>>>> Committing new javadoc...\n"
     git add -f .
-    git commit -m "Javadoc for release ${TRAVIS_TAG} (${TRAVIS_COMMIT})"
+    git commit -m "docs: latest javadoc for ${TRAVIS_BRANCH} (${TRAVIS_COMMIT})"
     git push -f origin gh-pages
 
     popd


### PR DESCRIPTION
## PR summary
Fixes to the build scripts used to publish our javadocs.
The problem is that github recently stopped allowing the use of symbolic links within the gh-pages branch (which is used to build the repo's "Pages"), and we happen to have a symbolic link in the "docs" directory within the gh-pages branch.
That link was removed in a different commit, and this PR contains the corresponding changes needed to our build scripts so they work correctly moving forward.


## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## Current vs new behavior  
<!-- Please describe the current behavior that you are modifying and the new behavior. -->

## Does this PR introduce a breaking change?    
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->