### PR TITLE
feat(IAM Identity): Add support for IAM enterprise

### DIFF
--- a/modules/examples/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/IamIdentityExamples.java
+++ b/modules/examples/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/IamIdentityExamples.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2020, 2021.
+ * (C) Copyright IBM Corp. 2020, 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -20,48 +20,78 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.ibm.cloud.platform_services.iam_identity.v1.model.AccountSettingsComponent;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.AccountSettingsResponse;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.AccountSettingsTemplateList;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.AccountSettingsTemplateResponse;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.AccountSettingsUserMFA;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.ApiKey;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.ApiKeyList;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.CommitAccountSettingsTemplateOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.CommitProfileTemplateOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.CreateAccountSettingsAssignmentOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.CreateAccountSettingsTemplateOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.CreateAccountSettingsTemplateVersionOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.CreateApiKeyOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.CreateClaimRuleOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.CreateLinkOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.CreateMfaReportOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.CreateProfileLinkRequestLink;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.CreateProfileOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.CreateProfileTemplateOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.CreateProfileTemplateVersionOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.CreateReportOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.CreateServiceIdOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.CreateTrustedProfileAssignmentOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.DeleteAccountSettingsAssignmentOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.DeleteAccountSettingsTemplateVersionOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.DeleteAllVersionsOfAccountSettingsTemplateOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.DeleteAllVersionsOfProfileTemplateOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.DeleteApiKeyOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.DeleteClaimRuleOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.DeleteLinkOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.DeleteProfileIdentityOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.DeleteProfileOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.DeleteProfileTemplateVersionOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.DeleteServiceIdOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.DeleteTrustedProfileAssignmentOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.ExceptionResponse;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.GetAccountSettingsAssignmentOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.GetAccountSettingsOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.GetAccountSettingsTemplateVersionOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.GetApiKeyOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.GetApiKeysDetailsOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.GetClaimRuleOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.GetLatestAccountSettingsTemplateVersionOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.GetLatestProfileTemplateVersionOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.GetLinkOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.GetMfaReportOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.GetMfaStatusOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.GetProfileIdentitiesOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.GetProfileIdentityOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.GetProfileOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.GetProfileTemplateVersionOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.GetReportOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.GetServiceIdOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.GetTrustedProfileAssignmentOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.ListAccountSettingsTemplatesOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.ListApiKeysOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.ListClaimRulesOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.ListLinksOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.ListProfileTemplatesOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.ListProfilesOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.ListServiceIdsOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.ListTrustedProfileAssignmentsOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.ListVersionsOfAccountSettingsTemplateOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.ListVersionsOfProfileTemplateOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.LockApiKeyOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.LockServiceIdOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.ProfileClaimRule;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.ProfileClaimRuleConditions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.ProfileClaimRuleList;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.ProfileIdentitiesResponse;
-import com.ibm.cloud.platform_services.iam_identity.v1.model.ProfileIdentity;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.ProfileIdentityRequest;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.ProfileIdentityResponse;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.ProfileLink;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.ProfileLinkList;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.Report;
@@ -71,17 +101,28 @@ import com.ibm.cloud.platform_services.iam_identity.v1.model.ServiceId;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.ServiceIdList;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.SetProfileIdentitiesOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.SetProfileIdentityOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.TemplateAssignmentListResponse;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.TemplateAssignmentResponse;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.TemplateProfileComponentRequest;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.TrustedProfile;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.TrustedProfileTemplateClaimRule;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.TrustedProfileTemplateList;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.TrustedProfileTemplateResponse;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.TrustedProfilesList;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.UnlockApiKeyOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.UnlockServiceIdOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.UpdateAccountSettingsAssignmentOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.UpdateAccountSettingsOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.UpdateAccountSettingsTemplateVersionOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.UpdateApiKeyOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.UpdateClaimRuleOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.UpdateProfileOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.UpdateProfileTemplateVersionOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.UpdateServiceIdOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.UpdateTrustedProfileAssignmentOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.UserMfaEnrollments;
 import com.ibm.cloud.sdk.core.http.Response;
+import com.ibm.cloud.sdk.core.service.exception.NotFoundException;
 import com.ibm.cloud.sdk.core.service.exception.ServiceResponseException;
 import com.ibm.cloud.sdk.core.util.CredentialUtils;
 
@@ -96,6 +137,9 @@ import com.ibm.cloud.sdk.core.util.CredentialUtils;
 // IAM_IDENTITY_APIKEY=<IAM APIKEY for the User>
 // IAM_IDENTITY_ACCOUNT_ID=<AccountID which is unique to the User>
 // IAM_IDENTITY_IAM_ID=<IAM ID which is unique to the User account>
+// IAM_IDENTITY_IAM_ID_MEMBER=<IAM ID of a user belonging to the account but different to the one above>
+// IAM_IDENTITY_ENTERPISE_ACCOUNT_ID=<AccountID of the enterprise account>
+// IAM_IDENTITY_ENTERPISE_SUBACCOUNT_ID=<AccountID of an account in the enterprise>
 //
 // These configuration properties can be exported as environment variables, or stored
 // in a configuration file and then:
@@ -111,13 +155,18 @@ public class IamIdentityExamples {
     private static String serviceIdName = "Example-ServiceId";
     private static String profileName = "Example-Profile";
     private static String claimRuleType = "Profile-SAML";
-    private static String realmName = "https://w3id.sso.ibm.com/auth/sps/samlidp2/saml20";
+    private static String realmName = "https://my.test.realm/1234/saml20";
+    private static String profileTemplateName = "Example-Profile-Template";
+    private static String profileTemplateProfileName = "Profile-From-Example-Template";
+    private static String accountSettingsTemplateName = "Example-Account-Settings-Template";
 
     //values to be read from the env file
     private static String accountId;
     private static String iamId;
     private static String iamIdMember;
     private static String iamApiKey;
+    private static String enterpriseAccountId;
+    private static String enterpriseSubAccountId;
 
     // Variables used to hold various values shared between operations.
     private static String apikeyId;
@@ -125,7 +174,6 @@ public class IamIdentityExamples {
     private static String svcId;
     private static String svcIdEtag;
     private static String profileId;
-    private static String profileIamId;
     private static String profileEtag;
     private static String claimRuleId;
     private static String claimRuleEtag;
@@ -133,6 +181,16 @@ public class IamIdentityExamples {
     private static String accountSettingsEtag;
     private static String reportReferenceValue;
     private static String profileIdentitiesEtag;
+    private static String profileTemplateId;
+    private static long profileTemplateVersion;
+    private static String profileTemplateEtag;
+    private static String profileTemplateAssignmentId;
+    private static String profileTemplateAssignmentEtag;
+    private static String accountSettingsTemplateId;
+    private static long accountSettingsTemplateVersion;
+    private static String accountSettingsTemplateEtag;
+    private static String accountSettingsTemplateAssignmentId;
+    private static String accountSettingsTemplateAssignmentEtag;
 
     static {
         System.setProperty("IBM_CREDENTIALS_FILE", "../../iam_identity.env");
@@ -147,6 +205,8 @@ public class IamIdentityExamples {
         iamApiKey = config.get("APIKEY");
         iamId = config.get("IAM_ID");
         iamIdMember = config.get("IAM_ID_MEMBER");
+        enterpriseAccountId = config.get("ENTERPRISE_ACCOUNT_ID");
+        enterpriseSubAccountId = config.get("ENTERPRISE_SUBACCOUNT_ID");
 
         try {
             System.out.println("createApiKey() result:");
@@ -478,7 +538,6 @@ public class IamIdentityExamples {
             Response<TrustedProfile> response = service.createProfile(createProfileOptions).execute();
             TrustedProfile profile = response.getResult();
             profileId = profile.getId();
-            profileIamId = profile.getIamId();
 
             System.out.println(profile);
 
@@ -795,7 +854,6 @@ public class IamIdentityExamples {
                     .profileId(profileId).build();
             Response<ProfileIdentitiesResponse> response = service.getProfileIdentities(getProfileIdentitiesOptions)
                     .execute();
-            ProfileIdentitiesResponse profileIdentitiesResponseResult = response.getResult();
 
             ProfileIdentitiesResponse profileIdentityResponseResult = response.getResult();
             profileIdentitiesEtag = profileIdentityResponseResult.getEntityTag();
@@ -817,13 +875,13 @@ public class IamIdentityExamples {
             accounts.add(accountId);
             String type = "user";
             String description = "Identity description";
-            ProfileIdentity profileIdentity = new ProfileIdentity.Builder()
+            ProfileIdentityRequest profileIdentity = new ProfileIdentityRequest.Builder()
                     .identifier(iamId)
                     .accounts(accounts)
                     .type(type)
                     .description(description)
                     .build();
-            List<ProfileIdentity> listProfileIdentity = new ArrayList<ProfileIdentity>();
+            List<ProfileIdentityRequest> listProfileIdentity = new ArrayList<ProfileIdentityRequest>();
             listProfileIdentity.add(profileIdentity);
 
             SetProfileIdentitiesOptions setProfileIdentitiesOptions = new SetProfileIdentitiesOptions.Builder()
@@ -862,9 +920,9 @@ public class IamIdentityExamples {
                     .accounts(accounts)
                     .description(description)
                     .build();
-            Response<ProfileIdentity> response = service.setProfileIdentity(setProfileIdentityOptions).execute();
+            Response<ProfileIdentityResponse> response = service.setProfileIdentity(setProfileIdentityOptions).execute();
 
-            ProfileIdentity profileIdentityResponseResult = response.getResult();
+            ProfileIdentityResponse profileIdentityResponseResult = response.getResult();
             System.out.println(profileIdentityResponseResult);
 
             // end-set_profile_identity
@@ -883,9 +941,9 @@ public class IamIdentityExamples {
                     .identityType("user")
                     .identifierId(iamIdMember)
                     .build();
-            Response<ProfileIdentity> response = service.getProfileIdentity(getProfileIdentityOptions).execute();
+            Response<ProfileIdentityResponse> response = service.getProfileIdentity(getProfileIdentityOptions).execute();
 
-            ProfileIdentity profileIdentityResponseResult = response.getResult();
+            ProfileIdentityResponse profileIdentityResponseResult = response.getResult();
             System.out.println(profileIdentityResponseResult);
 
             // end-get_profile_identity
@@ -1108,6 +1166,870 @@ public class IamIdentityExamples {
         } catch (ServiceResponseException e) {
             logger.error(String.format("Service returned status code %s: %s\nError details: %s",
                     e.getStatusCode(), e.getMessage(), e.getDebuggingInfo()), e);
+        }
+
+        try {
+            System.out.println("createProfileTemplate() result:");
+
+            // begin-create_profile_template
+            ProfileClaimRuleConditions condition = new ProfileClaimRuleConditions.Builder()
+                    .claim("blueGroups")
+                    .operator("EQUALS")
+                    .value("\"cloud-docs-dev\"")
+                    .build();
+            List<ProfileClaimRuleConditions> conditions = new ArrayList<>();
+            conditions.add(condition);
+
+            TrustedProfileTemplateClaimRule claimRule = new TrustedProfileTemplateClaimRule.Builder()
+                    .name("My Rule")
+                    .realmName(realmName)
+                    .type(claimRuleType)
+                    .expiration(43200)
+                    .conditions(conditions)
+                    .build();
+
+            TemplateProfileComponentRequest profile = new TemplateProfileComponentRequest.Builder()
+                    .addRules(claimRule)
+                    .name(profileTemplateProfileName)
+                    .description("Trusted profile created from a template")
+                    .build();
+
+            CreateProfileTemplateOptions createProfileTemplateOptions = new CreateProfileTemplateOptions.Builder()
+                    .name(profileTemplateName)
+                    .description("IAM enterprise trusted profile template example")
+                    .accountId(enterpriseAccountId)
+                    .profile(profile)
+                    .build();
+
+            Response<TrustedProfileTemplateResponse> response = service.createProfileTemplate(createProfileTemplateOptions).execute();
+            TrustedProfileTemplateResponse trustedProfileTemplateResult = response.getResult();
+
+            // Save the id for use by other test methods.
+            profileTemplateId = trustedProfileTemplateResult.getId();
+            profileTemplateVersion = trustedProfileTemplateResult.getVersion().longValue();
+
+            System.out.println(trustedProfileTemplateResult);
+
+            // end-create_profile_template
+
+        } catch (ServiceResponseException e) {
+            logger.error(String.format("Service returned status code %s: %s\nError details: %s",
+                    e.getStatusCode(), e.getMessage(), e.getDebuggingInfo()), e);
+        }
+
+        try {
+            System.out.println("getProfileTemplateVersion() result:");
+
+            // begin-get_profile_template_version
+
+            GetProfileTemplateVersionOptions getProfileTemplateOptions = new GetProfileTemplateVersionOptions.Builder()
+                    .templateId(profileTemplateId)
+                    .version(Long.toString(profileTemplateVersion))
+                    .build();
+
+            Response<TrustedProfileTemplateResponse> response = service.getProfileTemplateVersion(getProfileTemplateOptions).execute();
+            TrustedProfileTemplateResponse profileTemplateResult = response.getResult();
+
+            // Grab the Etag value from the response for use in the update operation.
+            profileTemplateEtag = response.getHeaders().values("Etag").get(0);
+
+            System.out.println(profileTemplateResult);
+
+            // end-get_profile_template_version
+
+        } catch (ServiceResponseException e) {
+            logger.error(String.format("Service returned status code %s: %s\nError details: %s",
+                    e.getStatusCode(), e.getMessage(), e.getDebuggingInfo()), e);
+        }
+
+        try {
+            System.out.println("listProfileTemplates() result:");
+
+            // begin-list_profile_templates
+
+            ListProfileTemplatesOptions listOptions = new ListProfileTemplatesOptions.Builder()
+                    .accountId(enterpriseAccountId)
+                    .build();
+
+            Response<TrustedProfileTemplateList> response = service.listProfileTemplates(listOptions).execute();
+            TrustedProfileTemplateList listResult = response.getResult();
+            System.out.println(listResult);
+
+            // end-list_profile_templates
+
+        } catch (ServiceResponseException e) {
+            logger.error(String.format("Service returned status code %s: %s\nError details: %s",
+                    e.getStatusCode(), e.getMessage(), e.getDebuggingInfo()), e);
+        }
+
+        try {
+            System.out.println("updateProfileTemplateVersion() result:");
+
+            // begin-update_profile_template_version
+
+            UpdateProfileTemplateVersionOptions updateOptions = new UpdateProfileTemplateVersionOptions.Builder()
+                    .accountId(enterpriseAccountId)
+                    .templateId(profileTemplateId)
+                    .version(Long.toString(profileTemplateVersion))
+                    .ifMatch(profileTemplateEtag)
+                    .name(profileTemplateName)
+                    .description("IAM enterprise trusted profile template example - updated")
+                    .build();
+
+            Response<TrustedProfileTemplateResponse> updateResponse = service.updateProfileTemplateVersion(updateOptions).execute();
+            TrustedProfileTemplateResponse updateResult = updateResponse.getResult();
+
+            // Grab the Etag value from the response for use in the update operation.
+            profileTemplateEtag = updateResponse.getHeaders().values("Etag").get(0);
+
+            System.out.println(updateResult);
+
+            // end-update_profile_template_version
+
+        } catch (ServiceResponseException e) {
+            logger.error(String.format("Service returned status code %s: %s\nError details: %s",
+                    e.getStatusCode(), e.getMessage(), e.getDebuggingInfo()), e);
+        }
+
+        try {
+            System.out.println("commitProfileTemplate() result:");
+
+            // begin-commit_profile_template
+
+            CommitProfileTemplateOptions commitOptions = new CommitProfileTemplateOptions.Builder()
+                    .templateId(profileTemplateId)
+                    .version(Long.toString(profileTemplateVersion))
+                    .build();
+
+            Response<Void> commitResponse = service.commitProfileTemplate(commitOptions).execute();
+
+            // end-commit_profile_template
+
+            System.out.printf("commitProfileTemplate() response status code: %d%n", commitResponse.getStatusCode());
+
+        } catch (ServiceResponseException e) {
+            logger.error(String.format("Service returned status code %s: %s\nError details: %s",
+                    e.getStatusCode(), e.getMessage(), e.getDebuggingInfo()), e);
+        }
+
+        try {
+            System.out.println("createProfileTemplateAssignment() result:");
+
+            // begin-create_trusted_profile_assignment
+
+            CreateTrustedProfileAssignmentOptions assignOptions = new CreateTrustedProfileAssignmentOptions.Builder()
+                    .templateId(profileTemplateId)
+                    .templateVersion(profileTemplateVersion)
+                    .targetType("Account")
+                    .target(enterpriseSubAccountId)
+                    .build();
+
+            Response<TemplateAssignmentResponse> assignResponse = service.createTrustedProfileAssignment(assignOptions).execute();
+            TemplateAssignmentResponse assignmentResponseResult = assignResponse.getResult();
+
+            // Save the id for use by other test methods.
+            profileTemplateAssignmentId = assignmentResponseResult.getId();
+            // Grab the Etag value from the response for use in the update operation.
+            profileTemplateAssignmentEtag = assignResponse.getHeaders().values("Etag").get(0);
+
+            System.out.println(assignmentResponseResult);
+
+            // end-create_trusted_profile_assignment
+
+        } catch (ServiceResponseException e) {
+            logger.error(String.format("Service returned status code %s: %s\nError details: %s",
+                    e.getStatusCode(), e.getMessage(), e.getDebuggingInfo()), e);
+        }
+
+        try {
+            System.out.println("getProfileTemplateAssignment() result:");
+
+            // begin-get_trusted_profile_assignment
+
+            GetTrustedProfileAssignmentOptions getOptions = new GetTrustedProfileAssignmentOptions.Builder()
+                    .assignmentId(profileTemplateAssignmentId)
+                    .build();
+
+            Response<TemplateAssignmentResponse> getResponse = service.getTrustedProfileAssignment(getOptions).execute();
+            TemplateAssignmentResponse getResult = getResponse.getResult();
+
+            System.out.println(getResult);
+
+            // end-get_trusted_profile_assignment
+
+        } catch (ServiceResponseException e) {
+            logger.error(String.format("Service returned status code %s: %s\nError details: %s",
+                    e.getStatusCode(), e.getMessage(), e.getDebuggingInfo()), e);
+        }
+
+        try {
+            System.out.println("listTrustedProfileAssignments() result:");
+
+            // begin-list_trusted_profile_assignments
+
+            ListTrustedProfileAssignmentsOptions listOptions = new ListTrustedProfileAssignmentsOptions.Builder()
+                    .accountId(enterpriseAccountId)
+                    .templateId(profileTemplateId)
+                    .build();
+
+            Response<TemplateAssignmentListResponse> listResponse = service.listTrustedProfileAssignments(listOptions).execute();
+            TemplateAssignmentListResponse listResult = listResponse.getResult();
+            System.out.println(listResult);
+
+            // end-list_trusted_profile_assignments
+
+        } catch (ServiceResponseException e) {
+            logger.error(String.format("Service returned status code %s: %s\nError details: %s",
+                    e.getStatusCode(), e.getMessage(), e.getDebuggingInfo()), e);
+        }
+
+        try {
+            System.out.println("createProfileTemplateVersion() result:");
+
+            // begin-create_profile_template_version
+
+            ProfileClaimRuleConditions condition = new ProfileClaimRuleConditions.Builder()
+                    .claim("blueGroups")
+                    .operator("EQUALS")
+                    .value("\"cloud-docs-dev\"")
+                    .build();
+            List<ProfileClaimRuleConditions> conditions = new ArrayList<>();
+            conditions.add(condition);
+
+            TrustedProfileTemplateClaimRule claimRule = new TrustedProfileTemplateClaimRule.Builder()
+                    .name("My Rule")
+                    .realmName(realmName)
+                    .type(claimRuleType)
+                    .expiration(43200)
+                    .conditions(conditions)
+                    .build();
+
+            List<String> accounts = new ArrayList<String>();
+            accounts.add(enterpriseAccountId);
+            ProfileIdentityRequest profileIdentity = new ProfileIdentityRequest.Builder()
+                    .identifier(iamId)
+                    .accounts(accounts)
+                    .type("user")
+                    .description("Identity description")
+                    .build();
+            List<ProfileIdentityRequest> identities = new ArrayList<ProfileIdentityRequest>();
+            identities.add(profileIdentity);
+
+            TemplateProfileComponentRequest profile = new TemplateProfileComponentRequest.Builder()
+                    .addRules(claimRule)
+                    .name(profileTemplateProfileName)
+                    .description("Trusted profile created from a template - new version")
+                    .identities(identities)
+                    .build();
+
+            CreateProfileTemplateVersionOptions createOptions = new CreateProfileTemplateVersionOptions.Builder()
+                    .accountId(enterpriseAccountId)
+                    .templateId(profileTemplateId)
+                    .name(profileTemplateName)
+                    .description("IAM enterprise trusted profile template example - new version")
+                    .profile(profile)
+                    .build();
+
+            Response<TrustedProfileTemplateResponse> createResponse = service.createProfileTemplateVersion(createOptions).execute();
+            TrustedProfileTemplateResponse createResult = createResponse.getResult();
+
+            // Save the version for use by other test methods.
+            profileTemplateVersion = createResult.getVersion().longValue();
+            System.out.println(createResult);
+
+            // end-create_profile_template_version
+
+        } catch (ServiceResponseException e) {
+            logger.error(String.format("Service returned status code %s: %s\nError details: %s",
+                    e.getStatusCode(), e.getMessage(), e.getDebuggingInfo()), e);
+        }
+
+        try {
+            System.out.println("getLatestProfileTemplateVersion() result:");
+
+            // begin-get_latest_profile_template_version
+
+            GetLatestProfileTemplateVersionOptions getOptions = new GetLatestProfileTemplateVersionOptions.Builder()
+                    .templateId(profileTemplateId)
+                    .build();
+
+            Response<TrustedProfileTemplateResponse> getResponse = service.getLatestProfileTemplateVersion(getOptions).execute();
+            TrustedProfileTemplateResponse getResult = getResponse.getResult();
+
+            System.out.println(getResult);
+
+            // end-get_latest_profile_template_version
+
+        } catch (ServiceResponseException e) {
+            logger.error(String.format("Service returned status code %s: %s\nError details: %s",
+                    e.getStatusCode(), e.getMessage(), e.getDebuggingInfo()), e);
+        }
+
+        try {
+            System.out.println("listVersionsOfProfileTemplate() result:");
+
+            // begin-list_versions_of_profile_template
+
+            ListVersionsOfProfileTemplateOptions listOptions = new ListVersionsOfProfileTemplateOptions.Builder()
+                    .templateId(profileTemplateId)
+                    .build();
+
+            Response<TrustedProfileTemplateList> listResponse = service.listVersionsOfProfileTemplate(listOptions).execute();
+            TrustedProfileTemplateList listResult = listResponse.getResult();
+
+            System.out.println(listResult);
+
+            // end-list_versions_of_profile_template
+
+        } catch (ServiceResponseException e) {
+            logger.error(String.format("Service returned status code %s: %s\nError details: %s",
+                    e.getStatusCode(), e.getMessage(), e.getDebuggingInfo()), e);
+        }
+
+        try {
+            CommitProfileTemplateOptions commitOptions = new CommitProfileTemplateOptions.Builder()
+                    .templateId(profileTemplateId)
+                    .version(Long.toString(profileTemplateVersion))
+                    .build();
+            service.commitProfileTemplate(commitOptions).execute();
+
+            waitUntilTrustedProfileAssignmentFinished(profileTemplateAssignmentId, service);
+
+            System.out.println("updateTrustedProfileAssignment() result:");
+
+            // begin-update_trusted_profile_assignment
+
+            UpdateTrustedProfileAssignmentOptions updateOptions = new UpdateTrustedProfileAssignmentOptions.Builder()
+                    .assignmentId(profileTemplateAssignmentId)
+                    .templateVersion(profileTemplateVersion)
+                    .ifMatch(profileTemplateAssignmentEtag)
+                    .build();
+
+            Response<TemplateAssignmentResponse> updateResponse = service.updateTrustedProfileAssignment(updateOptions).execute();
+            TemplateAssignmentResponse updateResult = updateResponse.getResult();
+
+            // Grab the Etag value from the response for use in the update operation.
+            profileTemplateAssignmentEtag = updateResponse.getHeaders().values("Etag").get(0);
+
+            System.out.println(updateResult);
+
+            // end-update_trusted_profile_assignment
+
+        } catch (ServiceResponseException e) {
+            logger.error(String.format("Service returned status code %s: %s\nError details: %s",
+                    e.getStatusCode(), e.getMessage(), e.getDebuggingInfo()), e);
+        }
+
+        try {
+            System.out.println("deleteTrustedProfileAssignment() result:");
+
+            waitUntilTrustedProfileAssignmentFinished(profileTemplateAssignmentId, service);
+
+            // begin-delete_trusted_profile_assignment
+
+            DeleteTrustedProfileAssignmentOptions deleteOptions = new DeleteTrustedProfileAssignmentOptions.Builder()
+                    .assignmentId(profileTemplateAssignmentId)
+                    .build();
+
+            Response<ExceptionResponse> deleteResponse = service.deleteTrustedProfileAssignment(deleteOptions).execute();
+
+            // end-delete_trusted_profile_assignment
+
+            System.out.printf("deleteTrustedProfileAssignment() response status code: %d%n", deleteResponse.getStatusCode());
+
+        } catch (ServiceResponseException e) {
+            logger.error(String.format("Service returned status code %s: %s\nError details: %s",
+                    e.getStatusCode(), e.getMessage(), e.getDebuggingInfo()), e);
+        }
+
+        try {
+            System.out.println("deleteProfileTemplateVersion() result:");
+
+            // begin-delete_profile_template_version
+
+            DeleteProfileTemplateVersionOptions deleteOptions = new DeleteProfileTemplateVersionOptions.Builder()
+                    .templateId(profileTemplateId)
+                    .version("1")
+                    .build();
+
+            Response<Void> deleteResponse = service.deleteProfileTemplateVersion(deleteOptions).execute();
+
+            // end-delete_profile_template_version
+
+            System.out.printf("deleteProfileTemplateVersion() response status code: %d%n", deleteResponse.getStatusCode());
+
+        } catch (ServiceResponseException e) {
+            logger.error(String.format("Service returned status code %s: %s\nError details: %s",
+                    e.getStatusCode(), e.getMessage(), e.getDebuggingInfo()), e);
+        }
+
+        try {
+            System.out.println("deleteProfileTemplateAllVersions() result:");
+
+            waitUntilTrustedProfileAssignmentFinished(profileTemplateAssignmentId, service);
+
+            // begin-delete_all_versions_of_profile_template
+
+            DeleteAllVersionsOfProfileTemplateOptions deleteTeplateOptions = new DeleteAllVersionsOfProfileTemplateOptions.Builder()
+                    .templateId(profileTemplateId)
+                    .build();
+
+            Response<Void> deleteResponse = service.deleteAllVersionsOfProfileTemplate(deleteTeplateOptions).execute();
+
+            // end-delete_all_versions_of_profile_template
+
+            System.out.printf("deleteProfileTemplateAllVersions() response status code: %d%n", deleteResponse.getStatusCode());
+
+        } catch (ServiceResponseException e) {
+            logger.error(String.format("Service returned status code %s: %s\nError details: %s",
+                    e.getStatusCode(), e.getMessage(), e.getDebuggingInfo()), e);
+        }
+
+        try {
+            System.out.println("createAccountSettingsTemplate() result:");
+
+            // begin-create_account_settings_template
+
+            AccountSettingsComponent accountSettings = new AccountSettingsComponent.Builder()
+                    .mfa("LEVEL1")
+                    .systemAccessTokenExpirationInSeconds("3000")
+                    .build();
+
+            CreateAccountSettingsTemplateOptions createOptions = new CreateAccountSettingsTemplateOptions.Builder()
+                    .accountId(enterpriseAccountId)
+                    .name(accountSettingsTemplateName)
+                    .description("IAM enterprise account settings template example")
+                    .accountSettings(accountSettings)
+                    .build();
+
+            Response<AccountSettingsTemplateResponse> createResponse = service.createAccountSettingsTemplate(createOptions).execute();
+            AccountSettingsTemplateResponse createResult = createResponse.getResult();
+
+            // Save the id for use by other test methods.
+            accountSettingsTemplateId = createResult.getId();
+            accountSettingsTemplateVersion = createResult.getVersion().longValue();
+
+            System.out.println(createResult);
+
+            // end-create_account_settings_template
+
+        } catch (ServiceResponseException e) {
+            logger.error(String.format("Service returned status code %s: %s\nError details: %s",
+                    e.getStatusCode(), e.getMessage(), e.getDebuggingInfo()), e);
+        }
+
+        try {
+            System.out.println("getAccountSettingsTemplateVersion() result:");
+
+            // begin-get_account_settings_template_version
+
+            GetAccountSettingsTemplateVersionOptions getOptions = new GetAccountSettingsTemplateVersionOptions.Builder()
+                    .templateId(accountSettingsTemplateId)
+                    .version(Long.toString(accountSettingsTemplateVersion))
+                    .build();
+
+            Response<AccountSettingsTemplateResponse> response = service.getAccountSettingsTemplateVersion(getOptions).execute();
+            AccountSettingsTemplateResponse getResult = response.getResult();
+
+            // Grab the Etag value from the response for use in the update operation.
+            accountSettingsTemplateEtag = response.getHeaders().values("Etag").get(0);
+
+            System.out.println(getResult);
+
+            // end-get_account_settings_template_version
+
+        } catch (ServiceResponseException e) {
+            logger.error(String.format("Service returned status code %s: %s\nError details: %s",
+                    e.getStatusCode(), e.getMessage(), e.getDebuggingInfo()), e);
+        }
+
+        try {
+            System.out.println("listAccountSettingsTemplates() result:");
+
+            // begin-list_account_settings_templates
+
+            ListAccountSettingsTemplatesOptions listOptions = new ListAccountSettingsTemplatesOptions.Builder()
+                    .accountId(enterpriseAccountId)
+                    .build();
+
+            Response<AccountSettingsTemplateList> response = service.listAccountSettingsTemplates(listOptions).execute();
+            AccountSettingsTemplateList result = response.getResult();
+
+            System.out.println(result);
+
+            // end-list_account_settings_templates
+
+        } catch (ServiceResponseException e) {
+            logger.error(String.format("Service returned status code %s: %s\nError details: %s",
+                    e.getStatusCode(), e.getMessage(), e.getDebuggingInfo()), e);
+        }
+
+        try {
+            System.out.println("updateAccountSettingsTemplateVersion() result:");
+
+            // begin-update_account_settings_template_version
+
+            AccountSettingsComponent accountSettings = new AccountSettingsComponent.Builder()
+                    .mfa("LEVEL1")
+                    .systemAccessTokenExpirationInSeconds("3000")
+                    .build();
+            UpdateAccountSettingsTemplateVersionOptions updateOptions = new UpdateAccountSettingsTemplateVersionOptions.Builder()
+                    .accountId(enterpriseAccountId)
+                    .templateId(accountSettingsTemplateId)
+                    .version(Long.toString(accountSettingsTemplateVersion))
+                    .ifMatch(accountSettingsTemplateEtag)
+                    .name(accountSettingsTemplateName)
+                    .description("IAM enterprise account settings template example - updated")
+                    .accountSettings(accountSettings)
+                    .build();
+
+            Response<AccountSettingsTemplateResponse> updateResponse = service.updateAccountSettingsTemplateVersion(updateOptions).execute();
+            AccountSettingsTemplateResponse updateResult = updateResponse.getResult();
+
+            // Grab the Etag value from the response for use in the update operation.
+            accountSettingsTemplateEtag = updateResponse.getHeaders().values("Etag").get(0);
+
+            System.out.println(updateResult);
+
+            // end-update_account_settings_template_version
+
+        } catch (ServiceResponseException e) {
+            logger.error(String.format("Service returned status code %s: %s\nError details: %s",
+                    e.getStatusCode(), e.getMessage(), e.getDebuggingInfo()), e);
+        }
+
+        try {
+            System.out.println("commitAccountSettingsTemplate() result:");
+
+            // begin-commit_account_settings_template
+
+            CommitAccountSettingsTemplateOptions commitOptions = new CommitAccountSettingsTemplateOptions.Builder()
+                    .templateId(accountSettingsTemplateId)
+                    .version(Long.toString(accountSettingsTemplateVersion))
+                    .build();
+
+            Response<Void> commitResponse = service.commitAccountSettingsTemplate(commitOptions).execute();
+
+            // end-commit_account_settings_template
+
+            System.out.printf("deleteProfileTemplateAllVersions() response status code: %d%n", commitResponse.getStatusCode());
+
+        } catch (ServiceResponseException e) {
+            logger.error(String.format("Service returned status code %s: %s\nError details: %s",
+                    e.getStatusCode(), e.getMessage(), e.getDebuggingInfo()), e);
+        }
+
+        try {
+            System.out.println("createAccountSettingsAssignment() result:");
+
+            // begin-create_account_settings_assignment
+
+            CreateAccountSettingsAssignmentOptions assignOptions = new CreateAccountSettingsAssignmentOptions.Builder()
+                    .templateId(accountSettingsTemplateId)
+                    .templateVersion(accountSettingsTemplateVersion)
+                    .targetType("Account")
+                    .target(enterpriseSubAccountId)
+                    .build();
+
+            Response<TemplateAssignmentResponse> assignResponse = service.createAccountSettingsAssignment(assignOptions).execute();
+            TemplateAssignmentResponse assignmentResult = assignResponse.getResult();
+
+            // Save the id for use by other test methods.
+            accountSettingsTemplateAssignmentId = assignmentResult.getId();
+            // Grab the Etag value from the response for use in the update operation.
+            accountSettingsTemplateAssignmentEtag = assignResponse.getHeaders().values("Etag").get(0);
+
+            System.out.println(assignmentResult);
+
+            // end-create_account_settings_assignment
+
+        } catch (ServiceResponseException e) {
+            logger.error(String.format("Service returned status code %s: %s\nError details: %s",
+                    e.getStatusCode(), e.getMessage(), e.getDebuggingInfo()), e);
+        }
+
+        try {
+            System.out.println("listAccountSettingsAssignments() result:");
+
+            // begin-list_account_settings_assignments
+
+            ListAccountSettingsTemplatesOptions listOptions = new ListAccountSettingsTemplatesOptions.Builder()
+                    .accountId(enterpriseAccountId)
+                    .build();
+
+            Response<AccountSettingsTemplateList> listResponse = service.listAccountSettingsTemplates(listOptions).execute();
+            AccountSettingsTemplateList listResult = listResponse.getResult();
+
+            System.out.println(listResult);
+
+            // end-list_account_settings_assignments
+
+        } catch (ServiceResponseException e) {
+            logger.error(String.format("Service returned status code %s: %s\nError details: %s",
+                    e.getStatusCode(), e.getMessage(), e.getDebuggingInfo()), e);
+        }
+
+        try {
+            System.out.println("getAccountSettingsAssignment() result:");
+
+            // begin-get_account_settings_assignment
+
+            GetAccountSettingsAssignmentOptions getOptions = new GetAccountSettingsAssignmentOptions.Builder()
+                    .assignmentId(accountSettingsTemplateAssignmentId)
+                    .build();
+
+            Response<TemplateAssignmentResponse> getResponse = service.getAccountSettingsAssignment(getOptions).execute();
+            TemplateAssignmentResponse getResult = getResponse.getResult();
+
+            // Grab the Etag value from the response for use in the update operation.
+            accountSettingsTemplateAssignmentEtag = getResponse.getHeaders().values("Etag").get(0);
+
+            System.out.println(getResult);
+
+            // end-get_account_settings_assignment
+
+        } catch (ServiceResponseException e) {
+            logger.error(String.format("Service returned status code %s: %s\nError details: %s",
+                    e.getStatusCode(), e.getMessage(), e.getDebuggingInfo()), e);
+        }
+
+        try {
+            System.out.println("createAccountSettingsTemplateVersion() result:");
+
+            // begin-create_account_settings_template_version
+
+            AccountSettingsComponent accountSettings = new AccountSettingsComponent.Builder()
+                    .mfa("LEVEL1")
+                    .systemAccessTokenExpirationInSeconds("2600")
+                    .restrictCreatePlatformApikey("RESTRICTED")
+                    .restrictCreateServiceId("RESTRICTED")
+                    .build();
+            CreateAccountSettingsTemplateVersionOptions createOptions = new CreateAccountSettingsTemplateVersionOptions.Builder()
+                    .accountId(enterpriseAccountId)
+                    .templateId(accountSettingsTemplateId)
+                    .name(accountSettingsTemplateName)
+                    .description("IAM enterprise account settings template example - new version")
+                    .accountSettings(accountSettings)
+                    .build();
+
+            Response<AccountSettingsTemplateResponse> createResponse = service.createAccountSettingsTemplateVersion(createOptions).execute();
+            AccountSettingsTemplateResponse createResult = createResponse.getResult();
+
+            // Save the version for use by other test methods.
+            accountSettingsTemplateVersion = createResult.getVersion().longValue();
+
+            System.out.println(createResult);
+
+            // end-create_account_settings_template_version
+
+        } catch (ServiceResponseException e) {
+            logger.error(String.format("Service returned status code %s: %s\nError details: %s",
+                    e.getStatusCode(), e.getMessage(), e.getDebuggingInfo()), e);
+        }
+
+        try {
+            System.out.println("getLatestAccountSettingsTemplateVersion() result:");
+
+            // begin-get_latest_account_settings_template_version
+
+            GetLatestAccountSettingsTemplateVersionOptions getOptions = new GetLatestAccountSettingsTemplateVersionOptions.Builder()
+                    .templateId(accountSettingsTemplateId)
+                    .build();
+
+            Response<AccountSettingsTemplateResponse> getResponse = service.getLatestAccountSettingsTemplateVersion(getOptions).execute();
+            AccountSettingsTemplateResponse getResult = getResponse.getResult();
+
+            System.out.println(getResult);
+
+            // end-get_latest_account_settings_template_version
+
+        } catch (ServiceResponseException e) {
+            logger.error(String.format("Service returned status code %s: %s\nError details: %s",
+                    e.getStatusCode(), e.getMessage(), e.getDebuggingInfo()), e);
+        }
+
+        try {
+            System.out.println("listVersionsOfAccountSettingsTemplate() result:");
+
+            // begin-list_versions_of_account_settings_template
+
+            ListVersionsOfAccountSettingsTemplateOptions listOptions = new ListVersionsOfAccountSettingsTemplateOptions.Builder()
+                    .templateId(accountSettingsTemplateId)
+                    .build();
+
+            Response<AccountSettingsTemplateList> listResponse = service.listVersionsOfAccountSettingsTemplate(listOptions).execute();
+            AccountSettingsTemplateList listResult = listResponse.getResult();
+
+            System.out.println(listResult);
+
+            // end-list_versions_of_account_settings_template
+
+        } catch (ServiceResponseException e) {
+            logger.error(String.format("Service returned status code %s: %s\nError details: %s",
+                    e.getStatusCode(), e.getMessage(), e.getDebuggingInfo()), e);
+        }
+
+        try {
+            System.out.println("updateAccountSettingsAssignment() result:");
+
+            CommitAccountSettingsTemplateOptions commitOptions = new CommitAccountSettingsTemplateOptions.Builder()
+                    .templateId(accountSettingsTemplateId)
+                    .version(Long.toString(accountSettingsTemplateVersion))
+                    .build();
+
+            service.commitAccountSettingsTemplate(commitOptions).execute();
+
+            waitUntilAccountSettingsAssignmentFinished(accountSettingsTemplateAssignmentId, service);
+
+            // begin-update_account_settings_assignment
+
+            UpdateAccountSettingsAssignmentOptions updateOptions = new UpdateAccountSettingsAssignmentOptions.Builder()
+                    .assignmentId(accountSettingsTemplateAssignmentId)
+                    .templateVersion(accountSettingsTemplateVersion)
+                    .ifMatch(accountSettingsTemplateAssignmentEtag)
+                    .build();
+
+            Response<TemplateAssignmentResponse> updateResponse = service.updateAccountSettingsAssignment(updateOptions).execute();
+            TemplateAssignmentResponse updateResult = updateResponse.getResult();
+
+            // Grab the Etag value from the response for use in the update operation.
+            accountSettingsTemplateAssignmentEtag = updateResponse.getHeaders().values("Etag").get(0);
+
+            System.out.println(updateResult);
+
+            // end-update_account_settings_assignment
+
+        } catch (ServiceResponseException e) {
+            logger.error(String.format("Service returned status code %s: %s\nError details: %s",
+                    e.getStatusCode(), e.getMessage(), e.getDebuggingInfo()), e);
+        }
+
+        try {
+            System.out.println("deleteAccountSettingsAssignment() result:");
+
+            waitUntilAccountSettingsAssignmentFinished(accountSettingsTemplateAssignmentId, service);
+
+            // begin-delete_account_settings_assignment
+
+            DeleteAccountSettingsAssignmentOptions deleteOptions = new DeleteAccountSettingsAssignmentOptions.Builder()
+                    .assignmentId(accountSettingsTemplateAssignmentId)
+                    .build();
+
+            Response<ExceptionResponse> deleteResponse = service.deleteAccountSettingsAssignment(deleteOptions).execute();
+
+            // end-delete_account_settings_assignment
+
+            System.out.printf("deleteProfileTemplateAllVersions() response status code: %d%n", deleteResponse.getStatusCode());
+
+        } catch (ServiceResponseException e) {
+            logger.error(String.format("Service returned status code %s: %s\nError details: %s",
+                    e.getStatusCode(), e.getMessage(), e.getDebuggingInfo()), e);
+        }
+
+        try {
+            System.out.println("deleteAccountSettingsTemplateVersion() result:");
+
+            // begin-delete_account_settings_template_version
+
+            DeleteAccountSettingsTemplateVersionOptions deleteOptions = new DeleteAccountSettingsTemplateVersionOptions.Builder()
+                    .templateId(accountSettingsTemplateId)
+                    .version("1")
+                    .build();
+
+            Response<Void> deleteResponse = service.deleteAccountSettingsTemplateVersion(deleteOptions).execute();
+
+            // end-delete_account_settings_template_version
+
+            System.out.printf("deleteProfileTemplateAllVersions() response status code: %d%n", deleteResponse.getStatusCode());
+
+        } catch (ServiceResponseException e) {
+            logger.error(String.format("Service returned status code %s: %s\nError details: %s",
+                    e.getStatusCode(), e.getMessage(), e.getDebuggingInfo()), e);
+        }
+
+        try {
+            System.out.println("deleteAllVersionsOfAccountSettingsTemplate() result:");
+
+            waitUntilAccountSettingsAssignmentFinished(accountSettingsTemplateAssignmentId, service);
+
+            // begin-delete_all_versions_of_account_settings_template
+
+            DeleteAllVersionsOfAccountSettingsTemplateOptions deleteTeplateOptions = new DeleteAllVersionsOfAccountSettingsTemplateOptions.Builder()
+                    .templateId(accountSettingsTemplateId)
+                    .build();
+
+            Response<Void> deleteResponse = service.deleteAllVersionsOfAccountSettingsTemplate(deleteTeplateOptions).execute();
+
+            // end-delete_all_versions_of_account_settings_template
+
+            System.out.printf("deleteProfileTemplateAllVersions() response status code: %d%n", deleteResponse.getStatusCode());
+
+        } catch (ServiceResponseException e) {
+            logger.error(String.format("Service returned status code %s: %s\nError details: %s",
+                    e.getStatusCode(), e.getMessage(), e.getDebuggingInfo()), e);
+        }
+    }
+
+    private static void sleep(int numSecs) {
+        try {
+            Thread.sleep(numSecs * 1000);
+        } catch (Throwable t) {
+        }
+    }
+
+    private static boolean isFinished(String status) {
+        return ("succeeded".equalsIgnoreCase(status) || "failed".equalsIgnoreCase(status));
+    }
+
+    private static void waitUntilTrustedProfileAssignmentFinished(String assignmentId, IamIdentity service) {
+        GetTrustedProfileAssignmentOptions getOptions = new GetTrustedProfileAssignmentOptions.Builder()
+                .assignmentId(assignmentId)
+                .build();
+
+        boolean finished = false;
+        for (int i = 0; i < 50; i++) {
+            Response<TemplateAssignmentResponse> getResponse = null;
+            try {
+                getResponse = service.getTrustedProfileAssignment(getOptions).execute();
+                TemplateAssignmentResponse result = getResponse.getResult();
+                finished = isFinished(result.getStatus());
+                if (finished) {
+                    // Grab the Etag value from the response for use in the update operation.
+                    profileTemplateAssignmentEtag = getResponse.getHeaders().values("Etag").get(0);
+                    break;
+                }
+            } catch (NotFoundException e) {
+                // assignment removed
+                finished = true;
+                break;
+            }
+            sleep(10);
+        }
+    }
+
+    private static void waitUntilAccountSettingsAssignmentFinished(String assignmentId, IamIdentity service) {
+        GetAccountSettingsAssignmentOptions getOptions = new GetAccountSettingsAssignmentOptions.Builder()
+                .assignmentId(assignmentId)
+                .build();
+
+        boolean finished = false;
+        for (int i = 0; i < 50; i++) {
+            Response<TemplateAssignmentResponse> getResponse = null;
+            try {
+                getResponse = service.getAccountSettingsAssignment(getOptions).execute();
+                TemplateAssignmentResponse result = getResponse.getResult();
+                finished = isFinished(result.getStatus());
+                if (finished) {
+                    // Grab the Etag value from the response for use in the update operation.
+                    accountSettingsTemplateAssignmentEtag = getResponse.getHeaders().values("Etag").get(0);
+                    break;
+                }
+            } catch (NotFoundException e) {
+                // assignment removed
+                finished = true;
+                break;
+            }
+            sleep(10);
         }
     }
 }

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/IamIdentity.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/IamIdentity.java
@@ -12,7 +12,7 @@
  */
 
 /*
- * IBM OpenAPI SDK Code Generator Version: 3.72.0-5d70f2bb-20230511-203609
+ * IBM OpenAPI SDK Code Generator Version: 3.74.0-89f1dbab-20230630-160213
  */
 
 package com.ibm.cloud.platform_services.iam_identity.v1;
@@ -20,44 +20,73 @@ package com.ibm.cloud.platform_services.iam_identity.v1;
 import com.google.gson.JsonObject;
 import com.ibm.cloud.platform_services.common.SdkCommon;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.AccountSettingsResponse;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.AccountSettingsTemplateList;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.AccountSettingsTemplateResponse;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.ApiKey;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.ApiKeyList;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.CommitAccountSettingsTemplateOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.CommitProfileTemplateOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.CreateAccountSettingsAssignmentOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.CreateAccountSettingsTemplateOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.CreateAccountSettingsTemplateVersionOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.CreateApiKeyOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.CreateClaimRuleOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.CreateLinkOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.CreateMfaReportOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.CreateProfileOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.CreateProfileTemplateOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.CreateProfileTemplateVersionOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.CreateReportOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.CreateServiceIdOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.CreateTrustedProfileAssignmentOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.DeleteAccountSettingsAssignmentOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.DeleteAccountSettingsTemplateVersionOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.DeleteAllVersionsOfAccountSettingsTemplateOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.DeleteAllVersionsOfProfileTemplateOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.DeleteApiKeyOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.DeleteClaimRuleOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.DeleteLinkOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.DeleteProfileIdentityOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.DeleteProfileOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.DeleteProfileTemplateVersionOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.DeleteServiceIdOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.DeleteTrustedProfileAssignmentOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.ExceptionResponse;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.GetAccountSettingsAssignmentOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.GetAccountSettingsOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.GetAccountSettingsTemplateVersionOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.GetApiKeyOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.GetApiKeysDetailsOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.GetClaimRuleOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.GetLatestAccountSettingsTemplateVersionOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.GetLatestProfileTemplateVersionOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.GetLinkOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.GetMfaReportOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.GetMfaStatusOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.GetProfileIdentitiesOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.GetProfileIdentityOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.GetProfileOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.GetProfileTemplateVersionOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.GetReportOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.GetServiceIdOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.GetTrustedProfileAssignmentOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.ListAccountSettingsAssignmentsOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.ListAccountSettingsTemplatesOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.ListApiKeysOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.ListClaimRulesOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.ListLinksOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.ListProfileTemplatesOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.ListProfilesOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.ListServiceIdsOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.ListTrustedProfileAssignmentsOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.ListVersionsOfAccountSettingsTemplateOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.ListVersionsOfProfileTemplateOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.LockApiKeyOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.LockServiceIdOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.ProfileClaimRule;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.ProfileClaimRuleList;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.ProfileIdentitiesResponse;
-import com.ibm.cloud.platform_services.iam_identity.v1.model.ProfileIdentity;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.ProfileIdentityResponse;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.ProfileLink;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.ProfileLinkList;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.Report;
@@ -67,15 +96,23 @@ import com.ibm.cloud.platform_services.iam_identity.v1.model.ServiceId;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.ServiceIdList;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.SetProfileIdentitiesOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.SetProfileIdentityOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.TemplateAssignmentListResponse;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.TemplateAssignmentResponse;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.TrustedProfile;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.TrustedProfileTemplateList;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.TrustedProfileTemplateResponse;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.TrustedProfilesList;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.UnlockApiKeyOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.UnlockServiceIdOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.UpdateAccountSettingsAssignmentOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.UpdateAccountSettingsOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.UpdateAccountSettingsTemplateVersionOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.UpdateApiKeyOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.UpdateClaimRuleOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.UpdateProfileOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.UpdateProfileTemplateVersionOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.UpdateServiceIdOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.UpdateTrustedProfileAssignmentOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.UserMfaEnrollments;
 import com.ibm.cloud.sdk.core.http.RequestBuilder;
 import com.ibm.cloud.sdk.core.http.ResponseConverter;
@@ -437,7 +474,7 @@ public class IamIdentity extends BaseService {
    *
    * Returns a list of service IDs. Users can manage user API keys for themself, or service ID API keys for service IDs
    * that are bound to an entity they have access to. Note: apikey details are only included in the response when
-   * creating a Service ID with an api key.
+   * creating a Service ID with an apikey.
    *
    * @param listServiceIdsOptions the {@link ListServiceIdsOptions} containing the options for the call
    * @return a {@link ServiceCall} with a result of type {@link ServiceIdList}
@@ -483,7 +520,7 @@ public class IamIdentity extends BaseService {
    *
    * Returns a list of service IDs. Users can manage user API keys for themself, or service ID API keys for service IDs
    * that are bound to an entity they have access to. Note: apikey details are only included in the response when
-   * creating a Service ID with an api key.
+   * creating a Service ID with an apikey.
    *
    * @return a {@link ServiceCall} with a result of type {@link ServiceIdList}
    */
@@ -535,7 +572,7 @@ public class IamIdentity extends BaseService {
    *
    * Returns the details of a service ID. Users can manage user API keys for themself, or service ID API keys for
    * service IDs that are bound to an entity they have access to. Note: apikey details are only included in the response
-   * when creating a Service ID with an api key.
+   * when creating a Service ID with an apikey.
    *
    * @param getServiceIdOptions the {@link GetServiceIdOptions} containing the options for the call
    * @return a {@link ServiceCall} with a result of type {@link ServiceId}
@@ -1157,9 +1194,9 @@ public class IamIdentity extends BaseService {
    * Add a specific identity that can assume the trusted profile.
    *
    * @param setProfileIdentityOptions the {@link SetProfileIdentityOptions} containing the options for the call
-   * @return a {@link ServiceCall} with a result of type {@link ProfileIdentity}
+   * @return a {@link ServiceCall} with a result of type {@link ProfileIdentityResponse}
    */
-  public ServiceCall<ProfileIdentity> setProfileIdentity(SetProfileIdentityOptions setProfileIdentityOptions) {
+  public ServiceCall<ProfileIdentityResponse> setProfileIdentity(SetProfileIdentityOptions setProfileIdentityOptions) {
     com.ibm.cloud.sdk.core.util.Validator.notNull(setProfileIdentityOptions,
       "setProfileIdentityOptions cannot be null");
     Map<String, String> pathParamsMap = new HashMap<String, String>();
@@ -1174,9 +1211,6 @@ public class IamIdentity extends BaseService {
     final JsonObject contentJson = new JsonObject();
     contentJson.addProperty("identifier", setProfileIdentityOptions.identifier());
     contentJson.addProperty("type", setProfileIdentityOptions.type());
-    if (setProfileIdentityOptions.iamId() != null) {
-      contentJson.addProperty("iam_id", setProfileIdentityOptions.iamId());
-    }
     if (setProfileIdentityOptions.accounts() != null) {
       contentJson.add("accounts", com.ibm.cloud.sdk.core.util.GsonSingleton.getGson().toJsonTree(setProfileIdentityOptions.accounts()));
     }
@@ -1184,8 +1218,8 @@ public class IamIdentity extends BaseService {
       contentJson.addProperty("description", setProfileIdentityOptions.description());
     }
     builder.bodyJson(contentJson);
-    ResponseConverter<ProfileIdentity> responseConverter =
-      ResponseConverterUtils.getValue(new com.google.gson.reflect.TypeToken<ProfileIdentity>() { }.getType());
+    ResponseConverter<ProfileIdentityResponse> responseConverter =
+      ResponseConverterUtils.getValue(new com.google.gson.reflect.TypeToken<ProfileIdentityResponse>() { }.getType());
     return createServiceCall(builder.build(), responseConverter);
   }
 
@@ -1195,9 +1229,9 @@ public class IamIdentity extends BaseService {
    * Get the identity that can assume the trusted profile.
    *
    * @param getProfileIdentityOptions the {@link GetProfileIdentityOptions} containing the options for the call
-   * @return a {@link ServiceCall} with a result of type {@link ProfileIdentity}
+   * @return a {@link ServiceCall} with a result of type {@link ProfileIdentityResponse}
    */
-  public ServiceCall<ProfileIdentity> getProfileIdentity(GetProfileIdentityOptions getProfileIdentityOptions) {
+  public ServiceCall<ProfileIdentityResponse> getProfileIdentity(GetProfileIdentityOptions getProfileIdentityOptions) {
     com.ibm.cloud.sdk.core.util.Validator.notNull(getProfileIdentityOptions,
       "getProfileIdentityOptions cannot be null");
     Map<String, String> pathParamsMap = new HashMap<String, String>();
@@ -1210,8 +1244,8 @@ public class IamIdentity extends BaseService {
       builder.header(header.getKey(), header.getValue());
     }
     builder.header("Accept", "application/json");
-    ResponseConverter<ProfileIdentity> responseConverter =
-      ResponseConverterUtils.getValue(new com.google.gson.reflect.TypeToken<ProfileIdentity>() { }.getType());
+    ResponseConverter<ProfileIdentityResponse> responseConverter =
+      ResponseConverterUtils.getValue(new com.google.gson.reflect.TypeToken<ProfileIdentityResponse>() { }.getType());
     return createServiceCall(builder.build(), responseConverter);
   }
 
@@ -1269,7 +1303,7 @@ public class IamIdentity extends BaseService {
   /**
    * Update account configurations.
    *
-   * Allows a user to configure settings on their account with regards to MFA, MFA excemption list,  session lifetimes,
+   * Allows a user to configure settings on their account with regards to MFA, MFA excemption list, session lifetimes,
    * access control for creating new identities, and enforcing IP restrictions on token creation.
    *
    * @param updateAccountSettingsOptions the {@link UpdateAccountSettingsOptions} containing the options for the call
@@ -1404,6 +1438,520 @@ public class IamIdentity extends BaseService {
   }
 
   /**
+   * List assignments.
+   *
+   * List account settings assignments.
+   *
+   * @param listAccountSettingsAssignmentsOptions the {@link ListAccountSettingsAssignmentsOptions} containing the options for the call
+   * @return a {@link ServiceCall} with a result of type {@link TemplateAssignmentListResponse}
+   */
+  public ServiceCall<TemplateAssignmentListResponse> listAccountSettingsAssignments(ListAccountSettingsAssignmentsOptions listAccountSettingsAssignmentsOptions) {
+    if (listAccountSettingsAssignmentsOptions == null) {
+      listAccountSettingsAssignmentsOptions = new ListAccountSettingsAssignmentsOptions.Builder().build();
+    }
+    RequestBuilder builder = RequestBuilder.get(RequestBuilder.resolveRequestUrl(getServiceUrl(), "/v1/account_settings_assignments/"));
+    Map<String, String> sdkHeaders = SdkCommon.getSdkHeaders("iam_identity", "v1", "listAccountSettingsAssignments");
+    for (Entry<String, String> header : sdkHeaders.entrySet()) {
+      builder.header(header.getKey(), header.getValue());
+    }
+    builder.header("Accept", "application/json");
+    if (listAccountSettingsAssignmentsOptions.accountId() != null) {
+      builder.query("account_id", String.valueOf(listAccountSettingsAssignmentsOptions.accountId()));
+    }
+    if (listAccountSettingsAssignmentsOptions.templateId() != null) {
+      builder.query("template_id", String.valueOf(listAccountSettingsAssignmentsOptions.templateId()));
+    }
+    if (listAccountSettingsAssignmentsOptions.templateVersion() != null) {
+      builder.query("template_version", String.valueOf(listAccountSettingsAssignmentsOptions.templateVersion()));
+    }
+    if (listAccountSettingsAssignmentsOptions.target() != null) {
+      builder.query("target", String.valueOf(listAccountSettingsAssignmentsOptions.target()));
+    }
+    if (listAccountSettingsAssignmentsOptions.targetType() != null) {
+      builder.query("target_type", String.valueOf(listAccountSettingsAssignmentsOptions.targetType()));
+    }
+    if (listAccountSettingsAssignmentsOptions.limit() != null) {
+      builder.query("limit", String.valueOf(listAccountSettingsAssignmentsOptions.limit()));
+    }
+    if (listAccountSettingsAssignmentsOptions.pagetoken() != null) {
+      builder.query("pagetoken", String.valueOf(listAccountSettingsAssignmentsOptions.pagetoken()));
+    }
+    if (listAccountSettingsAssignmentsOptions.sort() != null) {
+      builder.query("sort", String.valueOf(listAccountSettingsAssignmentsOptions.sort()));
+    }
+    if (listAccountSettingsAssignmentsOptions.order() != null) {
+      builder.query("order", String.valueOf(listAccountSettingsAssignmentsOptions.order()));
+    }
+    if (listAccountSettingsAssignmentsOptions.includeHistory() != null) {
+      builder.query("include_history", String.valueOf(listAccountSettingsAssignmentsOptions.includeHistory()));
+    }
+    ResponseConverter<TemplateAssignmentListResponse> responseConverter =
+      ResponseConverterUtils.getValue(new com.google.gson.reflect.TypeToken<TemplateAssignmentListResponse>() { }.getType());
+    return createServiceCall(builder.build(), responseConverter);
+  }
+
+  /**
+   * List assignments.
+   *
+   * List account settings assignments.
+   *
+   * @return a {@link ServiceCall} with a result of type {@link TemplateAssignmentListResponse}
+   */
+  public ServiceCall<TemplateAssignmentListResponse> listAccountSettingsAssignments() {
+    return listAccountSettingsAssignments(null);
+  }
+
+  /**
+   * Create assignment.
+   *
+   * Create an assigment for an account settings template.
+   *
+   * @param createAccountSettingsAssignmentOptions the {@link CreateAccountSettingsAssignmentOptions} containing the options for the call
+   * @return a {@link ServiceCall} with a result of type {@link TemplateAssignmentResponse}
+   */
+  public ServiceCall<TemplateAssignmentResponse> createAccountSettingsAssignment(CreateAccountSettingsAssignmentOptions createAccountSettingsAssignmentOptions) {
+    com.ibm.cloud.sdk.core.util.Validator.notNull(createAccountSettingsAssignmentOptions,
+      "createAccountSettingsAssignmentOptions cannot be null");
+    RequestBuilder builder = RequestBuilder.post(RequestBuilder.resolveRequestUrl(getServiceUrl(), "/v1/account_settings_assignments/"));
+    Map<String, String> sdkHeaders = SdkCommon.getSdkHeaders("iam_identity", "v1", "createAccountSettingsAssignment");
+    for (Entry<String, String> header : sdkHeaders.entrySet()) {
+      builder.header(header.getKey(), header.getValue());
+    }
+    builder.header("Accept", "application/json");
+    final JsonObject contentJson = new JsonObject();
+    contentJson.addProperty("template_id", createAccountSettingsAssignmentOptions.templateId());
+    contentJson.addProperty("template_version", createAccountSettingsAssignmentOptions.templateVersion());
+    contentJson.addProperty("target_type", createAccountSettingsAssignmentOptions.targetType());
+    contentJson.addProperty("target", createAccountSettingsAssignmentOptions.target());
+    builder.bodyJson(contentJson);
+    ResponseConverter<TemplateAssignmentResponse> responseConverter =
+      ResponseConverterUtils.getValue(new com.google.gson.reflect.TypeToken<TemplateAssignmentResponse>() { }.getType());
+    return createServiceCall(builder.build(), responseConverter);
+  }
+
+  /**
+   * Get assignment.
+   *
+   * Get an assigment for an account settings template.
+   *
+   * @param getAccountSettingsAssignmentOptions the {@link GetAccountSettingsAssignmentOptions} containing the options for the call
+   * @return a {@link ServiceCall} with a result of type {@link TemplateAssignmentResponse}
+   */
+  public ServiceCall<TemplateAssignmentResponse> getAccountSettingsAssignment(GetAccountSettingsAssignmentOptions getAccountSettingsAssignmentOptions) {
+    com.ibm.cloud.sdk.core.util.Validator.notNull(getAccountSettingsAssignmentOptions,
+      "getAccountSettingsAssignmentOptions cannot be null");
+    Map<String, String> pathParamsMap = new HashMap<String, String>();
+    pathParamsMap.put("assignment_id", getAccountSettingsAssignmentOptions.assignmentId());
+    RequestBuilder builder = RequestBuilder.get(RequestBuilder.resolveRequestUrl(getServiceUrl(), "/v1/account_settings_assignments/{assignment_id}", pathParamsMap));
+    Map<String, String> sdkHeaders = SdkCommon.getSdkHeaders("iam_identity", "v1", "getAccountSettingsAssignment");
+    for (Entry<String, String> header : sdkHeaders.entrySet()) {
+      builder.header(header.getKey(), header.getValue());
+    }
+    builder.header("Accept", "application/json");
+    if (getAccountSettingsAssignmentOptions.includeHistory() != null) {
+      builder.query("include_history", String.valueOf(getAccountSettingsAssignmentOptions.includeHistory()));
+    }
+    ResponseConverter<TemplateAssignmentResponse> responseConverter =
+      ResponseConverterUtils.getValue(new com.google.gson.reflect.TypeToken<TemplateAssignmentResponse>() { }.getType());
+    return createServiceCall(builder.build(), responseConverter);
+  }
+
+  /**
+   * Delete assignment.
+   *
+   * Delete an account settings template assignment. This removes any IAM resources created by this assignment in child
+   * accounts.
+   *
+   * @param deleteAccountSettingsAssignmentOptions the {@link DeleteAccountSettingsAssignmentOptions} containing the options for the call
+   * @return a {@link ServiceCall} with a result of type {@link ExceptionResponse}
+   */
+  public ServiceCall<ExceptionResponse> deleteAccountSettingsAssignment(DeleteAccountSettingsAssignmentOptions deleteAccountSettingsAssignmentOptions) {
+    com.ibm.cloud.sdk.core.util.Validator.notNull(deleteAccountSettingsAssignmentOptions,
+      "deleteAccountSettingsAssignmentOptions cannot be null");
+    Map<String, String> pathParamsMap = new HashMap<String, String>();
+    pathParamsMap.put("assignment_id", deleteAccountSettingsAssignmentOptions.assignmentId());
+    RequestBuilder builder = RequestBuilder.delete(RequestBuilder.resolveRequestUrl(getServiceUrl(), "/v1/account_settings_assignments/{assignment_id}", pathParamsMap));
+    Map<String, String> sdkHeaders = SdkCommon.getSdkHeaders("iam_identity", "v1", "deleteAccountSettingsAssignment");
+    for (Entry<String, String> header : sdkHeaders.entrySet()) {
+      builder.header(header.getKey(), header.getValue());
+    }
+    builder.header("Accept", "application/json");
+    ResponseConverter<ExceptionResponse> responseConverter =
+      ResponseConverterUtils.getValue(new com.google.gson.reflect.TypeToken<ExceptionResponse>() { }.getType());
+    return createServiceCall(builder.build(), responseConverter);
+  }
+
+  /**
+   * Update assignment.
+   *
+   * Update an account settings assignment. Call this method to retry failed assignments or migrate the settings in
+   * child accounts to a new version.
+   *
+   * @param updateAccountSettingsAssignmentOptions the {@link UpdateAccountSettingsAssignmentOptions} containing the options for the call
+   * @return a {@link ServiceCall} with a result of type {@link TemplateAssignmentResponse}
+   */
+  public ServiceCall<TemplateAssignmentResponse> updateAccountSettingsAssignment(UpdateAccountSettingsAssignmentOptions updateAccountSettingsAssignmentOptions) {
+    com.ibm.cloud.sdk.core.util.Validator.notNull(updateAccountSettingsAssignmentOptions,
+      "updateAccountSettingsAssignmentOptions cannot be null");
+    Map<String, String> pathParamsMap = new HashMap<String, String>();
+    pathParamsMap.put("assignment_id", updateAccountSettingsAssignmentOptions.assignmentId());
+    RequestBuilder builder = RequestBuilder.patch(RequestBuilder.resolveRequestUrl(getServiceUrl(), "/v1/account_settings_assignments/{assignment_id}", pathParamsMap));
+    Map<String, String> sdkHeaders = SdkCommon.getSdkHeaders("iam_identity", "v1", "updateAccountSettingsAssignment");
+    for (Entry<String, String> header : sdkHeaders.entrySet()) {
+      builder.header(header.getKey(), header.getValue());
+    }
+    builder.header("Accept", "application/json");
+    builder.header("If-Match", updateAccountSettingsAssignmentOptions.ifMatch());
+    final JsonObject contentJson = new JsonObject();
+    contentJson.addProperty("template_version", updateAccountSettingsAssignmentOptions.templateVersion());
+    builder.bodyJson(contentJson);
+    ResponseConverter<TemplateAssignmentResponse> responseConverter =
+      ResponseConverterUtils.getValue(new com.google.gson.reflect.TypeToken<TemplateAssignmentResponse>() { }.getType());
+    return createServiceCall(builder.build(), responseConverter);
+  }
+
+  /**
+   * List account settings templates.
+   *
+   * List account settings templates in an enterprise account.
+   *
+   * @param listAccountSettingsTemplatesOptions the {@link ListAccountSettingsTemplatesOptions} containing the options for the call
+   * @return a {@link ServiceCall} with a result of type {@link AccountSettingsTemplateList}
+   */
+  public ServiceCall<AccountSettingsTemplateList> listAccountSettingsTemplates(ListAccountSettingsTemplatesOptions listAccountSettingsTemplatesOptions) {
+    if (listAccountSettingsTemplatesOptions == null) {
+      listAccountSettingsTemplatesOptions = new ListAccountSettingsTemplatesOptions.Builder().build();
+    }
+    RequestBuilder builder = RequestBuilder.get(RequestBuilder.resolveRequestUrl(getServiceUrl(), "/v1/account_settings_templates"));
+    Map<String, String> sdkHeaders = SdkCommon.getSdkHeaders("iam_identity", "v1", "listAccountSettingsTemplates");
+    for (Entry<String, String> header : sdkHeaders.entrySet()) {
+      builder.header(header.getKey(), header.getValue());
+    }
+    builder.header("Accept", "application/json");
+    if (listAccountSettingsTemplatesOptions.accountId() != null) {
+      builder.query("account_id", String.valueOf(listAccountSettingsTemplatesOptions.accountId()));
+    }
+    if (listAccountSettingsTemplatesOptions.limit() != null) {
+      builder.query("limit", String.valueOf(listAccountSettingsTemplatesOptions.limit()));
+    }
+    if (listAccountSettingsTemplatesOptions.pagetoken() != null) {
+      builder.query("pagetoken", String.valueOf(listAccountSettingsTemplatesOptions.pagetoken()));
+    }
+    if (listAccountSettingsTemplatesOptions.sort() != null) {
+      builder.query("sort", String.valueOf(listAccountSettingsTemplatesOptions.sort()));
+    }
+    if (listAccountSettingsTemplatesOptions.order() != null) {
+      builder.query("order", String.valueOf(listAccountSettingsTemplatesOptions.order()));
+    }
+    if (listAccountSettingsTemplatesOptions.includeHistory() != null) {
+      builder.query("include_history", String.valueOf(listAccountSettingsTemplatesOptions.includeHistory()));
+    }
+    ResponseConverter<AccountSettingsTemplateList> responseConverter =
+      ResponseConverterUtils.getValue(new com.google.gson.reflect.TypeToken<AccountSettingsTemplateList>() { }.getType());
+    return createServiceCall(builder.build(), responseConverter);
+  }
+
+  /**
+   * List account settings templates.
+   *
+   * List account settings templates in an enterprise account.
+   *
+   * @return a {@link ServiceCall} with a result of type {@link AccountSettingsTemplateList}
+   */
+  public ServiceCall<AccountSettingsTemplateList> listAccountSettingsTemplates() {
+    return listAccountSettingsTemplates(null);
+  }
+
+  /**
+   * Create an account settings template.
+   *
+   * Create a new account settings template in an enterprise account.
+   *
+   * @param createAccountSettingsTemplateOptions the {@link CreateAccountSettingsTemplateOptions} containing the options for the call
+   * @return a {@link ServiceCall} with a result of type {@link AccountSettingsTemplateResponse}
+   */
+  public ServiceCall<AccountSettingsTemplateResponse> createAccountSettingsTemplate(CreateAccountSettingsTemplateOptions createAccountSettingsTemplateOptions) {
+    com.ibm.cloud.sdk.core.util.Validator.notNull(createAccountSettingsTemplateOptions,
+      "createAccountSettingsTemplateOptions cannot be null");
+    RequestBuilder builder = RequestBuilder.post(RequestBuilder.resolveRequestUrl(getServiceUrl(), "/v1/account_settings_templates"));
+    Map<String, String> sdkHeaders = SdkCommon.getSdkHeaders("iam_identity", "v1", "createAccountSettingsTemplate");
+    for (Entry<String, String> header : sdkHeaders.entrySet()) {
+      builder.header(header.getKey(), header.getValue());
+    }
+    builder.header("Accept", "application/json");
+    final JsonObject contentJson = new JsonObject();
+    if (createAccountSettingsTemplateOptions.accountId() != null) {
+      contentJson.addProperty("account_id", createAccountSettingsTemplateOptions.accountId());
+    }
+    if (createAccountSettingsTemplateOptions.name() != null) {
+      contentJson.addProperty("name", createAccountSettingsTemplateOptions.name());
+    }
+    if (createAccountSettingsTemplateOptions.description() != null) {
+      contentJson.addProperty("description", createAccountSettingsTemplateOptions.description());
+    }
+    if (createAccountSettingsTemplateOptions.accountSettings() != null) {
+      contentJson.add("account_settings", com.ibm.cloud.sdk.core.util.GsonSingleton.getGson().toJsonTree(createAccountSettingsTemplateOptions.accountSettings()));
+    }
+    builder.bodyJson(contentJson);
+    ResponseConverter<AccountSettingsTemplateResponse> responseConverter =
+      ResponseConverterUtils.getValue(new com.google.gson.reflect.TypeToken<AccountSettingsTemplateResponse>() { }.getType());
+    return createServiceCall(builder.build(), responseConverter);
+  }
+
+  /**
+   * Create an account settings template.
+   *
+   * Create a new account settings template in an enterprise account.
+   *
+   * @return a {@link ServiceCall} with a result of type {@link AccountSettingsTemplateResponse}
+   */
+  public ServiceCall<AccountSettingsTemplateResponse> createAccountSettingsTemplate() {
+    return createAccountSettingsTemplate(null);
+  }
+
+  /**
+   * Get latest version of an account settings template.
+   *
+   * Get the latest version of a specific account settings template in an enterprise account.
+   *
+   * @param getLatestAccountSettingsTemplateVersionOptions the {@link GetLatestAccountSettingsTemplateVersionOptions} containing the options for the call
+   * @return a {@link ServiceCall} with a result of type {@link AccountSettingsTemplateResponse}
+   */
+  public ServiceCall<AccountSettingsTemplateResponse> getLatestAccountSettingsTemplateVersion(GetLatestAccountSettingsTemplateVersionOptions getLatestAccountSettingsTemplateVersionOptions) {
+    com.ibm.cloud.sdk.core.util.Validator.notNull(getLatestAccountSettingsTemplateVersionOptions,
+      "getLatestAccountSettingsTemplateVersionOptions cannot be null");
+    Map<String, String> pathParamsMap = new HashMap<String, String>();
+    pathParamsMap.put("template_id", getLatestAccountSettingsTemplateVersionOptions.templateId());
+    RequestBuilder builder = RequestBuilder.get(RequestBuilder.resolveRequestUrl(getServiceUrl(), "/v1/account_settings_templates/{template_id}", pathParamsMap));
+    Map<String, String> sdkHeaders = SdkCommon.getSdkHeaders("iam_identity", "v1", "getLatestAccountSettingsTemplateVersion");
+    for (Entry<String, String> header : sdkHeaders.entrySet()) {
+      builder.header(header.getKey(), header.getValue());
+    }
+    builder.header("Accept", "application/json");
+    if (getLatestAccountSettingsTemplateVersionOptions.includeHistory() != null) {
+      builder.query("include_history", String.valueOf(getLatestAccountSettingsTemplateVersionOptions.includeHistory()));
+    }
+    ResponseConverter<AccountSettingsTemplateResponse> responseConverter =
+      ResponseConverterUtils.getValue(new com.google.gson.reflect.TypeToken<AccountSettingsTemplateResponse>() { }.getType());
+    return createServiceCall(builder.build(), responseConverter);
+  }
+
+  /**
+   * Delete all versions of an account settings template.
+   *
+   * Delete all versions of an account settings template in an enterprise account. If any version is assigned to child
+   * accounts, you must first delete the assignment.
+   *
+   * @param deleteAllVersionsOfAccountSettingsTemplateOptions the {@link DeleteAllVersionsOfAccountSettingsTemplateOptions} containing the options for the call
+   * @return a {@link ServiceCall} with a void result
+   */
+  public ServiceCall<Void> deleteAllVersionsOfAccountSettingsTemplate(DeleteAllVersionsOfAccountSettingsTemplateOptions deleteAllVersionsOfAccountSettingsTemplateOptions) {
+    com.ibm.cloud.sdk.core.util.Validator.notNull(deleteAllVersionsOfAccountSettingsTemplateOptions,
+      "deleteAllVersionsOfAccountSettingsTemplateOptions cannot be null");
+    Map<String, String> pathParamsMap = new HashMap<String, String>();
+    pathParamsMap.put("template_id", deleteAllVersionsOfAccountSettingsTemplateOptions.templateId());
+    RequestBuilder builder = RequestBuilder.delete(RequestBuilder.resolveRequestUrl(getServiceUrl(), "/v1/account_settings_templates/{template_id}", pathParamsMap));
+    Map<String, String> sdkHeaders = SdkCommon.getSdkHeaders("iam_identity", "v1", "deleteAllVersionsOfAccountSettingsTemplate");
+    for (Entry<String, String> header : sdkHeaders.entrySet()) {
+      builder.header(header.getKey(), header.getValue());
+    }
+    ResponseConverter<Void> responseConverter = ResponseConverterUtils.getVoid();
+    return createServiceCall(builder.build(), responseConverter);
+  }
+
+  /**
+   * List account settings template versions.
+   *
+   * List the versions of a specific account settings template in an enterprise account.
+   *
+   * @param listVersionsOfAccountSettingsTemplateOptions the {@link ListVersionsOfAccountSettingsTemplateOptions} containing the options for the call
+   * @return a {@link ServiceCall} with a result of type {@link AccountSettingsTemplateList}
+   */
+  public ServiceCall<AccountSettingsTemplateList> listVersionsOfAccountSettingsTemplate(ListVersionsOfAccountSettingsTemplateOptions listVersionsOfAccountSettingsTemplateOptions) {
+    com.ibm.cloud.sdk.core.util.Validator.notNull(listVersionsOfAccountSettingsTemplateOptions,
+      "listVersionsOfAccountSettingsTemplateOptions cannot be null");
+    Map<String, String> pathParamsMap = new HashMap<String, String>();
+    pathParamsMap.put("template_id", listVersionsOfAccountSettingsTemplateOptions.templateId());
+    RequestBuilder builder = RequestBuilder.get(RequestBuilder.resolveRequestUrl(getServiceUrl(), "/v1/account_settings_templates/{template_id}/versions", pathParamsMap));
+    Map<String, String> sdkHeaders = SdkCommon.getSdkHeaders("iam_identity", "v1", "listVersionsOfAccountSettingsTemplate");
+    for (Entry<String, String> header : sdkHeaders.entrySet()) {
+      builder.header(header.getKey(), header.getValue());
+    }
+    builder.header("Accept", "application/json");
+    if (listVersionsOfAccountSettingsTemplateOptions.limit() != null) {
+      builder.query("limit", String.valueOf(listVersionsOfAccountSettingsTemplateOptions.limit()));
+    }
+    if (listVersionsOfAccountSettingsTemplateOptions.pagetoken() != null) {
+      builder.query("pagetoken", String.valueOf(listVersionsOfAccountSettingsTemplateOptions.pagetoken()));
+    }
+    if (listVersionsOfAccountSettingsTemplateOptions.sort() != null) {
+      builder.query("sort", String.valueOf(listVersionsOfAccountSettingsTemplateOptions.sort()));
+    }
+    if (listVersionsOfAccountSettingsTemplateOptions.order() != null) {
+      builder.query("order", String.valueOf(listVersionsOfAccountSettingsTemplateOptions.order()));
+    }
+    if (listVersionsOfAccountSettingsTemplateOptions.includeHistory() != null) {
+      builder.query("include_history", String.valueOf(listVersionsOfAccountSettingsTemplateOptions.includeHistory()));
+    }
+    ResponseConverter<AccountSettingsTemplateList> responseConverter =
+      ResponseConverterUtils.getValue(new com.google.gson.reflect.TypeToken<AccountSettingsTemplateList>() { }.getType());
+    return createServiceCall(builder.build(), responseConverter);
+  }
+
+  /**
+   * Create a new version of an account settings template.
+   *
+   * Create a new version of an account settings template in an Enterprise Account.
+   *
+   * @param createAccountSettingsTemplateVersionOptions the {@link CreateAccountSettingsTemplateVersionOptions} containing the options for the call
+   * @return a {@link ServiceCall} with a result of type {@link AccountSettingsTemplateResponse}
+   */
+  public ServiceCall<AccountSettingsTemplateResponse> createAccountSettingsTemplateVersion(CreateAccountSettingsTemplateVersionOptions createAccountSettingsTemplateVersionOptions) {
+    com.ibm.cloud.sdk.core.util.Validator.notNull(createAccountSettingsTemplateVersionOptions,
+      "createAccountSettingsTemplateVersionOptions cannot be null");
+    Map<String, String> pathParamsMap = new HashMap<String, String>();
+    pathParamsMap.put("template_id", createAccountSettingsTemplateVersionOptions.templateId());
+    RequestBuilder builder = RequestBuilder.post(RequestBuilder.resolveRequestUrl(getServiceUrl(), "/v1/account_settings_templates/{template_id}/versions", pathParamsMap));
+    Map<String, String> sdkHeaders = SdkCommon.getSdkHeaders("iam_identity", "v1", "createAccountSettingsTemplateVersion");
+    for (Entry<String, String> header : sdkHeaders.entrySet()) {
+      builder.header(header.getKey(), header.getValue());
+    }
+    builder.header("Accept", "application/json");
+    final JsonObject contentJson = new JsonObject();
+    if (createAccountSettingsTemplateVersionOptions.accountId() != null) {
+      contentJson.addProperty("account_id", createAccountSettingsTemplateVersionOptions.accountId());
+    }
+    if (createAccountSettingsTemplateVersionOptions.name() != null) {
+      contentJson.addProperty("name", createAccountSettingsTemplateVersionOptions.name());
+    }
+    if (createAccountSettingsTemplateVersionOptions.description() != null) {
+      contentJson.addProperty("description", createAccountSettingsTemplateVersionOptions.description());
+    }
+    if (createAccountSettingsTemplateVersionOptions.accountSettings() != null) {
+      contentJson.add("account_settings", com.ibm.cloud.sdk.core.util.GsonSingleton.getGson().toJsonTree(createAccountSettingsTemplateVersionOptions.accountSettings()));
+    }
+    builder.bodyJson(contentJson);
+    ResponseConverter<AccountSettingsTemplateResponse> responseConverter =
+      ResponseConverterUtils.getValue(new com.google.gson.reflect.TypeToken<AccountSettingsTemplateResponse>() { }.getType());
+    return createServiceCall(builder.build(), responseConverter);
+  }
+
+  /**
+   * Get version of an account settings template.
+   *
+   * Get a specific version of an account settings template in an Enterprise Account.
+   *
+   * @param getAccountSettingsTemplateVersionOptions the {@link GetAccountSettingsTemplateVersionOptions} containing the options for the call
+   * @return a {@link ServiceCall} with a result of type {@link AccountSettingsTemplateResponse}
+   */
+  public ServiceCall<AccountSettingsTemplateResponse> getAccountSettingsTemplateVersion(GetAccountSettingsTemplateVersionOptions getAccountSettingsTemplateVersionOptions) {
+    com.ibm.cloud.sdk.core.util.Validator.notNull(getAccountSettingsTemplateVersionOptions,
+      "getAccountSettingsTemplateVersionOptions cannot be null");
+    Map<String, String> pathParamsMap = new HashMap<String, String>();
+    pathParamsMap.put("template_id", getAccountSettingsTemplateVersionOptions.templateId());
+    pathParamsMap.put("version", getAccountSettingsTemplateVersionOptions.version());
+    RequestBuilder builder = RequestBuilder.get(RequestBuilder.resolveRequestUrl(getServiceUrl(), "/v1/account_settings_templates/{template_id}/versions/{version}", pathParamsMap));
+    Map<String, String> sdkHeaders = SdkCommon.getSdkHeaders("iam_identity", "v1", "getAccountSettingsTemplateVersion");
+    for (Entry<String, String> header : sdkHeaders.entrySet()) {
+      builder.header(header.getKey(), header.getValue());
+    }
+    builder.header("Accept", "application/json");
+    if (getAccountSettingsTemplateVersionOptions.includeHistory() != null) {
+      builder.query("include_history", String.valueOf(getAccountSettingsTemplateVersionOptions.includeHistory()));
+    }
+    ResponseConverter<AccountSettingsTemplateResponse> responseConverter =
+      ResponseConverterUtils.getValue(new com.google.gson.reflect.TypeToken<AccountSettingsTemplateResponse>() { }.getType());
+    return createServiceCall(builder.build(), responseConverter);
+  }
+
+  /**
+   * Update version of an account settings template.
+   *
+   * Update a specific version of an account settings template in an Enterprise Account.
+   *
+   * @param updateAccountSettingsTemplateVersionOptions the {@link UpdateAccountSettingsTemplateVersionOptions} containing the options for the call
+   * @return a {@link ServiceCall} with a result of type {@link AccountSettingsTemplateResponse}
+   */
+  public ServiceCall<AccountSettingsTemplateResponse> updateAccountSettingsTemplateVersion(UpdateAccountSettingsTemplateVersionOptions updateAccountSettingsTemplateVersionOptions) {
+    com.ibm.cloud.sdk.core.util.Validator.notNull(updateAccountSettingsTemplateVersionOptions,
+      "updateAccountSettingsTemplateVersionOptions cannot be null");
+    Map<String, String> pathParamsMap = new HashMap<String, String>();
+    pathParamsMap.put("template_id", updateAccountSettingsTemplateVersionOptions.templateId());
+    pathParamsMap.put("version", updateAccountSettingsTemplateVersionOptions.version());
+    RequestBuilder builder = RequestBuilder.put(RequestBuilder.resolveRequestUrl(getServiceUrl(), "/v1/account_settings_templates/{template_id}/versions/{version}", pathParamsMap));
+    Map<String, String> sdkHeaders = SdkCommon.getSdkHeaders("iam_identity", "v1", "updateAccountSettingsTemplateVersion");
+    for (Entry<String, String> header : sdkHeaders.entrySet()) {
+      builder.header(header.getKey(), header.getValue());
+    }
+    builder.header("Accept", "application/json");
+    builder.header("If-Match", updateAccountSettingsTemplateVersionOptions.ifMatch());
+    final JsonObject contentJson = new JsonObject();
+    if (updateAccountSettingsTemplateVersionOptions.accountId() != null) {
+      contentJson.addProperty("account_id", updateAccountSettingsTemplateVersionOptions.accountId());
+    }
+    if (updateAccountSettingsTemplateVersionOptions.name() != null) {
+      contentJson.addProperty("name", updateAccountSettingsTemplateVersionOptions.name());
+    }
+    if (updateAccountSettingsTemplateVersionOptions.description() != null) {
+      contentJson.addProperty("description", updateAccountSettingsTemplateVersionOptions.description());
+    }
+    if (updateAccountSettingsTemplateVersionOptions.accountSettings() != null) {
+      contentJson.add("account_settings", com.ibm.cloud.sdk.core.util.GsonSingleton.getGson().toJsonTree(updateAccountSettingsTemplateVersionOptions.accountSettings()));
+    }
+    builder.bodyJson(contentJson);
+    ResponseConverter<AccountSettingsTemplateResponse> responseConverter =
+      ResponseConverterUtils.getValue(new com.google.gson.reflect.TypeToken<AccountSettingsTemplateResponse>() { }.getType());
+    return createServiceCall(builder.build(), responseConverter);
+  }
+
+  /**
+   * Delete version of an account settings template.
+   *
+   * Delete a specific version of an account settings template in an Enterprise Account.
+   *
+   * @param deleteAccountSettingsTemplateVersionOptions the {@link DeleteAccountSettingsTemplateVersionOptions} containing the options for the call
+   * @return a {@link ServiceCall} with a void result
+   */
+  public ServiceCall<Void> deleteAccountSettingsTemplateVersion(DeleteAccountSettingsTemplateVersionOptions deleteAccountSettingsTemplateVersionOptions) {
+    com.ibm.cloud.sdk.core.util.Validator.notNull(deleteAccountSettingsTemplateVersionOptions,
+      "deleteAccountSettingsTemplateVersionOptions cannot be null");
+    Map<String, String> pathParamsMap = new HashMap<String, String>();
+    pathParamsMap.put("template_id", deleteAccountSettingsTemplateVersionOptions.templateId());
+    pathParamsMap.put("version", deleteAccountSettingsTemplateVersionOptions.version());
+    RequestBuilder builder = RequestBuilder.delete(RequestBuilder.resolveRequestUrl(getServiceUrl(), "/v1/account_settings_templates/{template_id}/versions/{version}", pathParamsMap));
+    Map<String, String> sdkHeaders = SdkCommon.getSdkHeaders("iam_identity", "v1", "deleteAccountSettingsTemplateVersion");
+    for (Entry<String, String> header : sdkHeaders.entrySet()) {
+      builder.header(header.getKey(), header.getValue());
+    }
+    ResponseConverter<Void> responseConverter = ResponseConverterUtils.getVoid();
+    return createServiceCall(builder.build(), responseConverter);
+  }
+
+  /**
+   * Commit a template version.
+   *
+   * Commit a specific version of an account settings template in an Enterprise Account. A Template must be committed
+   * before being assigned, and once committed, can no longer be modified.
+   *
+   * @param commitAccountSettingsTemplateOptions the {@link CommitAccountSettingsTemplateOptions} containing the options for the call
+   * @return a {@link ServiceCall} with a void result
+   */
+  public ServiceCall<Void> commitAccountSettingsTemplate(CommitAccountSettingsTemplateOptions commitAccountSettingsTemplateOptions) {
+    com.ibm.cloud.sdk.core.util.Validator.notNull(commitAccountSettingsTemplateOptions,
+      "commitAccountSettingsTemplateOptions cannot be null");
+    Map<String, String> pathParamsMap = new HashMap<String, String>();
+    pathParamsMap.put("template_id", commitAccountSettingsTemplateOptions.templateId());
+    pathParamsMap.put("version", commitAccountSettingsTemplateOptions.version());
+    RequestBuilder builder = RequestBuilder.post(RequestBuilder.resolveRequestUrl(getServiceUrl(), "/v1/account_settings_templates/{template_id}/versions/{version}/commit", pathParamsMap));
+    Map<String, String> sdkHeaders = SdkCommon.getSdkHeaders("iam_identity", "v1", "commitAccountSettingsTemplate");
+    for (Entry<String, String> header : sdkHeaders.entrySet()) {
+      builder.header(header.getKey(), header.getValue());
+    }
+    ResponseConverter<Void> responseConverter = ResponseConverterUtils.getVoid();
+    return createServiceCall(builder.build(), responseConverter);
+  }
+
+  /**
    * Trigger activity report for the account.
    *
    * Trigger activity report for the account by specifying the account ID. It can take a few minutes to generate the
@@ -1435,7 +1983,7 @@ public class IamIdentity extends BaseService {
   }
 
   /**
-   * Get activity report for the account.
+   * Get activity report across on account scope.
    *
    * Get activity report for the account by specifying the account ID and the reference that is generated by triggering
    * the report. Reports older than a day are deleted when generating a new report.
@@ -1457,6 +2005,529 @@ public class IamIdentity extends BaseService {
     builder.header("Accept", "application/json");
     ResponseConverter<Report> responseConverter =
       ResponseConverterUtils.getValue(new com.google.gson.reflect.TypeToken<Report>() { }.getType());
+    return createServiceCall(builder.build(), responseConverter);
+  }
+
+  /**
+   * List assignments.
+   *
+   * List trusted profile template assignments.
+   *
+   * @param listTrustedProfileAssignmentsOptions the {@link ListTrustedProfileAssignmentsOptions} containing the options for the call
+   * @return a {@link ServiceCall} with a result of type {@link TemplateAssignmentListResponse}
+   */
+  public ServiceCall<TemplateAssignmentListResponse> listTrustedProfileAssignments(ListTrustedProfileAssignmentsOptions listTrustedProfileAssignmentsOptions) {
+    if (listTrustedProfileAssignmentsOptions == null) {
+      listTrustedProfileAssignmentsOptions = new ListTrustedProfileAssignmentsOptions.Builder().build();
+    }
+    RequestBuilder builder = RequestBuilder.get(RequestBuilder.resolveRequestUrl(getServiceUrl(), "/v1/profile_assignments/"));
+    Map<String, String> sdkHeaders = SdkCommon.getSdkHeaders("iam_identity", "v1", "listTrustedProfileAssignments");
+    for (Entry<String, String> header : sdkHeaders.entrySet()) {
+      builder.header(header.getKey(), header.getValue());
+    }
+    builder.header("Accept", "application/json");
+    if (listTrustedProfileAssignmentsOptions.accountId() != null) {
+      builder.query("account_id", String.valueOf(listTrustedProfileAssignmentsOptions.accountId()));
+    }
+    if (listTrustedProfileAssignmentsOptions.templateId() != null) {
+      builder.query("template_id", String.valueOf(listTrustedProfileAssignmentsOptions.templateId()));
+    }
+    if (listTrustedProfileAssignmentsOptions.templateVersion() != null) {
+      builder.query("template_version", String.valueOf(listTrustedProfileAssignmentsOptions.templateVersion()));
+    }
+    if (listTrustedProfileAssignmentsOptions.target() != null) {
+      builder.query("target", String.valueOf(listTrustedProfileAssignmentsOptions.target()));
+    }
+    if (listTrustedProfileAssignmentsOptions.targetType() != null) {
+      builder.query("target_type", String.valueOf(listTrustedProfileAssignmentsOptions.targetType()));
+    }
+    if (listTrustedProfileAssignmentsOptions.limit() != null) {
+      builder.query("limit", String.valueOf(listTrustedProfileAssignmentsOptions.limit()));
+    }
+    if (listTrustedProfileAssignmentsOptions.pagetoken() != null) {
+      builder.query("pagetoken", String.valueOf(listTrustedProfileAssignmentsOptions.pagetoken()));
+    }
+    if (listTrustedProfileAssignmentsOptions.sort() != null) {
+      builder.query("sort", String.valueOf(listTrustedProfileAssignmentsOptions.sort()));
+    }
+    if (listTrustedProfileAssignmentsOptions.order() != null) {
+      builder.query("order", String.valueOf(listTrustedProfileAssignmentsOptions.order()));
+    }
+    if (listTrustedProfileAssignmentsOptions.includeHistory() != null) {
+      builder.query("include_history", String.valueOf(listTrustedProfileAssignmentsOptions.includeHistory()));
+    }
+    ResponseConverter<TemplateAssignmentListResponse> responseConverter =
+      ResponseConverterUtils.getValue(new com.google.gson.reflect.TypeToken<TemplateAssignmentListResponse>() { }.getType());
+    return createServiceCall(builder.build(), responseConverter);
+  }
+
+  /**
+   * List assignments.
+   *
+   * List trusted profile template assignments.
+   *
+   * @return a {@link ServiceCall} with a result of type {@link TemplateAssignmentListResponse}
+   */
+  public ServiceCall<TemplateAssignmentListResponse> listTrustedProfileAssignments() {
+    return listTrustedProfileAssignments(null);
+  }
+
+  /**
+   * Create assignment.
+   *
+   * Create an assigment for a trusted profile template.
+   *
+   * @param createTrustedProfileAssignmentOptions the {@link CreateTrustedProfileAssignmentOptions} containing the options for the call
+   * @return a {@link ServiceCall} with a result of type {@link TemplateAssignmentResponse}
+   */
+  public ServiceCall<TemplateAssignmentResponse> createTrustedProfileAssignment(CreateTrustedProfileAssignmentOptions createTrustedProfileAssignmentOptions) {
+    com.ibm.cloud.sdk.core.util.Validator.notNull(createTrustedProfileAssignmentOptions,
+      "createTrustedProfileAssignmentOptions cannot be null");
+    RequestBuilder builder = RequestBuilder.post(RequestBuilder.resolveRequestUrl(getServiceUrl(), "/v1/profile_assignments/"));
+    Map<String, String> sdkHeaders = SdkCommon.getSdkHeaders("iam_identity", "v1", "createTrustedProfileAssignment");
+    for (Entry<String, String> header : sdkHeaders.entrySet()) {
+      builder.header(header.getKey(), header.getValue());
+    }
+    builder.header("Accept", "application/json");
+    final JsonObject contentJson = new JsonObject();
+    contentJson.addProperty("template_id", createTrustedProfileAssignmentOptions.templateId());
+    contentJson.addProperty("template_version", createTrustedProfileAssignmentOptions.templateVersion());
+    contentJson.addProperty("target_type", createTrustedProfileAssignmentOptions.targetType());
+    contentJson.addProperty("target", createTrustedProfileAssignmentOptions.target());
+    builder.bodyJson(contentJson);
+    ResponseConverter<TemplateAssignmentResponse> responseConverter =
+      ResponseConverterUtils.getValue(new com.google.gson.reflect.TypeToken<TemplateAssignmentResponse>() { }.getType());
+    return createServiceCall(builder.build(), responseConverter);
+  }
+
+  /**
+   * Get assignment.
+   *
+   * Get an assigment for a trusted profile template.
+   *
+   * @param getTrustedProfileAssignmentOptions the {@link GetTrustedProfileAssignmentOptions} containing the options for the call
+   * @return a {@link ServiceCall} with a result of type {@link TemplateAssignmentResponse}
+   */
+  public ServiceCall<TemplateAssignmentResponse> getTrustedProfileAssignment(GetTrustedProfileAssignmentOptions getTrustedProfileAssignmentOptions) {
+    com.ibm.cloud.sdk.core.util.Validator.notNull(getTrustedProfileAssignmentOptions,
+      "getTrustedProfileAssignmentOptions cannot be null");
+    Map<String, String> pathParamsMap = new HashMap<String, String>();
+    pathParamsMap.put("assignment_id", getTrustedProfileAssignmentOptions.assignmentId());
+    RequestBuilder builder = RequestBuilder.get(RequestBuilder.resolveRequestUrl(getServiceUrl(), "/v1/profile_assignments/{assignment_id}", pathParamsMap));
+    Map<String, String> sdkHeaders = SdkCommon.getSdkHeaders("iam_identity", "v1", "getTrustedProfileAssignment");
+    for (Entry<String, String> header : sdkHeaders.entrySet()) {
+      builder.header(header.getKey(), header.getValue());
+    }
+    builder.header("Accept", "application/json");
+    if (getTrustedProfileAssignmentOptions.includeHistory() != null) {
+      builder.query("include_history", String.valueOf(getTrustedProfileAssignmentOptions.includeHistory()));
+    }
+    ResponseConverter<TemplateAssignmentResponse> responseConverter =
+      ResponseConverterUtils.getValue(new com.google.gson.reflect.TypeToken<TemplateAssignmentResponse>() { }.getType());
+    return createServiceCall(builder.build(), responseConverter);
+  }
+
+  /**
+   * Delete assignment.
+   *
+   * Delete a trusted profile assignment. This removes any IAM resources created by this assignment in child accounts.
+   *
+   * @param deleteTrustedProfileAssignmentOptions the {@link DeleteTrustedProfileAssignmentOptions} containing the options for the call
+   * @return a {@link ServiceCall} with a result of type {@link ExceptionResponse}
+   */
+  public ServiceCall<ExceptionResponse> deleteTrustedProfileAssignment(DeleteTrustedProfileAssignmentOptions deleteTrustedProfileAssignmentOptions) {
+    com.ibm.cloud.sdk.core.util.Validator.notNull(deleteTrustedProfileAssignmentOptions,
+      "deleteTrustedProfileAssignmentOptions cannot be null");
+    Map<String, String> pathParamsMap = new HashMap<String, String>();
+    pathParamsMap.put("assignment_id", deleteTrustedProfileAssignmentOptions.assignmentId());
+    RequestBuilder builder = RequestBuilder.delete(RequestBuilder.resolveRequestUrl(getServiceUrl(), "/v1/profile_assignments/{assignment_id}", pathParamsMap));
+    Map<String, String> sdkHeaders = SdkCommon.getSdkHeaders("iam_identity", "v1", "deleteTrustedProfileAssignment");
+    for (Entry<String, String> header : sdkHeaders.entrySet()) {
+      builder.header(header.getKey(), header.getValue());
+    }
+    builder.header("Accept", "application/json");
+    ResponseConverter<ExceptionResponse> responseConverter =
+      ResponseConverterUtils.getValue(new com.google.gson.reflect.TypeToken<ExceptionResponse>() { }.getType());
+    return createServiceCall(builder.build(), responseConverter);
+  }
+
+  /**
+   * Update assignment.
+   *
+   * Update a trusted profile assignment. Call this method to retry failed assignments or migrate the trusted profile in
+   * child accounts to a new version.
+   *
+   * @param updateTrustedProfileAssignmentOptions the {@link UpdateTrustedProfileAssignmentOptions} containing the options for the call
+   * @return a {@link ServiceCall} with a result of type {@link TemplateAssignmentResponse}
+   */
+  public ServiceCall<TemplateAssignmentResponse> updateTrustedProfileAssignment(UpdateTrustedProfileAssignmentOptions updateTrustedProfileAssignmentOptions) {
+    com.ibm.cloud.sdk.core.util.Validator.notNull(updateTrustedProfileAssignmentOptions,
+      "updateTrustedProfileAssignmentOptions cannot be null");
+    Map<String, String> pathParamsMap = new HashMap<String, String>();
+    pathParamsMap.put("assignment_id", updateTrustedProfileAssignmentOptions.assignmentId());
+    RequestBuilder builder = RequestBuilder.patch(RequestBuilder.resolveRequestUrl(getServiceUrl(), "/v1/profile_assignments/{assignment_id}", pathParamsMap));
+    Map<String, String> sdkHeaders = SdkCommon.getSdkHeaders("iam_identity", "v1", "updateTrustedProfileAssignment");
+    for (Entry<String, String> header : sdkHeaders.entrySet()) {
+      builder.header(header.getKey(), header.getValue());
+    }
+    builder.header("Accept", "application/json");
+    builder.header("If-Match", updateTrustedProfileAssignmentOptions.ifMatch());
+    final JsonObject contentJson = new JsonObject();
+    contentJson.addProperty("template_version", updateTrustedProfileAssignmentOptions.templateVersion());
+    builder.bodyJson(contentJson);
+    ResponseConverter<TemplateAssignmentResponse> responseConverter =
+      ResponseConverterUtils.getValue(new com.google.gson.reflect.TypeToken<TemplateAssignmentResponse>() { }.getType());
+    return createServiceCall(builder.build(), responseConverter);
+  }
+
+  /**
+   * List trusted profile templates.
+   *
+   * List the trusted profile templates in an enterprise account.
+   *
+   * @param listProfileTemplatesOptions the {@link ListProfileTemplatesOptions} containing the options for the call
+   * @return a {@link ServiceCall} with a result of type {@link TrustedProfileTemplateList}
+   */
+  public ServiceCall<TrustedProfileTemplateList> listProfileTemplates(ListProfileTemplatesOptions listProfileTemplatesOptions) {
+    if (listProfileTemplatesOptions == null) {
+      listProfileTemplatesOptions = new ListProfileTemplatesOptions.Builder().build();
+    }
+    RequestBuilder builder = RequestBuilder.get(RequestBuilder.resolveRequestUrl(getServiceUrl(), "/v1/profile_templates"));
+    Map<String, String> sdkHeaders = SdkCommon.getSdkHeaders("iam_identity", "v1", "listProfileTemplates");
+    for (Entry<String, String> header : sdkHeaders.entrySet()) {
+      builder.header(header.getKey(), header.getValue());
+    }
+    builder.header("Accept", "application/json");
+    if (listProfileTemplatesOptions.accountId() != null) {
+      builder.query("account_id", String.valueOf(listProfileTemplatesOptions.accountId()));
+    }
+    if (listProfileTemplatesOptions.limit() != null) {
+      builder.query("limit", String.valueOf(listProfileTemplatesOptions.limit()));
+    }
+    if (listProfileTemplatesOptions.pagetoken() != null) {
+      builder.query("pagetoken", String.valueOf(listProfileTemplatesOptions.pagetoken()));
+    }
+    if (listProfileTemplatesOptions.sort() != null) {
+      builder.query("sort", String.valueOf(listProfileTemplatesOptions.sort()));
+    }
+    if (listProfileTemplatesOptions.order() != null) {
+      builder.query("order", String.valueOf(listProfileTemplatesOptions.order()));
+    }
+    if (listProfileTemplatesOptions.includeHistory() != null) {
+      builder.query("include_history", String.valueOf(listProfileTemplatesOptions.includeHistory()));
+    }
+    ResponseConverter<TrustedProfileTemplateList> responseConverter =
+      ResponseConverterUtils.getValue(new com.google.gson.reflect.TypeToken<TrustedProfileTemplateList>() { }.getType());
+    return createServiceCall(builder.build(), responseConverter);
+  }
+
+  /**
+   * List trusted profile templates.
+   *
+   * List the trusted profile templates in an enterprise account.
+   *
+   * @return a {@link ServiceCall} with a result of type {@link TrustedProfileTemplateList}
+   */
+  public ServiceCall<TrustedProfileTemplateList> listProfileTemplates() {
+    return listProfileTemplates(null);
+  }
+
+  /**
+   * Create a trusted profile template.
+   *
+   * Create a new trusted profile template in an enterprise account.
+   *
+   * @param createProfileTemplateOptions the {@link CreateProfileTemplateOptions} containing the options for the call
+   * @return a {@link ServiceCall} with a result of type {@link TrustedProfileTemplateResponse}
+   */
+  public ServiceCall<TrustedProfileTemplateResponse> createProfileTemplate(CreateProfileTemplateOptions createProfileTemplateOptions) {
+    com.ibm.cloud.sdk.core.util.Validator.notNull(createProfileTemplateOptions,
+      "createProfileTemplateOptions cannot be null");
+    RequestBuilder builder = RequestBuilder.post(RequestBuilder.resolveRequestUrl(getServiceUrl(), "/v1/profile_templates"));
+    Map<String, String> sdkHeaders = SdkCommon.getSdkHeaders("iam_identity", "v1", "createProfileTemplate");
+    for (Entry<String, String> header : sdkHeaders.entrySet()) {
+      builder.header(header.getKey(), header.getValue());
+    }
+    builder.header("Accept", "application/json");
+    final JsonObject contentJson = new JsonObject();
+    if (createProfileTemplateOptions.accountId() != null) {
+      contentJson.addProperty("account_id", createProfileTemplateOptions.accountId());
+    }
+    if (createProfileTemplateOptions.name() != null) {
+      contentJson.addProperty("name", createProfileTemplateOptions.name());
+    }
+    if (createProfileTemplateOptions.description() != null) {
+      contentJson.addProperty("description", createProfileTemplateOptions.description());
+    }
+    if (createProfileTemplateOptions.profile() != null) {
+      contentJson.add("profile", com.ibm.cloud.sdk.core.util.GsonSingleton.getGson().toJsonTree(createProfileTemplateOptions.profile()));
+    }
+    if (createProfileTemplateOptions.policyTemplateReferences() != null) {
+      contentJson.add("policy_template_references", com.ibm.cloud.sdk.core.util.GsonSingleton.getGson().toJsonTree(createProfileTemplateOptions.policyTemplateReferences()));
+    }
+    builder.bodyJson(contentJson);
+    ResponseConverter<TrustedProfileTemplateResponse> responseConverter =
+      ResponseConverterUtils.getValue(new com.google.gson.reflect.TypeToken<TrustedProfileTemplateResponse>() { }.getType());
+    return createServiceCall(builder.build(), responseConverter);
+  }
+
+  /**
+   * Create a trusted profile template.
+   *
+   * Create a new trusted profile template in an enterprise account.
+   *
+   * @return a {@link ServiceCall} with a result of type {@link TrustedProfileTemplateResponse}
+   */
+  public ServiceCall<TrustedProfileTemplateResponse> createProfileTemplate() {
+    return createProfileTemplate(null);
+  }
+
+  /**
+   * Get latest version of a trusted profile template.
+   *
+   * Get the latest version of a trusted profile template in an enterprise account.
+   *
+   * @param getLatestProfileTemplateVersionOptions the {@link GetLatestProfileTemplateVersionOptions} containing the options for the call
+   * @return a {@link ServiceCall} with a result of type {@link TrustedProfileTemplateResponse}
+   */
+  public ServiceCall<TrustedProfileTemplateResponse> getLatestProfileTemplateVersion(GetLatestProfileTemplateVersionOptions getLatestProfileTemplateVersionOptions) {
+    com.ibm.cloud.sdk.core.util.Validator.notNull(getLatestProfileTemplateVersionOptions,
+      "getLatestProfileTemplateVersionOptions cannot be null");
+    Map<String, String> pathParamsMap = new HashMap<String, String>();
+    pathParamsMap.put("template_id", getLatestProfileTemplateVersionOptions.templateId());
+    RequestBuilder builder = RequestBuilder.get(RequestBuilder.resolveRequestUrl(getServiceUrl(), "/v1/profile_templates/{template_id}", pathParamsMap));
+    Map<String, String> sdkHeaders = SdkCommon.getSdkHeaders("iam_identity", "v1", "getLatestProfileTemplateVersion");
+    for (Entry<String, String> header : sdkHeaders.entrySet()) {
+      builder.header(header.getKey(), header.getValue());
+    }
+    builder.header("Accept", "application/json");
+    if (getLatestProfileTemplateVersionOptions.includeHistory() != null) {
+      builder.query("include_history", String.valueOf(getLatestProfileTemplateVersionOptions.includeHistory()));
+    }
+    ResponseConverter<TrustedProfileTemplateResponse> responseConverter =
+      ResponseConverterUtils.getValue(new com.google.gson.reflect.TypeToken<TrustedProfileTemplateResponse>() { }.getType());
+    return createServiceCall(builder.build(), responseConverter);
+  }
+
+  /**
+   * Delete all versions of a trusted profile template.
+   *
+   * Delete all versions of a trusted profile template in an enterprise account. If any version is assigned to child
+   * accounts, you must first delete the assignment.
+   *
+   * @param deleteAllVersionsOfProfileTemplateOptions the {@link DeleteAllVersionsOfProfileTemplateOptions} containing the options for the call
+   * @return a {@link ServiceCall} with a void result
+   */
+  public ServiceCall<Void> deleteAllVersionsOfProfileTemplate(DeleteAllVersionsOfProfileTemplateOptions deleteAllVersionsOfProfileTemplateOptions) {
+    com.ibm.cloud.sdk.core.util.Validator.notNull(deleteAllVersionsOfProfileTemplateOptions,
+      "deleteAllVersionsOfProfileTemplateOptions cannot be null");
+    Map<String, String> pathParamsMap = new HashMap<String, String>();
+    pathParamsMap.put("template_id", deleteAllVersionsOfProfileTemplateOptions.templateId());
+    RequestBuilder builder = RequestBuilder.delete(RequestBuilder.resolveRequestUrl(getServiceUrl(), "/v1/profile_templates/{template_id}", pathParamsMap));
+    Map<String, String> sdkHeaders = SdkCommon.getSdkHeaders("iam_identity", "v1", "deleteAllVersionsOfProfileTemplate");
+    for (Entry<String, String> header : sdkHeaders.entrySet()) {
+      builder.header(header.getKey(), header.getValue());
+    }
+    ResponseConverter<Void> responseConverter = ResponseConverterUtils.getVoid();
+    return createServiceCall(builder.build(), responseConverter);
+  }
+
+  /**
+   * List trusted profile template versions.
+   *
+   * List the versions of a trusted profile template in an enterprise account.
+   *
+   * @param listVersionsOfProfileTemplateOptions the {@link ListVersionsOfProfileTemplateOptions} containing the options for the call
+   * @return a {@link ServiceCall} with a result of type {@link TrustedProfileTemplateList}
+   */
+  public ServiceCall<TrustedProfileTemplateList> listVersionsOfProfileTemplate(ListVersionsOfProfileTemplateOptions listVersionsOfProfileTemplateOptions) {
+    com.ibm.cloud.sdk.core.util.Validator.notNull(listVersionsOfProfileTemplateOptions,
+      "listVersionsOfProfileTemplateOptions cannot be null");
+    Map<String, String> pathParamsMap = new HashMap<String, String>();
+    pathParamsMap.put("template_id", listVersionsOfProfileTemplateOptions.templateId());
+    RequestBuilder builder = RequestBuilder.get(RequestBuilder.resolveRequestUrl(getServiceUrl(), "/v1/profile_templates/{template_id}/versions", pathParamsMap));
+    Map<String, String> sdkHeaders = SdkCommon.getSdkHeaders("iam_identity", "v1", "listVersionsOfProfileTemplate");
+    for (Entry<String, String> header : sdkHeaders.entrySet()) {
+      builder.header(header.getKey(), header.getValue());
+    }
+    builder.header("Accept", "application/json");
+    if (listVersionsOfProfileTemplateOptions.limit() != null) {
+      builder.query("limit", String.valueOf(listVersionsOfProfileTemplateOptions.limit()));
+    }
+    if (listVersionsOfProfileTemplateOptions.pagetoken() != null) {
+      builder.query("pagetoken", String.valueOf(listVersionsOfProfileTemplateOptions.pagetoken()));
+    }
+    if (listVersionsOfProfileTemplateOptions.sort() != null) {
+      builder.query("sort", String.valueOf(listVersionsOfProfileTemplateOptions.sort()));
+    }
+    if (listVersionsOfProfileTemplateOptions.order() != null) {
+      builder.query("order", String.valueOf(listVersionsOfProfileTemplateOptions.order()));
+    }
+    if (listVersionsOfProfileTemplateOptions.includeHistory() != null) {
+      builder.query("include_history", String.valueOf(listVersionsOfProfileTemplateOptions.includeHistory()));
+    }
+    ResponseConverter<TrustedProfileTemplateList> responseConverter =
+      ResponseConverterUtils.getValue(new com.google.gson.reflect.TypeToken<TrustedProfileTemplateList>() { }.getType());
+    return createServiceCall(builder.build(), responseConverter);
+  }
+
+  /**
+   * Create new version of a trusted profile template.
+   *
+   * Create a new version of a trusted profile template in an enterprise account.
+   *
+   * @param createProfileTemplateVersionOptions the {@link CreateProfileTemplateVersionOptions} containing the options for the call
+   * @return a {@link ServiceCall} with a result of type {@link TrustedProfileTemplateResponse}
+   */
+  public ServiceCall<TrustedProfileTemplateResponse> createProfileTemplateVersion(CreateProfileTemplateVersionOptions createProfileTemplateVersionOptions) {
+    com.ibm.cloud.sdk.core.util.Validator.notNull(createProfileTemplateVersionOptions,
+      "createProfileTemplateVersionOptions cannot be null");
+    Map<String, String> pathParamsMap = new HashMap<String, String>();
+    pathParamsMap.put("template_id", createProfileTemplateVersionOptions.templateId());
+    RequestBuilder builder = RequestBuilder.post(RequestBuilder.resolveRequestUrl(getServiceUrl(), "/v1/profile_templates/{template_id}/versions", pathParamsMap));
+    Map<String, String> sdkHeaders = SdkCommon.getSdkHeaders("iam_identity", "v1", "createProfileTemplateVersion");
+    for (Entry<String, String> header : sdkHeaders.entrySet()) {
+      builder.header(header.getKey(), header.getValue());
+    }
+    builder.header("Accept", "application/json");
+    final JsonObject contentJson = new JsonObject();
+    if (createProfileTemplateVersionOptions.accountId() != null) {
+      contentJson.addProperty("account_id", createProfileTemplateVersionOptions.accountId());
+    }
+    if (createProfileTemplateVersionOptions.name() != null) {
+      contentJson.addProperty("name", createProfileTemplateVersionOptions.name());
+    }
+    if (createProfileTemplateVersionOptions.description() != null) {
+      contentJson.addProperty("description", createProfileTemplateVersionOptions.description());
+    }
+    if (createProfileTemplateVersionOptions.profile() != null) {
+      contentJson.add("profile", com.ibm.cloud.sdk.core.util.GsonSingleton.getGson().toJsonTree(createProfileTemplateVersionOptions.profile()));
+    }
+    if (createProfileTemplateVersionOptions.policyTemplateReferences() != null) {
+      contentJson.add("policy_template_references", com.ibm.cloud.sdk.core.util.GsonSingleton.getGson().toJsonTree(createProfileTemplateVersionOptions.policyTemplateReferences()));
+    }
+    builder.bodyJson(contentJson);
+    ResponseConverter<TrustedProfileTemplateResponse> responseConverter =
+      ResponseConverterUtils.getValue(new com.google.gson.reflect.TypeToken<TrustedProfileTemplateResponse>() { }.getType());
+    return createServiceCall(builder.build(), responseConverter);
+  }
+
+  /**
+   * Get version of trusted profile template.
+   *
+   * Get a specific version of a trusted profile template in an enterprise account.
+   *
+   * @param getProfileTemplateVersionOptions the {@link GetProfileTemplateVersionOptions} containing the options for the call
+   * @return a {@link ServiceCall} with a result of type {@link TrustedProfileTemplateResponse}
+   */
+  public ServiceCall<TrustedProfileTemplateResponse> getProfileTemplateVersion(GetProfileTemplateVersionOptions getProfileTemplateVersionOptions) {
+    com.ibm.cloud.sdk.core.util.Validator.notNull(getProfileTemplateVersionOptions,
+      "getProfileTemplateVersionOptions cannot be null");
+    Map<String, String> pathParamsMap = new HashMap<String, String>();
+    pathParamsMap.put("template_id", getProfileTemplateVersionOptions.templateId());
+    pathParamsMap.put("version", getProfileTemplateVersionOptions.version());
+    RequestBuilder builder = RequestBuilder.get(RequestBuilder.resolveRequestUrl(getServiceUrl(), "/v1/profile_templates/{template_id}/versions/{version}", pathParamsMap));
+    Map<String, String> sdkHeaders = SdkCommon.getSdkHeaders("iam_identity", "v1", "getProfileTemplateVersion");
+    for (Entry<String, String> header : sdkHeaders.entrySet()) {
+      builder.header(header.getKey(), header.getValue());
+    }
+    builder.header("Accept", "application/json");
+    if (getProfileTemplateVersionOptions.includeHistory() != null) {
+      builder.query("include_history", String.valueOf(getProfileTemplateVersionOptions.includeHistory()));
+    }
+    ResponseConverter<TrustedProfileTemplateResponse> responseConverter =
+      ResponseConverterUtils.getValue(new com.google.gson.reflect.TypeToken<TrustedProfileTemplateResponse>() { }.getType());
+    return createServiceCall(builder.build(), responseConverter);
+  }
+
+  /**
+   * Update version of trusted profile template.
+   *
+   * Update a specific version of a trusted profile template in an enterprise account.
+   *
+   * @param updateProfileTemplateVersionOptions the {@link UpdateProfileTemplateVersionOptions} containing the options for the call
+   * @return a {@link ServiceCall} with a result of type {@link TrustedProfileTemplateResponse}
+   */
+  public ServiceCall<TrustedProfileTemplateResponse> updateProfileTemplateVersion(UpdateProfileTemplateVersionOptions updateProfileTemplateVersionOptions) {
+    com.ibm.cloud.sdk.core.util.Validator.notNull(updateProfileTemplateVersionOptions,
+      "updateProfileTemplateVersionOptions cannot be null");
+    Map<String, String> pathParamsMap = new HashMap<String, String>();
+    pathParamsMap.put("template_id", updateProfileTemplateVersionOptions.templateId());
+    pathParamsMap.put("version", updateProfileTemplateVersionOptions.version());
+    RequestBuilder builder = RequestBuilder.put(RequestBuilder.resolveRequestUrl(getServiceUrl(), "/v1/profile_templates/{template_id}/versions/{version}", pathParamsMap));
+    Map<String, String> sdkHeaders = SdkCommon.getSdkHeaders("iam_identity", "v1", "updateProfileTemplateVersion");
+    for (Entry<String, String> header : sdkHeaders.entrySet()) {
+      builder.header(header.getKey(), header.getValue());
+    }
+    builder.header("Accept", "application/json");
+    builder.header("If-Match", updateProfileTemplateVersionOptions.ifMatch());
+    final JsonObject contentJson = new JsonObject();
+    if (updateProfileTemplateVersionOptions.accountId() != null) {
+      contentJson.addProperty("account_id", updateProfileTemplateVersionOptions.accountId());
+    }
+    if (updateProfileTemplateVersionOptions.name() != null) {
+      contentJson.addProperty("name", updateProfileTemplateVersionOptions.name());
+    }
+    if (updateProfileTemplateVersionOptions.description() != null) {
+      contentJson.addProperty("description", updateProfileTemplateVersionOptions.description());
+    }
+    if (updateProfileTemplateVersionOptions.profile() != null) {
+      contentJson.add("profile", com.ibm.cloud.sdk.core.util.GsonSingleton.getGson().toJsonTree(updateProfileTemplateVersionOptions.profile()));
+    }
+    if (updateProfileTemplateVersionOptions.policyTemplateReferences() != null) {
+      contentJson.add("policy_template_references", com.ibm.cloud.sdk.core.util.GsonSingleton.getGson().toJsonTree(updateProfileTemplateVersionOptions.policyTemplateReferences()));
+    }
+    builder.bodyJson(contentJson);
+    ResponseConverter<TrustedProfileTemplateResponse> responseConverter =
+      ResponseConverterUtils.getValue(new com.google.gson.reflect.TypeToken<TrustedProfileTemplateResponse>() { }.getType());
+    return createServiceCall(builder.build(), responseConverter);
+  }
+
+  /**
+   * Delete version of trusted profile template.
+   *
+   * Delete a specific version of a trusted profile template in an enterprise account. If the version is assigned to
+   * child accounts, you must first delete the assignment.
+   *
+   * @param deleteProfileTemplateVersionOptions the {@link DeleteProfileTemplateVersionOptions} containing the options for the call
+   * @return a {@link ServiceCall} with a void result
+   */
+  public ServiceCall<Void> deleteProfileTemplateVersion(DeleteProfileTemplateVersionOptions deleteProfileTemplateVersionOptions) {
+    com.ibm.cloud.sdk.core.util.Validator.notNull(deleteProfileTemplateVersionOptions,
+      "deleteProfileTemplateVersionOptions cannot be null");
+    Map<String, String> pathParamsMap = new HashMap<String, String>();
+    pathParamsMap.put("template_id", deleteProfileTemplateVersionOptions.templateId());
+    pathParamsMap.put("version", deleteProfileTemplateVersionOptions.version());
+    RequestBuilder builder = RequestBuilder.delete(RequestBuilder.resolveRequestUrl(getServiceUrl(), "/v1/profile_templates/{template_id}/versions/{version}", pathParamsMap));
+    Map<String, String> sdkHeaders = SdkCommon.getSdkHeaders("iam_identity", "v1", "deleteProfileTemplateVersion");
+    for (Entry<String, String> header : sdkHeaders.entrySet()) {
+      builder.header(header.getKey(), header.getValue());
+    }
+    ResponseConverter<Void> responseConverter = ResponseConverterUtils.getVoid();
+    return createServiceCall(builder.build(), responseConverter);
+  }
+
+  /**
+   * Commit a template version.
+   *
+   * Commit a specific version of a trusted profile template in an enterprise account. You must commit a template before
+   * you can assign it to child accounts. Once a template is committed, you can no longer modify the template.
+   *
+   * @param commitProfileTemplateOptions the {@link CommitProfileTemplateOptions} containing the options for the call
+   * @return a {@link ServiceCall} with a void result
+   */
+  public ServiceCall<Void> commitProfileTemplate(CommitProfileTemplateOptions commitProfileTemplateOptions) {
+    com.ibm.cloud.sdk.core.util.Validator.notNull(commitProfileTemplateOptions,
+      "commitProfileTemplateOptions cannot be null");
+    Map<String, String> pathParamsMap = new HashMap<String, String>();
+    pathParamsMap.put("template_id", commitProfileTemplateOptions.templateId());
+    pathParamsMap.put("version", commitProfileTemplateOptions.version());
+    RequestBuilder builder = RequestBuilder.post(RequestBuilder.resolveRequestUrl(getServiceUrl(), "/v1/profile_templates/{template_id}/versions/{version}/commit", pathParamsMap));
+    Map<String, String> sdkHeaders = SdkCommon.getSdkHeaders("iam_identity", "v1", "commitProfileTemplate");
+    for (Entry<String, String> header : sdkHeaders.entrySet()) {
+      builder.header(header.getKey(), header.getValue());
+    }
+    ResponseConverter<Void> responseConverter = ResponseConverterUtils.getVoid();
     return createServiceCall(builder.build(), responseConverter);
   }
 

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/AccountSettingsComponent.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/AccountSettingsComponent.java
@@ -1,0 +1,434 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.google.gson.annotations.SerializedName;
+import com.ibm.cloud.sdk.core.service.model.GenericModel;
+
+/**
+ * AccountSettingsComponent.
+ */
+public class AccountSettingsComponent extends GenericModel {
+
+  /**
+   * Defines whether or not creating a service ID is access controlled. Valid values:
+   *   * RESTRICTED - only users assigned the 'Service ID creator' role on the IAM Identity Service can create service
+   * IDs, including the account owner
+   *   * NOT_RESTRICTED - all members of an account can create service IDs
+   *   * NOT_SET - to 'unset' a previous set value.
+   */
+  public interface RestrictCreateServiceId {
+    /** RESTRICTED. */
+    String RESTRICTED = "RESTRICTED";
+    /** NOT_RESTRICTED. */
+    String NOT_RESTRICTED = "NOT_RESTRICTED";
+    /** NOT_SET. */
+    String NOT_SET = "NOT_SET";
+  }
+
+  /**
+   * Defines whether or not creating platform API keys is access controlled. Valid values:
+   *   * RESTRICTED - to apply access control
+   *   * NOT_RESTRICTED - to remove access control
+   *   * NOT_SET - to 'unset' a previous set value.
+   */
+  public interface RestrictCreatePlatformApikey {
+    /** RESTRICTED. */
+    String RESTRICTED = "RESTRICTED";
+    /** NOT_RESTRICTED. */
+    String NOT_RESTRICTED = "NOT_RESTRICTED";
+    /** NOT_SET. */
+    String NOT_SET = "NOT_SET";
+  }
+
+  /**
+   * Defines the MFA trait for the account. Valid values:
+   *   * NONE - No MFA trait set
+   *   * TOTP - For all non-federated IBMId users
+   *   * TOTP4ALL - For all users
+   *   * LEVEL1 - Email-based MFA for all users
+   *   * LEVEL2 - TOTP-based MFA for all users
+   *   * LEVEL3 - U2F MFA for all users.
+   */
+  public interface Mfa {
+    /** NONE. */
+    String NONE = "NONE";
+    /** TOTP. */
+    String TOTP = "TOTP";
+    /** TOTP4ALL. */
+    String TOTP4ALL = "TOTP4ALL";
+    /** LEVEL1. */
+    String LEVEL1 = "LEVEL1";
+    /** LEVEL2. */
+    String LEVEL2 = "LEVEL2";
+    /** LEVEL3. */
+    String LEVEL3 = "LEVEL3";
+  }
+
+  @SerializedName("restrict_create_service_id")
+  protected String restrictCreateServiceId;
+  @SerializedName("restrict_create_platform_apikey")
+  protected String restrictCreatePlatformApikey;
+  @SerializedName("allowed_ip_addresses")
+  protected String allowedIpAddresses;
+  protected String mfa;
+  @SerializedName("user_mfa")
+  protected List<AccountSettingsUserMFA> userMfa;
+  @SerializedName("session_expiration_in_seconds")
+  protected String sessionExpirationInSeconds;
+  @SerializedName("session_invalidation_in_seconds")
+  protected String sessionInvalidationInSeconds;
+  @SerializedName("max_sessions_per_identity")
+  protected String maxSessionsPerIdentity;
+  @SerializedName("system_access_token_expiration_in_seconds")
+  protected String systemAccessTokenExpirationInSeconds;
+  @SerializedName("system_refresh_token_expiration_in_seconds")
+  protected String systemRefreshTokenExpirationInSeconds;
+
+  /**
+   * Builder.
+   */
+  public static class Builder {
+    private String restrictCreateServiceId;
+    private String restrictCreatePlatformApikey;
+    private String allowedIpAddresses;
+    private String mfa;
+    private List<AccountSettingsUserMFA> userMfa;
+    private String sessionExpirationInSeconds;
+    private String sessionInvalidationInSeconds;
+    private String maxSessionsPerIdentity;
+    private String systemAccessTokenExpirationInSeconds;
+    private String systemRefreshTokenExpirationInSeconds;
+
+    /**
+     * Instantiates a new Builder from an existing AccountSettingsComponent instance.
+     *
+     * @param accountSettingsComponent the instance to initialize the Builder with
+     */
+    private Builder(AccountSettingsComponent accountSettingsComponent) {
+      this.restrictCreateServiceId = accountSettingsComponent.restrictCreateServiceId;
+      this.restrictCreatePlatformApikey = accountSettingsComponent.restrictCreatePlatformApikey;
+      this.allowedIpAddresses = accountSettingsComponent.allowedIpAddresses;
+      this.mfa = accountSettingsComponent.mfa;
+      this.userMfa = accountSettingsComponent.userMfa;
+      this.sessionExpirationInSeconds = accountSettingsComponent.sessionExpirationInSeconds;
+      this.sessionInvalidationInSeconds = accountSettingsComponent.sessionInvalidationInSeconds;
+      this.maxSessionsPerIdentity = accountSettingsComponent.maxSessionsPerIdentity;
+      this.systemAccessTokenExpirationInSeconds = accountSettingsComponent.systemAccessTokenExpirationInSeconds;
+      this.systemRefreshTokenExpirationInSeconds = accountSettingsComponent.systemRefreshTokenExpirationInSeconds;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public Builder() {
+    }
+
+    /**
+     * Builds a AccountSettingsComponent.
+     *
+     * @return the new AccountSettingsComponent instance
+     */
+    public AccountSettingsComponent build() {
+      return new AccountSettingsComponent(this);
+    }
+
+    /**
+     * Adds an userMfa to userMfa.
+     *
+     * @param userMfa the new userMfa
+     * @return the AccountSettingsComponent builder
+     */
+    public Builder addUserMfa(AccountSettingsUserMFA userMfa) {
+      com.ibm.cloud.sdk.core.util.Validator.notNull(userMfa,
+        "userMfa cannot be null");
+      if (this.userMfa == null) {
+        this.userMfa = new ArrayList<AccountSettingsUserMFA>();
+      }
+      this.userMfa.add(userMfa);
+      return this;
+    }
+
+    /**
+     * Set the restrictCreateServiceId.
+     *
+     * @param restrictCreateServiceId the restrictCreateServiceId
+     * @return the AccountSettingsComponent builder
+     */
+    public Builder restrictCreateServiceId(String restrictCreateServiceId) {
+      this.restrictCreateServiceId = restrictCreateServiceId;
+      return this;
+    }
+
+    /**
+     * Set the restrictCreatePlatformApikey.
+     *
+     * @param restrictCreatePlatformApikey the restrictCreatePlatformApikey
+     * @return the AccountSettingsComponent builder
+     */
+    public Builder restrictCreatePlatformApikey(String restrictCreatePlatformApikey) {
+      this.restrictCreatePlatformApikey = restrictCreatePlatformApikey;
+      return this;
+    }
+
+    /**
+     * Set the allowedIpAddresses.
+     *
+     * @param allowedIpAddresses the allowedIpAddresses
+     * @return the AccountSettingsComponent builder
+     */
+    public Builder allowedIpAddresses(String allowedIpAddresses) {
+      this.allowedIpAddresses = allowedIpAddresses;
+      return this;
+    }
+
+    /**
+     * Set the mfa.
+     *
+     * @param mfa the mfa
+     * @return the AccountSettingsComponent builder
+     */
+    public Builder mfa(String mfa) {
+      this.mfa = mfa;
+      return this;
+    }
+
+    /**
+     * Set the userMfa.
+     * Existing userMfa will be replaced.
+     *
+     * @param userMfa the userMfa
+     * @return the AccountSettingsComponent builder
+     */
+    public Builder userMfa(List<AccountSettingsUserMFA> userMfa) {
+      this.userMfa = userMfa;
+      return this;
+    }
+
+    /**
+     * Set the sessionExpirationInSeconds.
+     *
+     * @param sessionExpirationInSeconds the sessionExpirationInSeconds
+     * @return the AccountSettingsComponent builder
+     */
+    public Builder sessionExpirationInSeconds(String sessionExpirationInSeconds) {
+      this.sessionExpirationInSeconds = sessionExpirationInSeconds;
+      return this;
+    }
+
+    /**
+     * Set the sessionInvalidationInSeconds.
+     *
+     * @param sessionInvalidationInSeconds the sessionInvalidationInSeconds
+     * @return the AccountSettingsComponent builder
+     */
+    public Builder sessionInvalidationInSeconds(String sessionInvalidationInSeconds) {
+      this.sessionInvalidationInSeconds = sessionInvalidationInSeconds;
+      return this;
+    }
+
+    /**
+     * Set the maxSessionsPerIdentity.
+     *
+     * @param maxSessionsPerIdentity the maxSessionsPerIdentity
+     * @return the AccountSettingsComponent builder
+     */
+    public Builder maxSessionsPerIdentity(String maxSessionsPerIdentity) {
+      this.maxSessionsPerIdentity = maxSessionsPerIdentity;
+      return this;
+    }
+
+    /**
+     * Set the systemAccessTokenExpirationInSeconds.
+     *
+     * @param systemAccessTokenExpirationInSeconds the systemAccessTokenExpirationInSeconds
+     * @return the AccountSettingsComponent builder
+     */
+    public Builder systemAccessTokenExpirationInSeconds(String systemAccessTokenExpirationInSeconds) {
+      this.systemAccessTokenExpirationInSeconds = systemAccessTokenExpirationInSeconds;
+      return this;
+    }
+
+    /**
+     * Set the systemRefreshTokenExpirationInSeconds.
+     *
+     * @param systemRefreshTokenExpirationInSeconds the systemRefreshTokenExpirationInSeconds
+     * @return the AccountSettingsComponent builder
+     */
+    public Builder systemRefreshTokenExpirationInSeconds(String systemRefreshTokenExpirationInSeconds) {
+      this.systemRefreshTokenExpirationInSeconds = systemRefreshTokenExpirationInSeconds;
+      return this;
+    }
+  }
+
+  protected AccountSettingsComponent() { }
+
+  protected AccountSettingsComponent(Builder builder) {
+    restrictCreateServiceId = builder.restrictCreateServiceId;
+    restrictCreatePlatformApikey = builder.restrictCreatePlatformApikey;
+    allowedIpAddresses = builder.allowedIpAddresses;
+    mfa = builder.mfa;
+    userMfa = builder.userMfa;
+    sessionExpirationInSeconds = builder.sessionExpirationInSeconds;
+    sessionInvalidationInSeconds = builder.sessionInvalidationInSeconds;
+    maxSessionsPerIdentity = builder.maxSessionsPerIdentity;
+    systemAccessTokenExpirationInSeconds = builder.systemAccessTokenExpirationInSeconds;
+    systemRefreshTokenExpirationInSeconds = builder.systemRefreshTokenExpirationInSeconds;
+  }
+
+  /**
+   * New builder.
+   *
+   * @return a AccountSettingsComponent builder
+   */
+  public Builder newBuilder() {
+    return new Builder(this);
+  }
+
+  /**
+   * Gets the restrictCreateServiceId.
+   *
+   * Defines whether or not creating a service ID is access controlled. Valid values:
+   *   * RESTRICTED - only users assigned the 'Service ID creator' role on the IAM Identity Service can create service
+   * IDs, including the account owner
+   *   * NOT_RESTRICTED - all members of an account can create service IDs
+   *   * NOT_SET - to 'unset' a previous set value.
+   *
+   * @return the restrictCreateServiceId
+   */
+  public String restrictCreateServiceId() {
+    return restrictCreateServiceId;
+  }
+
+  /**
+   * Gets the restrictCreatePlatformApikey.
+   *
+   * Defines whether or not creating platform API keys is access controlled. Valid values:
+   *   * RESTRICTED - to apply access control
+   *   * NOT_RESTRICTED - to remove access control
+   *   * NOT_SET - to 'unset' a previous set value.
+   *
+   * @return the restrictCreatePlatformApikey
+   */
+  public String restrictCreatePlatformApikey() {
+    return restrictCreatePlatformApikey;
+  }
+
+  /**
+   * Gets the allowedIpAddresses.
+   *
+   * Defines the IP addresses and subnets from which IAM tokens can be created for the account.
+   *
+   * @return the allowedIpAddresses
+   */
+  public String allowedIpAddresses() {
+    return allowedIpAddresses;
+  }
+
+  /**
+   * Gets the mfa.
+   *
+   * Defines the MFA trait for the account. Valid values:
+   *   * NONE - No MFA trait set
+   *   * TOTP - For all non-federated IBMId users
+   *   * TOTP4ALL - For all users
+   *   * LEVEL1 - Email-based MFA for all users
+   *   * LEVEL2 - TOTP-based MFA for all users
+   *   * LEVEL3 - U2F MFA for all users.
+   *
+   * @return the mfa
+   */
+  public String mfa() {
+    return mfa;
+  }
+
+  /**
+   * Gets the userMfa.
+   *
+   * List of users that are exempted from the MFA requirement of the account.
+   *
+   * @return the userMfa
+   */
+  public List<AccountSettingsUserMFA> userMfa() {
+    return userMfa;
+  }
+
+  /**
+   * Gets the sessionExpirationInSeconds.
+   *
+   * Defines the session expiration in seconds for the account. Valid values:
+   *   * Any whole number between between '900' and '86400'
+   *   * NOT_SET - To unset account setting and use service default.
+   *
+   * @return the sessionExpirationInSeconds
+   */
+  public String sessionExpirationInSeconds() {
+    return sessionExpirationInSeconds;
+  }
+
+  /**
+   * Gets the sessionInvalidationInSeconds.
+   *
+   * Defines the period of time in seconds in which a session will be invalidated due to inactivity. Valid values:
+   *   * Any whole number between '900' and '7200'
+   *   * NOT_SET - To unset account setting and use service default.
+   *
+   * @return the sessionInvalidationInSeconds
+   */
+  public String sessionInvalidationInSeconds() {
+    return sessionInvalidationInSeconds;
+  }
+
+  /**
+   * Gets the maxSessionsPerIdentity.
+   *
+   * Defines the max allowed sessions per identity required by the account. Valid values:
+   *   * Any whole number greater than 0
+   *   * NOT_SET - To unset account setting and use service default.
+   *
+   * @return the maxSessionsPerIdentity
+   */
+  public String maxSessionsPerIdentity() {
+    return maxSessionsPerIdentity;
+  }
+
+  /**
+   * Gets the systemAccessTokenExpirationInSeconds.
+   *
+   * Defines the access token expiration in seconds. Valid values:
+   *   * Any whole number between '900' and '3600'
+   *   * NOT_SET - To unset account setting and use service default.
+   *
+   * @return the systemAccessTokenExpirationInSeconds
+   */
+  public String systemAccessTokenExpirationInSeconds() {
+    return systemAccessTokenExpirationInSeconds;
+  }
+
+  /**
+   * Gets the systemRefreshTokenExpirationInSeconds.
+   *
+   * Defines the refresh token expiration in seconds. Valid values:
+   *   * Any whole number between '900' and '259200'
+   *   * NOT_SET - To unset account setting and use service default.
+   *
+   * @return the systemRefreshTokenExpirationInSeconds
+   */
+  public String systemRefreshTokenExpirationInSeconds() {
+    return systemRefreshTokenExpirationInSeconds;
+  }
+}
+

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/AccountSettingsResponse.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/AccountSettingsResponse.java
@@ -23,9 +23,10 @@ import com.ibm.cloud.sdk.core.service.model.GenericModel;
 public class AccountSettingsResponse extends GenericModel {
 
   /**
-   * Defines whether or not creating a Service Id is access controlled. Valid values:
-   *   * RESTRICTED - to apply access control
-   *   * NOT_RESTRICTED - to remove access control
+   * Defines whether or not creating a service ID is access controlled. Valid values:
+   *   * RESTRICTED - only users assigned the 'Service ID creator' role on the IAM Identity Service can create service
+   * IDs, including the account owner
+   *   * NOT_RESTRICTED - all members of an account can create service IDs
    *   * NOT_SET - to 'unset' a previous set value.
    */
   public interface RestrictCreateServiceId {
@@ -132,9 +133,10 @@ public class AccountSettingsResponse extends GenericModel {
   /**
    * Gets the restrictCreateServiceId.
    *
-   * Defines whether or not creating a Service Id is access controlled. Valid values:
-   *   * RESTRICTED - to apply access control
-   *   * NOT_RESTRICTED - to remove access control
+   * Defines whether or not creating a service ID is access controlled. Valid values:
+   *   * RESTRICTED - only users assigned the 'Service ID creator' role on the IAM Identity Service can create service
+   * IDs, including the account owner
+   *   * NOT_RESTRICTED - all members of an account can create service IDs
    *   * NOT_SET - to 'unset' a previous set value.
    *
    * @return the restrictCreateServiceId

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/AccountSettingsTemplateList.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/AccountSettingsTemplateList.java
@@ -1,0 +1,115 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import java.util.List;
+
+import com.google.gson.annotations.SerializedName;
+import com.ibm.cloud.sdk.core.service.model.GenericModel;
+
+/**
+ * AccountSettingsTemplateList.
+ */
+public class AccountSettingsTemplateList extends GenericModel {
+
+  protected ResponseContext context;
+  protected Long offset;
+  protected Long limit;
+  protected String first;
+  protected String previous;
+  protected String next;
+  @SerializedName("account_settings_templates")
+  protected List<AccountSettingsTemplateResponse> accountSettingsTemplates;
+
+  protected AccountSettingsTemplateList() { }
+
+  /**
+   * Gets the context.
+   *
+   * Context with key properties for problem determination.
+   *
+   * @return the context
+   */
+  public ResponseContext getContext() {
+    return context;
+  }
+
+  /**
+   * Gets the offset.
+   *
+   * The offset of the current page.
+   *
+   * @return the offset
+   */
+  public Long getOffset() {
+    return offset;
+  }
+
+  /**
+   * Gets the limit.
+   *
+   * Optional size of a single page.
+   *
+   * @return the limit
+   */
+  public Long getLimit() {
+    return limit;
+  }
+
+  /**
+   * Gets the first.
+   *
+   * Link to the first page.
+   *
+   * @return the first
+   */
+  public String getFirst() {
+    return first;
+  }
+
+  /**
+   * Gets the previous.
+   *
+   * Link to the previous available page. If 'previous' property is not part of the response no previous page is
+   * available.
+   *
+   * @return the previous
+   */
+  public String getPrevious() {
+    return previous;
+  }
+
+  /**
+   * Gets the next.
+   *
+   * Link to the next available page. If 'next' property is not part of the response no next page is available.
+   *
+   * @return the next
+   */
+  public String getNext() {
+    return next;
+  }
+
+  /**
+   * Gets the accountSettingsTemplates.
+   *
+   * List of account settings templates based on the query paramters and the page size. The account_settings_templates
+   * array is always part of the response but might be empty depending on the query parameter values provided.
+   *
+   * @return the accountSettingsTemplates
+   */
+  public List<AccountSettingsTemplateResponse> getAccountSettingsTemplates() {
+    return accountSettingsTemplates;
+  }
+}
+

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/AccountSettingsTemplateResponse.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/AccountSettingsTemplateResponse.java
@@ -1,0 +1,201 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import java.util.List;
+
+import com.google.gson.annotations.SerializedName;
+import com.ibm.cloud.sdk.core.service.model.GenericModel;
+
+/**
+ * Response body format for account settings template REST requests.
+ */
+public class AccountSettingsTemplateResponse extends GenericModel {
+
+  protected String id;
+  protected Long version;
+  @SerializedName("account_id")
+  protected String accountId;
+  protected String name;
+  protected String description;
+  protected Boolean committed;
+  @SerializedName("account_settings")
+  protected AccountSettingsComponent accountSettings;
+  protected List<EnityHistoryRecord> history;
+  @SerializedName("entity_tag")
+  protected String entityTag;
+  protected String crn;
+  @SerializedName("created_at")
+  protected String createdAt;
+  @SerializedName("created_by_id")
+  protected String createdById;
+  @SerializedName("last_modified_at")
+  protected String lastModifiedAt;
+  @SerializedName("last_modified_by_id")
+  protected String lastModifiedById;
+
+  protected AccountSettingsTemplateResponse() { }
+
+  /**
+   * Gets the id.
+   *
+   * ID of the the template.
+   *
+   * @return the id
+   */
+  public String getId() {
+    return id;
+  }
+
+  /**
+   * Gets the version.
+   *
+   * Version of the the template.
+   *
+   * @return the version
+   */
+  public Long getVersion() {
+    return version;
+  }
+
+  /**
+   * Gets the accountId.
+   *
+   * ID of the account where the template resides.
+   *
+   * @return the accountId
+   */
+  public String getAccountId() {
+    return accountId;
+  }
+
+  /**
+   * Gets the name.
+   *
+   * The name of the trusted profile template. This is visible only in the enterprise account.
+   *
+   * @return the name
+   */
+  public String getName() {
+    return name;
+  }
+
+  /**
+   * Gets the description.
+   *
+   * The description of the trusted profile template. Describe the template for enterprise account users.
+   *
+   * @return the description
+   */
+  public String getDescription() {
+    return description;
+  }
+
+  /**
+   * Gets the committed.
+   *
+   * Committed flag determines if the template is ready for assignment.
+   *
+   * @return the committed
+   */
+  public Boolean isCommitted() {
+    return committed;
+  }
+
+  /**
+   * Gets the accountSettings.
+   *
+   * @return the accountSettings
+   */
+  public AccountSettingsComponent getAccountSettings() {
+    return accountSettings;
+  }
+
+  /**
+   * Gets the history.
+   *
+   * History of the Template.
+   *
+   * @return the history
+   */
+  public List<EnityHistoryRecord> getHistory() {
+    return history;
+  }
+
+  /**
+   * Gets the entityTag.
+   *
+   * Entity tag for this templateId-version combination.
+   *
+   * @return the entityTag
+   */
+  public String getEntityTag() {
+    return entityTag;
+  }
+
+  /**
+   * Gets the crn.
+   *
+   * Cloud resource name.
+   *
+   * @return the crn
+   */
+  public String getCrn() {
+    return crn;
+  }
+
+  /**
+   * Gets the createdAt.
+   *
+   * Template Created At.
+   *
+   * @return the createdAt
+   */
+  public String getCreatedAt() {
+    return createdAt;
+  }
+
+  /**
+   * Gets the createdById.
+   *
+   * IAMid of the creator.
+   *
+   * @return the createdById
+   */
+  public String getCreatedById() {
+    return createdById;
+  }
+
+  /**
+   * Gets the lastModifiedAt.
+   *
+   * Template last modified at.
+   *
+   * @return the lastModifiedAt
+   */
+  public String getLastModifiedAt() {
+    return lastModifiedAt;
+  }
+
+  /**
+   * Gets the lastModifiedById.
+   *
+   * IAMid of the identity that made the latest modification.
+   *
+   * @return the lastModifiedById
+   */
+  public String getLastModifiedById() {
+    return lastModifiedById;
+  }
+}
+

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/Activity.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/Activity.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ApiKey.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ApiKey.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ApiKeyInsideCreateServiceIdRequest.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ApiKeyInsideCreateServiceIdRequest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ApiKeyList.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ApiKeyList.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ApikeyActivity.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ApikeyActivity.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ApikeyActivityServiceid.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ApikeyActivityServiceid.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ApikeyActivityUser.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ApikeyActivityUser.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/CommitAccountSettingsTemplateOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/CommitAccountSettingsTemplateOptions.java
@@ -1,0 +1,133 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import com.ibm.cloud.sdk.core.service.model.GenericModel;
+
+/**
+ * The commitAccountSettingsTemplate options.
+ */
+public class CommitAccountSettingsTemplateOptions extends GenericModel {
+
+  protected String templateId;
+  protected String version;
+
+  /**
+   * Builder.
+   */
+  public static class Builder {
+    private String templateId;
+    private String version;
+
+    /**
+     * Instantiates a new Builder from an existing CommitAccountSettingsTemplateOptions instance.
+     *
+     * @param commitAccountSettingsTemplateOptions the instance to initialize the Builder with
+     */
+    private Builder(CommitAccountSettingsTemplateOptions commitAccountSettingsTemplateOptions) {
+      this.templateId = commitAccountSettingsTemplateOptions.templateId;
+      this.version = commitAccountSettingsTemplateOptions.version;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public Builder() {
+    }
+
+    /**
+     * Instantiates a new builder with required properties.
+     *
+     * @param templateId the templateId
+     * @param version the version
+     */
+    public Builder(String templateId, String version) {
+      this.templateId = templateId;
+      this.version = version;
+    }
+
+    /**
+     * Builds a CommitAccountSettingsTemplateOptions.
+     *
+     * @return the new CommitAccountSettingsTemplateOptions instance
+     */
+    public CommitAccountSettingsTemplateOptions build() {
+      return new CommitAccountSettingsTemplateOptions(this);
+    }
+
+    /**
+     * Set the templateId.
+     *
+     * @param templateId the templateId
+     * @return the CommitAccountSettingsTemplateOptions builder
+     */
+    public Builder templateId(String templateId) {
+      this.templateId = templateId;
+      return this;
+    }
+
+    /**
+     * Set the version.
+     *
+     * @param version the version
+     * @return the CommitAccountSettingsTemplateOptions builder
+     */
+    public Builder version(String version) {
+      this.version = version;
+      return this;
+    }
+  }
+
+  protected CommitAccountSettingsTemplateOptions() { }
+
+  protected CommitAccountSettingsTemplateOptions(Builder builder) {
+    com.ibm.cloud.sdk.core.util.Validator.notEmpty(builder.templateId,
+      "templateId cannot be empty");
+    com.ibm.cloud.sdk.core.util.Validator.notEmpty(builder.version,
+      "version cannot be empty");
+    templateId = builder.templateId;
+    version = builder.version;
+  }
+
+  /**
+   * New builder.
+   *
+   * @return a CommitAccountSettingsTemplateOptions builder
+   */
+  public Builder newBuilder() {
+    return new Builder(this);
+  }
+
+  /**
+   * Gets the templateId.
+   *
+   * ID of the account settings template.
+   *
+   * @return the templateId
+   */
+  public String templateId() {
+    return templateId;
+  }
+
+  /**
+   * Gets the version.
+   *
+   * Version of the account settings template.
+   *
+   * @return the version
+   */
+  public String version() {
+    return version;
+  }
+}
+

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/CommitProfileTemplateOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/CommitProfileTemplateOptions.java
@@ -1,0 +1,133 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import com.ibm.cloud.sdk.core.service.model.GenericModel;
+
+/**
+ * The commitProfileTemplate options.
+ */
+public class CommitProfileTemplateOptions extends GenericModel {
+
+  protected String templateId;
+  protected String version;
+
+  /**
+   * Builder.
+   */
+  public static class Builder {
+    private String templateId;
+    private String version;
+
+    /**
+     * Instantiates a new Builder from an existing CommitProfileTemplateOptions instance.
+     *
+     * @param commitProfileTemplateOptions the instance to initialize the Builder with
+     */
+    private Builder(CommitProfileTemplateOptions commitProfileTemplateOptions) {
+      this.templateId = commitProfileTemplateOptions.templateId;
+      this.version = commitProfileTemplateOptions.version;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public Builder() {
+    }
+
+    /**
+     * Instantiates a new builder with required properties.
+     *
+     * @param templateId the templateId
+     * @param version the version
+     */
+    public Builder(String templateId, String version) {
+      this.templateId = templateId;
+      this.version = version;
+    }
+
+    /**
+     * Builds a CommitProfileTemplateOptions.
+     *
+     * @return the new CommitProfileTemplateOptions instance
+     */
+    public CommitProfileTemplateOptions build() {
+      return new CommitProfileTemplateOptions(this);
+    }
+
+    /**
+     * Set the templateId.
+     *
+     * @param templateId the templateId
+     * @return the CommitProfileTemplateOptions builder
+     */
+    public Builder templateId(String templateId) {
+      this.templateId = templateId;
+      return this;
+    }
+
+    /**
+     * Set the version.
+     *
+     * @param version the version
+     * @return the CommitProfileTemplateOptions builder
+     */
+    public Builder version(String version) {
+      this.version = version;
+      return this;
+    }
+  }
+
+  protected CommitProfileTemplateOptions() { }
+
+  protected CommitProfileTemplateOptions(Builder builder) {
+    com.ibm.cloud.sdk.core.util.Validator.notEmpty(builder.templateId,
+      "templateId cannot be empty");
+    com.ibm.cloud.sdk.core.util.Validator.notEmpty(builder.version,
+      "version cannot be empty");
+    templateId = builder.templateId;
+    version = builder.version;
+  }
+
+  /**
+   * New builder.
+   *
+   * @return a CommitProfileTemplateOptions builder
+   */
+  public Builder newBuilder() {
+    return new Builder(this);
+  }
+
+  /**
+   * Gets the templateId.
+   *
+   * ID of the trusted profile template.
+   *
+   * @return the templateId
+   */
+  public String templateId() {
+    return templateId;
+  }
+
+  /**
+   * Gets the version.
+   *
+   * Version of the Profile Template.
+   *
+   * @return the version
+   */
+  public String version() {
+    return version;
+  }
+}
+

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/CreateAccountSettingsAssignmentOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/CreateAccountSettingsAssignmentOptions.java
@@ -1,0 +1,203 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import com.ibm.cloud.sdk.core.service.model.GenericModel;
+
+/**
+ * The createAccountSettingsAssignment options.
+ */
+public class CreateAccountSettingsAssignmentOptions extends GenericModel {
+
+  /**
+   * Type of target to deploy to.
+   */
+  public interface TargetType {
+    /** Account. */
+    String ACCOUNT = "Account";
+    /** AccountGroup. */
+    String ACCOUNTGROUP = "AccountGroup";
+  }
+
+  protected String templateId;
+  protected Long templateVersion;
+  protected String targetType;
+  protected String target;
+
+  /**
+   * Builder.
+   */
+  public static class Builder {
+    private String templateId;
+    private Long templateVersion;
+    private String targetType;
+    private String target;
+
+    /**
+     * Instantiates a new Builder from an existing CreateAccountSettingsAssignmentOptions instance.
+     *
+     * @param createAccountSettingsAssignmentOptions the instance to initialize the Builder with
+     */
+    private Builder(CreateAccountSettingsAssignmentOptions createAccountSettingsAssignmentOptions) {
+      this.templateId = createAccountSettingsAssignmentOptions.templateId;
+      this.templateVersion = createAccountSettingsAssignmentOptions.templateVersion;
+      this.targetType = createAccountSettingsAssignmentOptions.targetType;
+      this.target = createAccountSettingsAssignmentOptions.target;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public Builder() {
+    }
+
+    /**
+     * Instantiates a new builder with required properties.
+     *
+     * @param templateId the templateId
+     * @param templateVersion the templateVersion
+     * @param targetType the targetType
+     * @param target the target
+     */
+    public Builder(String templateId, Long templateVersion, String targetType, String target) {
+      this.templateId = templateId;
+      this.templateVersion = templateVersion;
+      this.targetType = targetType;
+      this.target = target;
+    }
+
+    /**
+     * Builds a CreateAccountSettingsAssignmentOptions.
+     *
+     * @return the new CreateAccountSettingsAssignmentOptions instance
+     */
+    public CreateAccountSettingsAssignmentOptions build() {
+      return new CreateAccountSettingsAssignmentOptions(this);
+    }
+
+    /**
+     * Set the templateId.
+     *
+     * @param templateId the templateId
+     * @return the CreateAccountSettingsAssignmentOptions builder
+     */
+    public Builder templateId(String templateId) {
+      this.templateId = templateId;
+      return this;
+    }
+
+    /**
+     * Set the templateVersion.
+     *
+     * @param templateVersion the templateVersion
+     * @return the CreateAccountSettingsAssignmentOptions builder
+     */
+    public Builder templateVersion(long templateVersion) {
+      this.templateVersion = templateVersion;
+      return this;
+    }
+
+    /**
+     * Set the targetType.
+     *
+     * @param targetType the targetType
+     * @return the CreateAccountSettingsAssignmentOptions builder
+     */
+    public Builder targetType(String targetType) {
+      this.targetType = targetType;
+      return this;
+    }
+
+    /**
+     * Set the target.
+     *
+     * @param target the target
+     * @return the CreateAccountSettingsAssignmentOptions builder
+     */
+    public Builder target(String target) {
+      this.target = target;
+      return this;
+    }
+  }
+
+  protected CreateAccountSettingsAssignmentOptions() { }
+
+  protected CreateAccountSettingsAssignmentOptions(Builder builder) {
+    com.ibm.cloud.sdk.core.util.Validator.notNull(builder.templateId,
+      "templateId cannot be null");
+    com.ibm.cloud.sdk.core.util.Validator.notNull(builder.templateVersion,
+      "templateVersion cannot be null");
+    com.ibm.cloud.sdk.core.util.Validator.notNull(builder.targetType,
+      "targetType cannot be null");
+    com.ibm.cloud.sdk.core.util.Validator.notNull(builder.target,
+      "target cannot be null");
+    templateId = builder.templateId;
+    templateVersion = builder.templateVersion;
+    targetType = builder.targetType;
+    target = builder.target;
+  }
+
+  /**
+   * New builder.
+   *
+   * @return a CreateAccountSettingsAssignmentOptions builder
+   */
+  public Builder newBuilder() {
+    return new Builder(this);
+  }
+
+  /**
+   * Gets the templateId.
+   *
+   * ID of the template to assign.
+   *
+   * @return the templateId
+   */
+  public String templateId() {
+    return templateId;
+  }
+
+  /**
+   * Gets the templateVersion.
+   *
+   * Version of the template to assign.
+   *
+   * @return the templateVersion
+   */
+  public Long templateVersion() {
+    return templateVersion;
+  }
+
+  /**
+   * Gets the targetType.
+   *
+   * Type of target to deploy to.
+   *
+   * @return the targetType
+   */
+  public String targetType() {
+    return targetType;
+  }
+
+  /**
+   * Gets the target.
+   *
+   * Identifier of target to deploy to.
+   *
+   * @return the target
+   */
+  public String target() {
+    return target;
+  }
+}
+

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/CreateAccountSettingsTemplateOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/CreateAccountSettingsTemplateOptions.java
@@ -1,0 +1,168 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import com.ibm.cloud.sdk.core.service.model.GenericModel;
+
+/**
+ * The createAccountSettingsTemplate options.
+ */
+public class CreateAccountSettingsTemplateOptions extends GenericModel {
+
+  protected String accountId;
+  protected String name;
+  protected String description;
+  protected AccountSettingsComponent accountSettings;
+
+  /**
+   * Builder.
+   */
+  public static class Builder {
+    private String accountId;
+    private String name;
+    private String description;
+    private AccountSettingsComponent accountSettings;
+
+    /**
+     * Instantiates a new Builder from an existing CreateAccountSettingsTemplateOptions instance.
+     *
+     * @param createAccountSettingsTemplateOptions the instance to initialize the Builder with
+     */
+    private Builder(CreateAccountSettingsTemplateOptions createAccountSettingsTemplateOptions) {
+      this.accountId = createAccountSettingsTemplateOptions.accountId;
+      this.name = createAccountSettingsTemplateOptions.name;
+      this.description = createAccountSettingsTemplateOptions.description;
+      this.accountSettings = createAccountSettingsTemplateOptions.accountSettings;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public Builder() {
+    }
+
+    /**
+     * Builds a CreateAccountSettingsTemplateOptions.
+     *
+     * @return the new CreateAccountSettingsTemplateOptions instance
+     */
+    public CreateAccountSettingsTemplateOptions build() {
+      return new CreateAccountSettingsTemplateOptions(this);
+    }
+
+    /**
+     * Set the accountId.
+     *
+     * @param accountId the accountId
+     * @return the CreateAccountSettingsTemplateOptions builder
+     */
+    public Builder accountId(String accountId) {
+      this.accountId = accountId;
+      return this;
+    }
+
+    /**
+     * Set the name.
+     *
+     * @param name the name
+     * @return the CreateAccountSettingsTemplateOptions builder
+     */
+    public Builder name(String name) {
+      this.name = name;
+      return this;
+    }
+
+    /**
+     * Set the description.
+     *
+     * @param description the description
+     * @return the CreateAccountSettingsTemplateOptions builder
+     */
+    public Builder description(String description) {
+      this.description = description;
+      return this;
+    }
+
+    /**
+     * Set the accountSettings.
+     *
+     * @param accountSettings the accountSettings
+     * @return the CreateAccountSettingsTemplateOptions builder
+     */
+    public Builder accountSettings(AccountSettingsComponent accountSettings) {
+      this.accountSettings = accountSettings;
+      return this;
+    }
+  }
+
+  protected CreateAccountSettingsTemplateOptions() { }
+
+  protected CreateAccountSettingsTemplateOptions(Builder builder) {
+    accountId = builder.accountId;
+    name = builder.name;
+    description = builder.description;
+    accountSettings = builder.accountSettings;
+  }
+
+  /**
+   * New builder.
+   *
+   * @return a CreateAccountSettingsTemplateOptions builder
+   */
+  public Builder newBuilder() {
+    return new Builder(this);
+  }
+
+  /**
+   * Gets the accountId.
+   *
+   * ID of the account where the template resides.
+   *
+   * @return the accountId
+   */
+  public String accountId() {
+    return accountId;
+  }
+
+  /**
+   * Gets the name.
+   *
+   * The name of the trusted profile template. This is visible only in the enterprise account.
+   *
+   * @return the name
+   */
+  public String name() {
+    return name;
+  }
+
+  /**
+   * Gets the description.
+   *
+   * The description of the trusted profile template. Describe the template for enterprise account users.
+   *
+   * @return the description
+   */
+  public String description() {
+    return description;
+  }
+
+  /**
+   * Gets the accountSettings.
+   *
+   * @return the accountSettings
+   */
+  public AccountSettingsComponent accountSettings() {
+    return accountSettings;
+  }
+}
+

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/CreateAccountSettingsTemplateVersionOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/CreateAccountSettingsTemplateVersionOptions.java
@@ -1,0 +1,205 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import com.ibm.cloud.sdk.core.service.model.GenericModel;
+
+/**
+ * The createAccountSettingsTemplateVersion options.
+ */
+public class CreateAccountSettingsTemplateVersionOptions extends GenericModel {
+
+  protected String templateId;
+  protected String accountId;
+  protected String name;
+  protected String description;
+  protected AccountSettingsComponent accountSettings;
+
+  /**
+   * Builder.
+   */
+  public static class Builder {
+    private String templateId;
+    private String accountId;
+    private String name;
+    private String description;
+    private AccountSettingsComponent accountSettings;
+
+    /**
+     * Instantiates a new Builder from an existing CreateAccountSettingsTemplateVersionOptions instance.
+     *
+     * @param createAccountSettingsTemplateVersionOptions the instance to initialize the Builder with
+     */
+    private Builder(CreateAccountSettingsTemplateVersionOptions createAccountSettingsTemplateVersionOptions) {
+      this.templateId = createAccountSettingsTemplateVersionOptions.templateId;
+      this.accountId = createAccountSettingsTemplateVersionOptions.accountId;
+      this.name = createAccountSettingsTemplateVersionOptions.name;
+      this.description = createAccountSettingsTemplateVersionOptions.description;
+      this.accountSettings = createAccountSettingsTemplateVersionOptions.accountSettings;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public Builder() {
+    }
+
+    /**
+     * Instantiates a new builder with required properties.
+     *
+     * @param templateId the templateId
+     */
+    public Builder(String templateId) {
+      this.templateId = templateId;
+    }
+
+    /**
+     * Builds a CreateAccountSettingsTemplateVersionOptions.
+     *
+     * @return the new CreateAccountSettingsTemplateVersionOptions instance
+     */
+    public CreateAccountSettingsTemplateVersionOptions build() {
+      return new CreateAccountSettingsTemplateVersionOptions(this);
+    }
+
+    /**
+     * Set the templateId.
+     *
+     * @param templateId the templateId
+     * @return the CreateAccountSettingsTemplateVersionOptions builder
+     */
+    public Builder templateId(String templateId) {
+      this.templateId = templateId;
+      return this;
+    }
+
+    /**
+     * Set the accountId.
+     *
+     * @param accountId the accountId
+     * @return the CreateAccountSettingsTemplateVersionOptions builder
+     */
+    public Builder accountId(String accountId) {
+      this.accountId = accountId;
+      return this;
+    }
+
+    /**
+     * Set the name.
+     *
+     * @param name the name
+     * @return the CreateAccountSettingsTemplateVersionOptions builder
+     */
+    public Builder name(String name) {
+      this.name = name;
+      return this;
+    }
+
+    /**
+     * Set the description.
+     *
+     * @param description the description
+     * @return the CreateAccountSettingsTemplateVersionOptions builder
+     */
+    public Builder description(String description) {
+      this.description = description;
+      return this;
+    }
+
+    /**
+     * Set the accountSettings.
+     *
+     * @param accountSettings the accountSettings
+     * @return the CreateAccountSettingsTemplateVersionOptions builder
+     */
+    public Builder accountSettings(AccountSettingsComponent accountSettings) {
+      this.accountSettings = accountSettings;
+      return this;
+    }
+  }
+
+  protected CreateAccountSettingsTemplateVersionOptions() { }
+
+  protected CreateAccountSettingsTemplateVersionOptions(Builder builder) {
+    com.ibm.cloud.sdk.core.util.Validator.notEmpty(builder.templateId,
+      "templateId cannot be empty");
+    templateId = builder.templateId;
+    accountId = builder.accountId;
+    name = builder.name;
+    description = builder.description;
+    accountSettings = builder.accountSettings;
+  }
+
+  /**
+   * New builder.
+   *
+   * @return a CreateAccountSettingsTemplateVersionOptions builder
+   */
+  public Builder newBuilder() {
+    return new Builder(this);
+  }
+
+  /**
+   * Gets the templateId.
+   *
+   * ID of the account settings template.
+   *
+   * @return the templateId
+   */
+  public String templateId() {
+    return templateId;
+  }
+
+  /**
+   * Gets the accountId.
+   *
+   * ID of the account where the template resides.
+   *
+   * @return the accountId
+   */
+  public String accountId() {
+    return accountId;
+  }
+
+  /**
+   * Gets the name.
+   *
+   * The name of the trusted profile template. This is visible only in the enterprise account.
+   *
+   * @return the name
+   */
+  public String name() {
+    return name;
+  }
+
+  /**
+   * Gets the description.
+   *
+   * The description of the trusted profile template. Describe the template for enterprise account users.
+   *
+   * @return the description
+   */
+  public String description() {
+    return description;
+  }
+
+  /**
+   * Gets the accountSettings.
+   *
+   * @return the accountSettings
+   */
+  public AccountSettingsComponent accountSettings() {
+    return accountSettings;
+  }
+}
+

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/CreateApiKeyOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/CreateApiKeyOptions.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -234,8 +234,7 @@ public class CreateApiKeyOptions extends GenericModel {
    *
    * You can optionally passthrough the API key value for this API key. If passed, NO validation of that apiKey value is
    * done, i.e. the value can be non-URL safe. If omitted, the API key management will create an URL safe opaque API key
-   * value. The value of the API key is checked for uniqueness. Please ensure enough variations when passing in this
-   * value.
+   * value. The value of the API key is checked for uniqueness. Ensure enough variations when passing in this value.
    *
    * @return the apikey
    */

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/CreateClaimRuleOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/CreateClaimRuleOptions.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/CreateLinkOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/CreateLinkOptions.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/CreateProfileLinkRequestLink.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/CreateProfileLinkRequestLink.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/CreateProfileOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/CreateProfileOptions.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/CreateProfileTemplateOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/CreateProfileTemplateOptions.java
@@ -1,0 +1,218 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.ibm.cloud.sdk.core.service.model.GenericModel;
+
+/**
+ * The createProfileTemplate options.
+ */
+public class CreateProfileTemplateOptions extends GenericModel {
+
+  protected String accountId;
+  protected String name;
+  protected String description;
+  protected TemplateProfileComponentRequest profile;
+  protected List<PolicyTemplateReference> policyTemplateReferences;
+
+  /**
+   * Builder.
+   */
+  public static class Builder {
+    private String accountId;
+    private String name;
+    private String description;
+    private TemplateProfileComponentRequest profile;
+    private List<PolicyTemplateReference> policyTemplateReferences;
+
+    /**
+     * Instantiates a new Builder from an existing CreateProfileTemplateOptions instance.
+     *
+     * @param createProfileTemplateOptions the instance to initialize the Builder with
+     */
+    private Builder(CreateProfileTemplateOptions createProfileTemplateOptions) {
+      this.accountId = createProfileTemplateOptions.accountId;
+      this.name = createProfileTemplateOptions.name;
+      this.description = createProfileTemplateOptions.description;
+      this.profile = createProfileTemplateOptions.profile;
+      this.policyTemplateReferences = createProfileTemplateOptions.policyTemplateReferences;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public Builder() {
+    }
+
+    /**
+     * Builds a CreateProfileTemplateOptions.
+     *
+     * @return the new CreateProfileTemplateOptions instance
+     */
+    public CreateProfileTemplateOptions build() {
+      return new CreateProfileTemplateOptions(this);
+    }
+
+    /**
+     * Adds an policyTemplateReferences to policyTemplateReferences.
+     *
+     * @param policyTemplateReferences the new policyTemplateReferences
+     * @return the CreateProfileTemplateOptions builder
+     */
+    public Builder addPolicyTemplateReferences(PolicyTemplateReference policyTemplateReferences) {
+      com.ibm.cloud.sdk.core.util.Validator.notNull(policyTemplateReferences,
+        "policyTemplateReferences cannot be null");
+      if (this.policyTemplateReferences == null) {
+        this.policyTemplateReferences = new ArrayList<PolicyTemplateReference>();
+      }
+      this.policyTemplateReferences.add(policyTemplateReferences);
+      return this;
+    }
+
+    /**
+     * Set the accountId.
+     *
+     * @param accountId the accountId
+     * @return the CreateProfileTemplateOptions builder
+     */
+    public Builder accountId(String accountId) {
+      this.accountId = accountId;
+      return this;
+    }
+
+    /**
+     * Set the name.
+     *
+     * @param name the name
+     * @return the CreateProfileTemplateOptions builder
+     */
+    public Builder name(String name) {
+      this.name = name;
+      return this;
+    }
+
+    /**
+     * Set the description.
+     *
+     * @param description the description
+     * @return the CreateProfileTemplateOptions builder
+     */
+    public Builder description(String description) {
+      this.description = description;
+      return this;
+    }
+
+    /**
+     * Set the profile.
+     *
+     * @param profile the profile
+     * @return the CreateProfileTemplateOptions builder
+     */
+    public Builder profile(TemplateProfileComponentRequest profile) {
+      this.profile = profile;
+      return this;
+    }
+
+    /**
+     * Set the policyTemplateReferences.
+     * Existing policyTemplateReferences will be replaced.
+     *
+     * @param policyTemplateReferences the policyTemplateReferences
+     * @return the CreateProfileTemplateOptions builder
+     */
+    public Builder policyTemplateReferences(List<PolicyTemplateReference> policyTemplateReferences) {
+      this.policyTemplateReferences = policyTemplateReferences;
+      return this;
+    }
+  }
+
+  protected CreateProfileTemplateOptions() { }
+
+  protected CreateProfileTemplateOptions(Builder builder) {
+    accountId = builder.accountId;
+    name = builder.name;
+    description = builder.description;
+    profile = builder.profile;
+    policyTemplateReferences = builder.policyTemplateReferences;
+  }
+
+  /**
+   * New builder.
+   *
+   * @return a CreateProfileTemplateOptions builder
+   */
+  public Builder newBuilder() {
+    return new Builder(this);
+  }
+
+  /**
+   * Gets the accountId.
+   *
+   * ID of the account where the template resides.
+   *
+   * @return the accountId
+   */
+  public String accountId() {
+    return accountId;
+  }
+
+  /**
+   * Gets the name.
+   *
+   * The name of the trusted profile template. This is visible only in the enterprise account. Required field when
+   * creating a new template. Otherwise this field is optional. If the field is included it will change the name value
+   * for all existing versions of the template.
+   *
+   * @return the name
+   */
+  public String name() {
+    return name;
+  }
+
+  /**
+   * Gets the description.
+   *
+   * The description of the trusted profile template. Describe the template for enterprise account users.
+   *
+   * @return the description
+   */
+  public String description() {
+    return description;
+  }
+
+  /**
+   * Gets the profile.
+   *
+   * Input body parameters for the TemplateProfileComponent.
+   *
+   * @return the profile
+   */
+  public TemplateProfileComponentRequest profile() {
+    return profile;
+  }
+
+  /**
+   * Gets the policyTemplateReferences.
+   *
+   * Existing policy templates that you can reference to assign access in the trusted profile component.
+   *
+   * @return the policyTemplateReferences
+   */
+  public List<PolicyTemplateReference> policyTemplateReferences() {
+    return policyTemplateReferences;
+  }
+}
+

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/CreateProfileTemplateVersionOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/CreateProfileTemplateVersionOptions.java
@@ -1,0 +1,255 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.ibm.cloud.sdk.core.service.model.GenericModel;
+
+/**
+ * The createProfileTemplateVersion options.
+ */
+public class CreateProfileTemplateVersionOptions extends GenericModel {
+
+  protected String templateId;
+  protected String accountId;
+  protected String name;
+  protected String description;
+  protected TemplateProfileComponentRequest profile;
+  protected List<PolicyTemplateReference> policyTemplateReferences;
+
+  /**
+   * Builder.
+   */
+  public static class Builder {
+    private String templateId;
+    private String accountId;
+    private String name;
+    private String description;
+    private TemplateProfileComponentRequest profile;
+    private List<PolicyTemplateReference> policyTemplateReferences;
+
+    /**
+     * Instantiates a new Builder from an existing CreateProfileTemplateVersionOptions instance.
+     *
+     * @param createProfileTemplateVersionOptions the instance to initialize the Builder with
+     */
+    private Builder(CreateProfileTemplateVersionOptions createProfileTemplateVersionOptions) {
+      this.templateId = createProfileTemplateVersionOptions.templateId;
+      this.accountId = createProfileTemplateVersionOptions.accountId;
+      this.name = createProfileTemplateVersionOptions.name;
+      this.description = createProfileTemplateVersionOptions.description;
+      this.profile = createProfileTemplateVersionOptions.profile;
+      this.policyTemplateReferences = createProfileTemplateVersionOptions.policyTemplateReferences;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public Builder() {
+    }
+
+    /**
+     * Instantiates a new builder with required properties.
+     *
+     * @param templateId the templateId
+     */
+    public Builder(String templateId) {
+      this.templateId = templateId;
+    }
+
+    /**
+     * Builds a CreateProfileTemplateVersionOptions.
+     *
+     * @return the new CreateProfileTemplateVersionOptions instance
+     */
+    public CreateProfileTemplateVersionOptions build() {
+      return new CreateProfileTemplateVersionOptions(this);
+    }
+
+    /**
+     * Adds an policyTemplateReferences to policyTemplateReferences.
+     *
+     * @param policyTemplateReferences the new policyTemplateReferences
+     * @return the CreateProfileTemplateVersionOptions builder
+     */
+    public Builder addPolicyTemplateReferences(PolicyTemplateReference policyTemplateReferences) {
+      com.ibm.cloud.sdk.core.util.Validator.notNull(policyTemplateReferences,
+        "policyTemplateReferences cannot be null");
+      if (this.policyTemplateReferences == null) {
+        this.policyTemplateReferences = new ArrayList<PolicyTemplateReference>();
+      }
+      this.policyTemplateReferences.add(policyTemplateReferences);
+      return this;
+    }
+
+    /**
+     * Set the templateId.
+     *
+     * @param templateId the templateId
+     * @return the CreateProfileTemplateVersionOptions builder
+     */
+    public Builder templateId(String templateId) {
+      this.templateId = templateId;
+      return this;
+    }
+
+    /**
+     * Set the accountId.
+     *
+     * @param accountId the accountId
+     * @return the CreateProfileTemplateVersionOptions builder
+     */
+    public Builder accountId(String accountId) {
+      this.accountId = accountId;
+      return this;
+    }
+
+    /**
+     * Set the name.
+     *
+     * @param name the name
+     * @return the CreateProfileTemplateVersionOptions builder
+     */
+    public Builder name(String name) {
+      this.name = name;
+      return this;
+    }
+
+    /**
+     * Set the description.
+     *
+     * @param description the description
+     * @return the CreateProfileTemplateVersionOptions builder
+     */
+    public Builder description(String description) {
+      this.description = description;
+      return this;
+    }
+
+    /**
+     * Set the profile.
+     *
+     * @param profile the profile
+     * @return the CreateProfileTemplateVersionOptions builder
+     */
+    public Builder profile(TemplateProfileComponentRequest profile) {
+      this.profile = profile;
+      return this;
+    }
+
+    /**
+     * Set the policyTemplateReferences.
+     * Existing policyTemplateReferences will be replaced.
+     *
+     * @param policyTemplateReferences the policyTemplateReferences
+     * @return the CreateProfileTemplateVersionOptions builder
+     */
+    public Builder policyTemplateReferences(List<PolicyTemplateReference> policyTemplateReferences) {
+      this.policyTemplateReferences = policyTemplateReferences;
+      return this;
+    }
+  }
+
+  protected CreateProfileTemplateVersionOptions() { }
+
+  protected CreateProfileTemplateVersionOptions(Builder builder) {
+    com.ibm.cloud.sdk.core.util.Validator.notEmpty(builder.templateId,
+      "templateId cannot be empty");
+    templateId = builder.templateId;
+    accountId = builder.accountId;
+    name = builder.name;
+    description = builder.description;
+    profile = builder.profile;
+    policyTemplateReferences = builder.policyTemplateReferences;
+  }
+
+  /**
+   * New builder.
+   *
+   * @return a CreateProfileTemplateVersionOptions builder
+   */
+  public Builder newBuilder() {
+    return new Builder(this);
+  }
+
+  /**
+   * Gets the templateId.
+   *
+   * ID of the trusted profile template.
+   *
+   * @return the templateId
+   */
+  public String templateId() {
+    return templateId;
+  }
+
+  /**
+   * Gets the accountId.
+   *
+   * ID of the account where the template resides.
+   *
+   * @return the accountId
+   */
+  public String accountId() {
+    return accountId;
+  }
+
+  /**
+   * Gets the name.
+   *
+   * The name of the trusted profile template. This is visible only in the enterprise account. Required field when
+   * creating a new template. Otherwise this field is optional. If the field is included it will change the name value
+   * for all existing versions of the template.
+   *
+   * @return the name
+   */
+  public String name() {
+    return name;
+  }
+
+  /**
+   * Gets the description.
+   *
+   * The description of the trusted profile template. Describe the template for enterprise account users.
+   *
+   * @return the description
+   */
+  public String description() {
+    return description;
+  }
+
+  /**
+   * Gets the profile.
+   *
+   * Input body parameters for the TemplateProfileComponent.
+   *
+   * @return the profile
+   */
+  public TemplateProfileComponentRequest profile() {
+    return profile;
+  }
+
+  /**
+   * Gets the policyTemplateReferences.
+   *
+   * Existing policy templates that you can reference to assign access in the trusted profile component.
+   *
+   * @return the policyTemplateReferences
+   */
+  public List<PolicyTemplateReference> policyTemplateReferences() {
+    return policyTemplateReferences;
+  }
+}
+

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/CreateReportOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/CreateReportOptions.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -145,7 +145,7 @@ public class CreateReportOptions extends GenericModel {
   /**
    * Gets the duration.
    *
-   * Optional duration of the report. The supported unit of duration is hours.
+   * Optional duration of the report, supported unit of duration is hours.
    *
    * @return the duration
    */

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/CreateServiceIdOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/CreateServiceIdOptions.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/CreateTrustedProfileAssignmentOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/CreateTrustedProfileAssignmentOptions.java
@@ -1,0 +1,203 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import com.ibm.cloud.sdk.core.service.model.GenericModel;
+
+/**
+ * The createTrustedProfileAssignment options.
+ */
+public class CreateTrustedProfileAssignmentOptions extends GenericModel {
+
+  /**
+   * Type of target to deploy to.
+   */
+  public interface TargetType {
+    /** Account. */
+    String ACCOUNT = "Account";
+    /** AccountGroup. */
+    String ACCOUNTGROUP = "AccountGroup";
+  }
+
+  protected String templateId;
+  protected Long templateVersion;
+  protected String targetType;
+  protected String target;
+
+  /**
+   * Builder.
+   */
+  public static class Builder {
+    private String templateId;
+    private Long templateVersion;
+    private String targetType;
+    private String target;
+
+    /**
+     * Instantiates a new Builder from an existing CreateTrustedProfileAssignmentOptions instance.
+     *
+     * @param createTrustedProfileAssignmentOptions the instance to initialize the Builder with
+     */
+    private Builder(CreateTrustedProfileAssignmentOptions createTrustedProfileAssignmentOptions) {
+      this.templateId = createTrustedProfileAssignmentOptions.templateId;
+      this.templateVersion = createTrustedProfileAssignmentOptions.templateVersion;
+      this.targetType = createTrustedProfileAssignmentOptions.targetType;
+      this.target = createTrustedProfileAssignmentOptions.target;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public Builder() {
+    }
+
+    /**
+     * Instantiates a new builder with required properties.
+     *
+     * @param templateId the templateId
+     * @param templateVersion the templateVersion
+     * @param targetType the targetType
+     * @param target the target
+     */
+    public Builder(String templateId, Long templateVersion, String targetType, String target) {
+      this.templateId = templateId;
+      this.templateVersion = templateVersion;
+      this.targetType = targetType;
+      this.target = target;
+    }
+
+    /**
+     * Builds a CreateTrustedProfileAssignmentOptions.
+     *
+     * @return the new CreateTrustedProfileAssignmentOptions instance
+     */
+    public CreateTrustedProfileAssignmentOptions build() {
+      return new CreateTrustedProfileAssignmentOptions(this);
+    }
+
+    /**
+     * Set the templateId.
+     *
+     * @param templateId the templateId
+     * @return the CreateTrustedProfileAssignmentOptions builder
+     */
+    public Builder templateId(String templateId) {
+      this.templateId = templateId;
+      return this;
+    }
+
+    /**
+     * Set the templateVersion.
+     *
+     * @param templateVersion the templateVersion
+     * @return the CreateTrustedProfileAssignmentOptions builder
+     */
+    public Builder templateVersion(long templateVersion) {
+      this.templateVersion = templateVersion;
+      return this;
+    }
+
+    /**
+     * Set the targetType.
+     *
+     * @param targetType the targetType
+     * @return the CreateTrustedProfileAssignmentOptions builder
+     */
+    public Builder targetType(String targetType) {
+      this.targetType = targetType;
+      return this;
+    }
+
+    /**
+     * Set the target.
+     *
+     * @param target the target
+     * @return the CreateTrustedProfileAssignmentOptions builder
+     */
+    public Builder target(String target) {
+      this.target = target;
+      return this;
+    }
+  }
+
+  protected CreateTrustedProfileAssignmentOptions() { }
+
+  protected CreateTrustedProfileAssignmentOptions(Builder builder) {
+    com.ibm.cloud.sdk.core.util.Validator.notNull(builder.templateId,
+      "templateId cannot be null");
+    com.ibm.cloud.sdk.core.util.Validator.notNull(builder.templateVersion,
+      "templateVersion cannot be null");
+    com.ibm.cloud.sdk.core.util.Validator.notNull(builder.targetType,
+      "targetType cannot be null");
+    com.ibm.cloud.sdk.core.util.Validator.notNull(builder.target,
+      "target cannot be null");
+    templateId = builder.templateId;
+    templateVersion = builder.templateVersion;
+    targetType = builder.targetType;
+    target = builder.target;
+  }
+
+  /**
+   * New builder.
+   *
+   * @return a CreateTrustedProfileAssignmentOptions builder
+   */
+  public Builder newBuilder() {
+    return new Builder(this);
+  }
+
+  /**
+   * Gets the templateId.
+   *
+   * ID of the template to assign.
+   *
+   * @return the templateId
+   */
+  public String templateId() {
+    return templateId;
+  }
+
+  /**
+   * Gets the templateVersion.
+   *
+   * Version of the template to assign.
+   *
+   * @return the templateVersion
+   */
+  public Long templateVersion() {
+    return templateVersion;
+  }
+
+  /**
+   * Gets the targetType.
+   *
+   * Type of target to deploy to.
+   *
+   * @return the targetType
+   */
+  public String targetType() {
+    return targetType;
+  }
+
+  /**
+   * Gets the target.
+   *
+   * Identifier of target to deploy to.
+   *
+   * @return the target
+   */
+  public String target() {
+    return target;
+  }
+}
+

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/DeleteAccountSettingsAssignmentOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/DeleteAccountSettingsAssignmentOptions.java
@@ -1,0 +1,103 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import com.ibm.cloud.sdk.core.service.model.GenericModel;
+
+/**
+ * The deleteAccountSettingsAssignment options.
+ */
+public class DeleteAccountSettingsAssignmentOptions extends GenericModel {
+
+  protected String assignmentId;
+
+  /**
+   * Builder.
+   */
+  public static class Builder {
+    private String assignmentId;
+
+    /**
+     * Instantiates a new Builder from an existing DeleteAccountSettingsAssignmentOptions instance.
+     *
+     * @param deleteAccountSettingsAssignmentOptions the instance to initialize the Builder with
+     */
+    private Builder(DeleteAccountSettingsAssignmentOptions deleteAccountSettingsAssignmentOptions) {
+      this.assignmentId = deleteAccountSettingsAssignmentOptions.assignmentId;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public Builder() {
+    }
+
+    /**
+     * Instantiates a new builder with required properties.
+     *
+     * @param assignmentId the assignmentId
+     */
+    public Builder(String assignmentId) {
+      this.assignmentId = assignmentId;
+    }
+
+    /**
+     * Builds a DeleteAccountSettingsAssignmentOptions.
+     *
+     * @return the new DeleteAccountSettingsAssignmentOptions instance
+     */
+    public DeleteAccountSettingsAssignmentOptions build() {
+      return new DeleteAccountSettingsAssignmentOptions(this);
+    }
+
+    /**
+     * Set the assignmentId.
+     *
+     * @param assignmentId the assignmentId
+     * @return the DeleteAccountSettingsAssignmentOptions builder
+     */
+    public Builder assignmentId(String assignmentId) {
+      this.assignmentId = assignmentId;
+      return this;
+    }
+  }
+
+  protected DeleteAccountSettingsAssignmentOptions() { }
+
+  protected DeleteAccountSettingsAssignmentOptions(Builder builder) {
+    com.ibm.cloud.sdk.core.util.Validator.notEmpty(builder.assignmentId,
+      "assignmentId cannot be empty");
+    assignmentId = builder.assignmentId;
+  }
+
+  /**
+   * New builder.
+   *
+   * @return a DeleteAccountSettingsAssignmentOptions builder
+   */
+  public Builder newBuilder() {
+    return new Builder(this);
+  }
+
+  /**
+   * Gets the assignmentId.
+   *
+   * ID of the Assignment Record.
+   *
+   * @return the assignmentId
+   */
+  public String assignmentId() {
+    return assignmentId;
+  }
+}
+

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/DeleteAccountSettingsTemplateVersionOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/DeleteAccountSettingsTemplateVersionOptions.java
@@ -1,0 +1,133 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import com.ibm.cloud.sdk.core.service.model.GenericModel;
+
+/**
+ * The deleteAccountSettingsTemplateVersion options.
+ */
+public class DeleteAccountSettingsTemplateVersionOptions extends GenericModel {
+
+  protected String templateId;
+  protected String version;
+
+  /**
+   * Builder.
+   */
+  public static class Builder {
+    private String templateId;
+    private String version;
+
+    /**
+     * Instantiates a new Builder from an existing DeleteAccountSettingsTemplateVersionOptions instance.
+     *
+     * @param deleteAccountSettingsTemplateVersionOptions the instance to initialize the Builder with
+     */
+    private Builder(DeleteAccountSettingsTemplateVersionOptions deleteAccountSettingsTemplateVersionOptions) {
+      this.templateId = deleteAccountSettingsTemplateVersionOptions.templateId;
+      this.version = deleteAccountSettingsTemplateVersionOptions.version;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public Builder() {
+    }
+
+    /**
+     * Instantiates a new builder with required properties.
+     *
+     * @param templateId the templateId
+     * @param version the version
+     */
+    public Builder(String templateId, String version) {
+      this.templateId = templateId;
+      this.version = version;
+    }
+
+    /**
+     * Builds a DeleteAccountSettingsTemplateVersionOptions.
+     *
+     * @return the new DeleteAccountSettingsTemplateVersionOptions instance
+     */
+    public DeleteAccountSettingsTemplateVersionOptions build() {
+      return new DeleteAccountSettingsTemplateVersionOptions(this);
+    }
+
+    /**
+     * Set the templateId.
+     *
+     * @param templateId the templateId
+     * @return the DeleteAccountSettingsTemplateVersionOptions builder
+     */
+    public Builder templateId(String templateId) {
+      this.templateId = templateId;
+      return this;
+    }
+
+    /**
+     * Set the version.
+     *
+     * @param version the version
+     * @return the DeleteAccountSettingsTemplateVersionOptions builder
+     */
+    public Builder version(String version) {
+      this.version = version;
+      return this;
+    }
+  }
+
+  protected DeleteAccountSettingsTemplateVersionOptions() { }
+
+  protected DeleteAccountSettingsTemplateVersionOptions(Builder builder) {
+    com.ibm.cloud.sdk.core.util.Validator.notEmpty(builder.templateId,
+      "templateId cannot be empty");
+    com.ibm.cloud.sdk.core.util.Validator.notEmpty(builder.version,
+      "version cannot be empty");
+    templateId = builder.templateId;
+    version = builder.version;
+  }
+
+  /**
+   * New builder.
+   *
+   * @return a DeleteAccountSettingsTemplateVersionOptions builder
+   */
+  public Builder newBuilder() {
+    return new Builder(this);
+  }
+
+  /**
+   * Gets the templateId.
+   *
+   * ID of the account settings template.
+   *
+   * @return the templateId
+   */
+  public String templateId() {
+    return templateId;
+  }
+
+  /**
+   * Gets the version.
+   *
+   * Version of the account settings template.
+   *
+   * @return the version
+   */
+  public String version() {
+    return version;
+  }
+}
+

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/DeleteAllVersionsOfAccountSettingsTemplateOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/DeleteAllVersionsOfAccountSettingsTemplateOptions.java
@@ -1,0 +1,103 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import com.ibm.cloud.sdk.core.service.model.GenericModel;
+
+/**
+ * The deleteAllVersionsOfAccountSettingsTemplate options.
+ */
+public class DeleteAllVersionsOfAccountSettingsTemplateOptions extends GenericModel {
+
+  protected String templateId;
+
+  /**
+   * Builder.
+   */
+  public static class Builder {
+    private String templateId;
+
+    /**
+     * Instantiates a new Builder from an existing DeleteAllVersionsOfAccountSettingsTemplateOptions instance.
+     *
+     * @param deleteAllVersionsOfAccountSettingsTemplateOptions the instance to initialize the Builder with
+     */
+    private Builder(DeleteAllVersionsOfAccountSettingsTemplateOptions deleteAllVersionsOfAccountSettingsTemplateOptions) {
+      this.templateId = deleteAllVersionsOfAccountSettingsTemplateOptions.templateId;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public Builder() {
+    }
+
+    /**
+     * Instantiates a new builder with required properties.
+     *
+     * @param templateId the templateId
+     */
+    public Builder(String templateId) {
+      this.templateId = templateId;
+    }
+
+    /**
+     * Builds a DeleteAllVersionsOfAccountSettingsTemplateOptions.
+     *
+     * @return the new DeleteAllVersionsOfAccountSettingsTemplateOptions instance
+     */
+    public DeleteAllVersionsOfAccountSettingsTemplateOptions build() {
+      return new DeleteAllVersionsOfAccountSettingsTemplateOptions(this);
+    }
+
+    /**
+     * Set the templateId.
+     *
+     * @param templateId the templateId
+     * @return the DeleteAllVersionsOfAccountSettingsTemplateOptions builder
+     */
+    public Builder templateId(String templateId) {
+      this.templateId = templateId;
+      return this;
+    }
+  }
+
+  protected DeleteAllVersionsOfAccountSettingsTemplateOptions() { }
+
+  protected DeleteAllVersionsOfAccountSettingsTemplateOptions(Builder builder) {
+    com.ibm.cloud.sdk.core.util.Validator.notEmpty(builder.templateId,
+      "templateId cannot be empty");
+    templateId = builder.templateId;
+  }
+
+  /**
+   * New builder.
+   *
+   * @return a DeleteAllVersionsOfAccountSettingsTemplateOptions builder
+   */
+  public Builder newBuilder() {
+    return new Builder(this);
+  }
+
+  /**
+   * Gets the templateId.
+   *
+   * ID of the account settings template.
+   *
+   * @return the templateId
+   */
+  public String templateId() {
+    return templateId;
+  }
+}
+

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/DeleteAllVersionsOfProfileTemplateOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/DeleteAllVersionsOfProfileTemplateOptions.java
@@ -1,0 +1,103 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import com.ibm.cloud.sdk.core.service.model.GenericModel;
+
+/**
+ * The deleteAllVersionsOfProfileTemplate options.
+ */
+public class DeleteAllVersionsOfProfileTemplateOptions extends GenericModel {
+
+  protected String templateId;
+
+  /**
+   * Builder.
+   */
+  public static class Builder {
+    private String templateId;
+
+    /**
+     * Instantiates a new Builder from an existing DeleteAllVersionsOfProfileTemplateOptions instance.
+     *
+     * @param deleteAllVersionsOfProfileTemplateOptions the instance to initialize the Builder with
+     */
+    private Builder(DeleteAllVersionsOfProfileTemplateOptions deleteAllVersionsOfProfileTemplateOptions) {
+      this.templateId = deleteAllVersionsOfProfileTemplateOptions.templateId;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public Builder() {
+    }
+
+    /**
+     * Instantiates a new builder with required properties.
+     *
+     * @param templateId the templateId
+     */
+    public Builder(String templateId) {
+      this.templateId = templateId;
+    }
+
+    /**
+     * Builds a DeleteAllVersionsOfProfileTemplateOptions.
+     *
+     * @return the new DeleteAllVersionsOfProfileTemplateOptions instance
+     */
+    public DeleteAllVersionsOfProfileTemplateOptions build() {
+      return new DeleteAllVersionsOfProfileTemplateOptions(this);
+    }
+
+    /**
+     * Set the templateId.
+     *
+     * @param templateId the templateId
+     * @return the DeleteAllVersionsOfProfileTemplateOptions builder
+     */
+    public Builder templateId(String templateId) {
+      this.templateId = templateId;
+      return this;
+    }
+  }
+
+  protected DeleteAllVersionsOfProfileTemplateOptions() { }
+
+  protected DeleteAllVersionsOfProfileTemplateOptions(Builder builder) {
+    com.ibm.cloud.sdk.core.util.Validator.notEmpty(builder.templateId,
+      "templateId cannot be empty");
+    templateId = builder.templateId;
+  }
+
+  /**
+   * New builder.
+   *
+   * @return a DeleteAllVersionsOfProfileTemplateOptions builder
+   */
+  public Builder newBuilder() {
+    return new Builder(this);
+  }
+
+  /**
+   * Gets the templateId.
+   *
+   * ID of the trusted profile template.
+   *
+   * @return the templateId
+   */
+  public String templateId() {
+    return templateId;
+  }
+}
+

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/DeleteApiKeyOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/DeleteApiKeyOptions.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/DeleteClaimRuleOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/DeleteClaimRuleOptions.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/DeleteLinkOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/DeleteLinkOptions.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/DeleteProfileOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/DeleteProfileOptions.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/DeleteProfileTemplateVersionOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/DeleteProfileTemplateVersionOptions.java
@@ -1,0 +1,133 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import com.ibm.cloud.sdk.core.service.model.GenericModel;
+
+/**
+ * The deleteProfileTemplateVersion options.
+ */
+public class DeleteProfileTemplateVersionOptions extends GenericModel {
+
+  protected String templateId;
+  protected String version;
+
+  /**
+   * Builder.
+   */
+  public static class Builder {
+    private String templateId;
+    private String version;
+
+    /**
+     * Instantiates a new Builder from an existing DeleteProfileTemplateVersionOptions instance.
+     *
+     * @param deleteProfileTemplateVersionOptions the instance to initialize the Builder with
+     */
+    private Builder(DeleteProfileTemplateVersionOptions deleteProfileTemplateVersionOptions) {
+      this.templateId = deleteProfileTemplateVersionOptions.templateId;
+      this.version = deleteProfileTemplateVersionOptions.version;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public Builder() {
+    }
+
+    /**
+     * Instantiates a new builder with required properties.
+     *
+     * @param templateId the templateId
+     * @param version the version
+     */
+    public Builder(String templateId, String version) {
+      this.templateId = templateId;
+      this.version = version;
+    }
+
+    /**
+     * Builds a DeleteProfileTemplateVersionOptions.
+     *
+     * @return the new DeleteProfileTemplateVersionOptions instance
+     */
+    public DeleteProfileTemplateVersionOptions build() {
+      return new DeleteProfileTemplateVersionOptions(this);
+    }
+
+    /**
+     * Set the templateId.
+     *
+     * @param templateId the templateId
+     * @return the DeleteProfileTemplateVersionOptions builder
+     */
+    public Builder templateId(String templateId) {
+      this.templateId = templateId;
+      return this;
+    }
+
+    /**
+     * Set the version.
+     *
+     * @param version the version
+     * @return the DeleteProfileTemplateVersionOptions builder
+     */
+    public Builder version(String version) {
+      this.version = version;
+      return this;
+    }
+  }
+
+  protected DeleteProfileTemplateVersionOptions() { }
+
+  protected DeleteProfileTemplateVersionOptions(Builder builder) {
+    com.ibm.cloud.sdk.core.util.Validator.notEmpty(builder.templateId,
+      "templateId cannot be empty");
+    com.ibm.cloud.sdk.core.util.Validator.notEmpty(builder.version,
+      "version cannot be empty");
+    templateId = builder.templateId;
+    version = builder.version;
+  }
+
+  /**
+   * New builder.
+   *
+   * @return a DeleteProfileTemplateVersionOptions builder
+   */
+  public Builder newBuilder() {
+    return new Builder(this);
+  }
+
+  /**
+   * Gets the templateId.
+   *
+   * ID of the trusted profile template.
+   *
+   * @return the templateId
+   */
+  public String templateId() {
+    return templateId;
+  }
+
+  /**
+   * Gets the version.
+   *
+   * Version of the Profile Template.
+   *
+   * @return the version
+   */
+  public String version() {
+    return version;
+  }
+}
+

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/DeleteServiceIdOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/DeleteServiceIdOptions.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/DeleteTrustedProfileAssignmentOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/DeleteTrustedProfileAssignmentOptions.java
@@ -1,0 +1,103 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import com.ibm.cloud.sdk.core.service.model.GenericModel;
+
+/**
+ * The deleteTrustedProfileAssignment options.
+ */
+public class DeleteTrustedProfileAssignmentOptions extends GenericModel {
+
+  protected String assignmentId;
+
+  /**
+   * Builder.
+   */
+  public static class Builder {
+    private String assignmentId;
+
+    /**
+     * Instantiates a new Builder from an existing DeleteTrustedProfileAssignmentOptions instance.
+     *
+     * @param deleteTrustedProfileAssignmentOptions the instance to initialize the Builder with
+     */
+    private Builder(DeleteTrustedProfileAssignmentOptions deleteTrustedProfileAssignmentOptions) {
+      this.assignmentId = deleteTrustedProfileAssignmentOptions.assignmentId;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public Builder() {
+    }
+
+    /**
+     * Instantiates a new builder with required properties.
+     *
+     * @param assignmentId the assignmentId
+     */
+    public Builder(String assignmentId) {
+      this.assignmentId = assignmentId;
+    }
+
+    /**
+     * Builds a DeleteTrustedProfileAssignmentOptions.
+     *
+     * @return the new DeleteTrustedProfileAssignmentOptions instance
+     */
+    public DeleteTrustedProfileAssignmentOptions build() {
+      return new DeleteTrustedProfileAssignmentOptions(this);
+    }
+
+    /**
+     * Set the assignmentId.
+     *
+     * @param assignmentId the assignmentId
+     * @return the DeleteTrustedProfileAssignmentOptions builder
+     */
+    public Builder assignmentId(String assignmentId) {
+      this.assignmentId = assignmentId;
+      return this;
+    }
+  }
+
+  protected DeleteTrustedProfileAssignmentOptions() { }
+
+  protected DeleteTrustedProfileAssignmentOptions(Builder builder) {
+    com.ibm.cloud.sdk.core.util.Validator.notEmpty(builder.assignmentId,
+      "assignmentId cannot be empty");
+    assignmentId = builder.assignmentId;
+  }
+
+  /**
+   * New builder.
+   *
+   * @return a DeleteTrustedProfileAssignmentOptions builder
+   */
+  public Builder newBuilder() {
+    return new Builder(this);
+  }
+
+  /**
+   * Gets the assignmentId.
+   *
+   * ID of the Assignment Record.
+   *
+   * @return the assignmentId
+   */
+  public String assignmentId() {
+    return assignmentId;
+  }
+}
+

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/EnityHistoryRecord.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/EnityHistoryRecord.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/EntityActivity.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/EntityActivity.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/Error.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/Error.java
@@ -1,0 +1,77 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import com.google.gson.annotations.SerializedName;
+import com.ibm.cloud.sdk.core.service.model.GenericModel;
+
+/**
+ * Error information.
+ */
+public class Error extends GenericModel {
+
+  protected String code;
+  @SerializedName("message_code")
+  protected String messageCode;
+  protected String message;
+  protected String details;
+
+  protected Error() { }
+
+  /**
+   * Gets the code.
+   *
+   * Error code of the REST Exception.
+   *
+   * @return the code
+   */
+  public String getCode() {
+    return code;
+  }
+
+  /**
+   * Gets the messageCode.
+   *
+   * Error message code of the REST Exception.
+   *
+   * @return the messageCode
+   */
+  public String getMessageCode() {
+    return messageCode;
+  }
+
+  /**
+   * Gets the message.
+   *
+   * Error message of the REST Exception. Error messages are derived base on the input locale of the REST request and
+   * the available Message catalogs. Dynamic fallback to 'us-english' is happening if no message catalog is available
+   * for the provided input locale.
+   *
+   * @return the message
+   */
+  public String getMessage() {
+    return message;
+  }
+
+  /**
+   * Gets the details.
+   *
+   * Error details of the REST Exception.
+   *
+   * @return the details
+   */
+  public String getDetails() {
+    return details;
+  }
+}
+

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ExceptionResponse.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ExceptionResponse.java
@@ -1,0 +1,77 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import java.util.List;
+
+import com.google.gson.annotations.SerializedName;
+import com.ibm.cloud.sdk.core.service.model.GenericModel;
+
+/**
+ * Response body parameters in case of error situations.
+ */
+public class ExceptionResponse extends GenericModel {
+
+  protected ResponseContext context;
+  @SerializedName("status_code")
+  protected String statusCode;
+  protected List<Error> errors;
+  protected String trace;
+
+  protected ExceptionResponse() { }
+
+  /**
+   * Gets the context.
+   *
+   * Context with key properties for problem determination.
+   *
+   * @return the context
+   */
+  public ResponseContext getContext() {
+    return context;
+  }
+
+  /**
+   * Gets the statusCode.
+   *
+   * Error message code of the REST Exception.
+   *
+   * @return the statusCode
+   */
+  public String getStatusCode() {
+    return statusCode;
+  }
+
+  /**
+   * Gets the errors.
+   *
+   * List of errors that occured.
+   *
+   * @return the errors
+   */
+  public List<Error> getErrors() {
+    return errors;
+  }
+
+  /**
+   * Gets the trace.
+   *
+   * Unique ID of the requst.
+   *
+   * @return the trace
+   */
+  public String getTrace() {
+    return trace;
+  }
+}
+

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/GetAccountSettingsAssignmentOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/GetAccountSettingsAssignmentOptions.java
@@ -1,0 +1,129 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import com.ibm.cloud.sdk.core.service.model.GenericModel;
+
+/**
+ * The getAccountSettingsAssignment options.
+ */
+public class GetAccountSettingsAssignmentOptions extends GenericModel {
+
+  protected String assignmentId;
+  protected Boolean includeHistory;
+
+  /**
+   * Builder.
+   */
+  public static class Builder {
+    private String assignmentId;
+    private Boolean includeHistory;
+
+    /**
+     * Instantiates a new Builder from an existing GetAccountSettingsAssignmentOptions instance.
+     *
+     * @param getAccountSettingsAssignmentOptions the instance to initialize the Builder with
+     */
+    private Builder(GetAccountSettingsAssignmentOptions getAccountSettingsAssignmentOptions) {
+      this.assignmentId = getAccountSettingsAssignmentOptions.assignmentId;
+      this.includeHistory = getAccountSettingsAssignmentOptions.includeHistory;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public Builder() {
+    }
+
+    /**
+     * Instantiates a new builder with required properties.
+     *
+     * @param assignmentId the assignmentId
+     */
+    public Builder(String assignmentId) {
+      this.assignmentId = assignmentId;
+    }
+
+    /**
+     * Builds a GetAccountSettingsAssignmentOptions.
+     *
+     * @return the new GetAccountSettingsAssignmentOptions instance
+     */
+    public GetAccountSettingsAssignmentOptions build() {
+      return new GetAccountSettingsAssignmentOptions(this);
+    }
+
+    /**
+     * Set the assignmentId.
+     *
+     * @param assignmentId the assignmentId
+     * @return the GetAccountSettingsAssignmentOptions builder
+     */
+    public Builder assignmentId(String assignmentId) {
+      this.assignmentId = assignmentId;
+      return this;
+    }
+
+    /**
+     * Set the includeHistory.
+     *
+     * @param includeHistory the includeHistory
+     * @return the GetAccountSettingsAssignmentOptions builder
+     */
+    public Builder includeHistory(Boolean includeHistory) {
+      this.includeHistory = includeHistory;
+      return this;
+    }
+  }
+
+  protected GetAccountSettingsAssignmentOptions() { }
+
+  protected GetAccountSettingsAssignmentOptions(Builder builder) {
+    com.ibm.cloud.sdk.core.util.Validator.notEmpty(builder.assignmentId,
+      "assignmentId cannot be empty");
+    assignmentId = builder.assignmentId;
+    includeHistory = builder.includeHistory;
+  }
+
+  /**
+   * New builder.
+   *
+   * @return a GetAccountSettingsAssignmentOptions builder
+   */
+  public Builder newBuilder() {
+    return new Builder(this);
+  }
+
+  /**
+   * Gets the assignmentId.
+   *
+   * ID of the Assignment Record.
+   *
+   * @return the assignmentId
+   */
+  public String assignmentId() {
+    return assignmentId;
+  }
+
+  /**
+   * Gets the includeHistory.
+   *
+   * Defines if the entity history is included in the response.
+   *
+   * @return the includeHistory
+   */
+  public Boolean includeHistory() {
+    return includeHistory;
+  }
+}
+

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/GetAccountSettingsOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/GetAccountSettingsOptions.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/GetAccountSettingsTemplateVersionOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/GetAccountSettingsTemplateVersionOptions.java
@@ -1,0 +1,159 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import com.ibm.cloud.sdk.core.service.model.GenericModel;
+
+/**
+ * The getAccountSettingsTemplateVersion options.
+ */
+public class GetAccountSettingsTemplateVersionOptions extends GenericModel {
+
+  protected String templateId;
+  protected String version;
+  protected Boolean includeHistory;
+
+  /**
+   * Builder.
+   */
+  public static class Builder {
+    private String templateId;
+    private String version;
+    private Boolean includeHistory;
+
+    /**
+     * Instantiates a new Builder from an existing GetAccountSettingsTemplateVersionOptions instance.
+     *
+     * @param getAccountSettingsTemplateVersionOptions the instance to initialize the Builder with
+     */
+    private Builder(GetAccountSettingsTemplateVersionOptions getAccountSettingsTemplateVersionOptions) {
+      this.templateId = getAccountSettingsTemplateVersionOptions.templateId;
+      this.version = getAccountSettingsTemplateVersionOptions.version;
+      this.includeHistory = getAccountSettingsTemplateVersionOptions.includeHistory;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public Builder() {
+    }
+
+    /**
+     * Instantiates a new builder with required properties.
+     *
+     * @param templateId the templateId
+     * @param version the version
+     */
+    public Builder(String templateId, String version) {
+      this.templateId = templateId;
+      this.version = version;
+    }
+
+    /**
+     * Builds a GetAccountSettingsTemplateVersionOptions.
+     *
+     * @return the new GetAccountSettingsTemplateVersionOptions instance
+     */
+    public GetAccountSettingsTemplateVersionOptions build() {
+      return new GetAccountSettingsTemplateVersionOptions(this);
+    }
+
+    /**
+     * Set the templateId.
+     *
+     * @param templateId the templateId
+     * @return the GetAccountSettingsTemplateVersionOptions builder
+     */
+    public Builder templateId(String templateId) {
+      this.templateId = templateId;
+      return this;
+    }
+
+    /**
+     * Set the version.
+     *
+     * @param version the version
+     * @return the GetAccountSettingsTemplateVersionOptions builder
+     */
+    public Builder version(String version) {
+      this.version = version;
+      return this;
+    }
+
+    /**
+     * Set the includeHistory.
+     *
+     * @param includeHistory the includeHistory
+     * @return the GetAccountSettingsTemplateVersionOptions builder
+     */
+    public Builder includeHistory(Boolean includeHistory) {
+      this.includeHistory = includeHistory;
+      return this;
+    }
+  }
+
+  protected GetAccountSettingsTemplateVersionOptions() { }
+
+  protected GetAccountSettingsTemplateVersionOptions(Builder builder) {
+    com.ibm.cloud.sdk.core.util.Validator.notEmpty(builder.templateId,
+      "templateId cannot be empty");
+    com.ibm.cloud.sdk.core.util.Validator.notEmpty(builder.version,
+      "version cannot be empty");
+    templateId = builder.templateId;
+    version = builder.version;
+    includeHistory = builder.includeHistory;
+  }
+
+  /**
+   * New builder.
+   *
+   * @return a GetAccountSettingsTemplateVersionOptions builder
+   */
+  public Builder newBuilder() {
+    return new Builder(this);
+  }
+
+  /**
+   * Gets the templateId.
+   *
+   * ID of the account settings template.
+   *
+   * @return the templateId
+   */
+  public String templateId() {
+    return templateId;
+  }
+
+  /**
+   * Gets the version.
+   *
+   * Version of the account settings template.
+   *
+   * @return the version
+   */
+  public String version() {
+    return version;
+  }
+
+  /**
+   * Gets the includeHistory.
+   *
+   * Defines if the entity history is included in the response.
+   *
+   * @return the includeHistory
+   */
+  public Boolean includeHistory() {
+    return includeHistory;
+  }
+}
+

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/GetApiKeyOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/GetApiKeyOptions.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -145,7 +145,7 @@ public class GetApiKeyOptions extends GenericModel {
    * Gets the includeActivity.
    *
    * Defines if the entity's activity is included in the response. Retrieving activity data is an expensive operation,
-   * so please only request this when needed.
+   * so only request this when needed.
    *
    * @return the includeActivity
    */

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/GetApiKeysDetailsOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/GetApiKeysDetailsOptions.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/GetClaimRuleOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/GetClaimRuleOptions.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/GetLatestAccountSettingsTemplateVersionOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/GetLatestAccountSettingsTemplateVersionOptions.java
@@ -1,0 +1,129 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import com.ibm.cloud.sdk.core.service.model.GenericModel;
+
+/**
+ * The getLatestAccountSettingsTemplateVersion options.
+ */
+public class GetLatestAccountSettingsTemplateVersionOptions extends GenericModel {
+
+  protected String templateId;
+  protected Boolean includeHistory;
+
+  /**
+   * Builder.
+   */
+  public static class Builder {
+    private String templateId;
+    private Boolean includeHistory;
+
+    /**
+     * Instantiates a new Builder from an existing GetLatestAccountSettingsTemplateVersionOptions instance.
+     *
+     * @param getLatestAccountSettingsTemplateVersionOptions the instance to initialize the Builder with
+     */
+    private Builder(GetLatestAccountSettingsTemplateVersionOptions getLatestAccountSettingsTemplateVersionOptions) {
+      this.templateId = getLatestAccountSettingsTemplateVersionOptions.templateId;
+      this.includeHistory = getLatestAccountSettingsTemplateVersionOptions.includeHistory;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public Builder() {
+    }
+
+    /**
+     * Instantiates a new builder with required properties.
+     *
+     * @param templateId the templateId
+     */
+    public Builder(String templateId) {
+      this.templateId = templateId;
+    }
+
+    /**
+     * Builds a GetLatestAccountSettingsTemplateVersionOptions.
+     *
+     * @return the new GetLatestAccountSettingsTemplateVersionOptions instance
+     */
+    public GetLatestAccountSettingsTemplateVersionOptions build() {
+      return new GetLatestAccountSettingsTemplateVersionOptions(this);
+    }
+
+    /**
+     * Set the templateId.
+     *
+     * @param templateId the templateId
+     * @return the GetLatestAccountSettingsTemplateVersionOptions builder
+     */
+    public Builder templateId(String templateId) {
+      this.templateId = templateId;
+      return this;
+    }
+
+    /**
+     * Set the includeHistory.
+     *
+     * @param includeHistory the includeHistory
+     * @return the GetLatestAccountSettingsTemplateVersionOptions builder
+     */
+    public Builder includeHistory(Boolean includeHistory) {
+      this.includeHistory = includeHistory;
+      return this;
+    }
+  }
+
+  protected GetLatestAccountSettingsTemplateVersionOptions() { }
+
+  protected GetLatestAccountSettingsTemplateVersionOptions(Builder builder) {
+    com.ibm.cloud.sdk.core.util.Validator.notEmpty(builder.templateId,
+      "templateId cannot be empty");
+    templateId = builder.templateId;
+    includeHistory = builder.includeHistory;
+  }
+
+  /**
+   * New builder.
+   *
+   * @return a GetLatestAccountSettingsTemplateVersionOptions builder
+   */
+  public Builder newBuilder() {
+    return new Builder(this);
+  }
+
+  /**
+   * Gets the templateId.
+   *
+   * ID of the account settings template.
+   *
+   * @return the templateId
+   */
+  public String templateId() {
+    return templateId;
+  }
+
+  /**
+   * Gets the includeHistory.
+   *
+   * Defines if the entity history is included in the response.
+   *
+   * @return the includeHistory
+   */
+  public Boolean includeHistory() {
+    return includeHistory;
+  }
+}
+

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/GetLatestProfileTemplateVersionOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/GetLatestProfileTemplateVersionOptions.java
@@ -1,0 +1,129 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import com.ibm.cloud.sdk.core.service.model.GenericModel;
+
+/**
+ * The getLatestProfileTemplateVersion options.
+ */
+public class GetLatestProfileTemplateVersionOptions extends GenericModel {
+
+  protected String templateId;
+  protected Boolean includeHistory;
+
+  /**
+   * Builder.
+   */
+  public static class Builder {
+    private String templateId;
+    private Boolean includeHistory;
+
+    /**
+     * Instantiates a new Builder from an existing GetLatestProfileTemplateVersionOptions instance.
+     *
+     * @param getLatestProfileTemplateVersionOptions the instance to initialize the Builder with
+     */
+    private Builder(GetLatestProfileTemplateVersionOptions getLatestProfileTemplateVersionOptions) {
+      this.templateId = getLatestProfileTemplateVersionOptions.templateId;
+      this.includeHistory = getLatestProfileTemplateVersionOptions.includeHistory;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public Builder() {
+    }
+
+    /**
+     * Instantiates a new builder with required properties.
+     *
+     * @param templateId the templateId
+     */
+    public Builder(String templateId) {
+      this.templateId = templateId;
+    }
+
+    /**
+     * Builds a GetLatestProfileTemplateVersionOptions.
+     *
+     * @return the new GetLatestProfileTemplateVersionOptions instance
+     */
+    public GetLatestProfileTemplateVersionOptions build() {
+      return new GetLatestProfileTemplateVersionOptions(this);
+    }
+
+    /**
+     * Set the templateId.
+     *
+     * @param templateId the templateId
+     * @return the GetLatestProfileTemplateVersionOptions builder
+     */
+    public Builder templateId(String templateId) {
+      this.templateId = templateId;
+      return this;
+    }
+
+    /**
+     * Set the includeHistory.
+     *
+     * @param includeHistory the includeHistory
+     * @return the GetLatestProfileTemplateVersionOptions builder
+     */
+    public Builder includeHistory(Boolean includeHistory) {
+      this.includeHistory = includeHistory;
+      return this;
+    }
+  }
+
+  protected GetLatestProfileTemplateVersionOptions() { }
+
+  protected GetLatestProfileTemplateVersionOptions(Builder builder) {
+    com.ibm.cloud.sdk.core.util.Validator.notEmpty(builder.templateId,
+      "templateId cannot be empty");
+    templateId = builder.templateId;
+    includeHistory = builder.includeHistory;
+  }
+
+  /**
+   * New builder.
+   *
+   * @return a GetLatestProfileTemplateVersionOptions builder
+   */
+  public Builder newBuilder() {
+    return new Builder(this);
+  }
+
+  /**
+   * Gets the templateId.
+   *
+   * ID of the trusted profile template.
+   *
+   * @return the templateId
+   */
+  public String templateId() {
+    return templateId;
+  }
+
+  /**
+   * Gets the includeHistory.
+   *
+   * Defines if the entity history is included in the response.
+   *
+   * @return the includeHistory
+   */
+  public Boolean includeHistory() {
+    return includeHistory;
+  }
+}
+

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/GetLatestTemplateVersionOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/GetLatestTemplateVersionOptions.java
@@ -1,0 +1,129 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import com.ibm.cloud.sdk.core.service.model.GenericModel;
+
+/**
+ * The getLatestTemplateVersion options.
+ */
+public class GetLatestTemplateVersionOptions extends GenericModel {
+
+  protected String templateId;
+  protected Boolean includeHistory;
+
+  /**
+   * Builder.
+   */
+  public static class Builder {
+    private String templateId;
+    private Boolean includeHistory;
+
+    /**
+     * Instantiates a new Builder from an existing GetLatestTemplateVersionOptions instance.
+     *
+     * @param getLatestTemplateVersionOptions the instance to initialize the Builder with
+     */
+    private Builder(GetLatestTemplateVersionOptions getLatestTemplateVersionOptions) {
+      this.templateId = getLatestTemplateVersionOptions.templateId;
+      this.includeHistory = getLatestTemplateVersionOptions.includeHistory;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public Builder() {
+    }
+
+    /**
+     * Instantiates a new builder with required properties.
+     *
+     * @param templateId the templateId
+     */
+    public Builder(String templateId) {
+      this.templateId = templateId;
+    }
+
+    /**
+     * Builds a GetLatestTemplateVersionOptions.
+     *
+     * @return the new GetLatestTemplateVersionOptions instance
+     */
+    public GetLatestTemplateVersionOptions build() {
+      return new GetLatestTemplateVersionOptions(this);
+    }
+
+    /**
+     * Set the templateId.
+     *
+     * @param templateId the templateId
+     * @return the GetLatestTemplateVersionOptions builder
+     */
+    public Builder templateId(String templateId) {
+      this.templateId = templateId;
+      return this;
+    }
+
+    /**
+     * Set the includeHistory.
+     *
+     * @param includeHistory the includeHistory
+     * @return the GetLatestTemplateVersionOptions builder
+     */
+    public Builder includeHistory(Boolean includeHistory) {
+      this.includeHistory = includeHistory;
+      return this;
+    }
+  }
+
+  protected GetLatestTemplateVersionOptions() { }
+
+  protected GetLatestTemplateVersionOptions(Builder builder) {
+    com.ibm.cloud.sdk.core.util.Validator.notEmpty(builder.templateId,
+      "templateId cannot be empty");
+    templateId = builder.templateId;
+    includeHistory = builder.includeHistory;
+  }
+
+  /**
+   * New builder.
+   *
+   * @return a GetLatestTemplateVersionOptions builder
+   */
+  public Builder newBuilder() {
+    return new Builder(this);
+  }
+
+  /**
+   * Gets the templateId.
+   *
+   * ID of the trusted profile template.
+   *
+   * @return the templateId
+   */
+  public String templateId() {
+    return templateId;
+  }
+
+  /**
+   * Gets the includeHistory.
+   *
+   * Defines if the entity history is included in the response.
+   *
+   * @return the includeHistory
+   */
+  public Boolean includeHistory() {
+    return includeHistory;
+  }
+}
+

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/GetLinkOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/GetLinkOptions.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/GetProfileOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/GetProfileOptions.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -119,7 +119,7 @@ public class GetProfileOptions extends GenericModel {
    * Gets the includeActivity.
    *
    * Defines if the entity's activity is included in the response. Retrieving activity data is an expensive operation,
-   * so please only request this when needed.
+   * so only request this when needed.
    *
    * @return the includeActivity
    */

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/GetProfileTemplateVersionOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/GetProfileTemplateVersionOptions.java
@@ -1,0 +1,159 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import com.ibm.cloud.sdk.core.service.model.GenericModel;
+
+/**
+ * The getProfileTemplateVersion options.
+ */
+public class GetProfileTemplateVersionOptions extends GenericModel {
+
+  protected String templateId;
+  protected String version;
+  protected Boolean includeHistory;
+
+  /**
+   * Builder.
+   */
+  public static class Builder {
+    private String templateId;
+    private String version;
+    private Boolean includeHistory;
+
+    /**
+     * Instantiates a new Builder from an existing GetProfileTemplateVersionOptions instance.
+     *
+     * @param getProfileTemplateVersionOptions the instance to initialize the Builder with
+     */
+    private Builder(GetProfileTemplateVersionOptions getProfileTemplateVersionOptions) {
+      this.templateId = getProfileTemplateVersionOptions.templateId;
+      this.version = getProfileTemplateVersionOptions.version;
+      this.includeHistory = getProfileTemplateVersionOptions.includeHistory;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public Builder() {
+    }
+
+    /**
+     * Instantiates a new builder with required properties.
+     *
+     * @param templateId the templateId
+     * @param version the version
+     */
+    public Builder(String templateId, String version) {
+      this.templateId = templateId;
+      this.version = version;
+    }
+
+    /**
+     * Builds a GetProfileTemplateVersionOptions.
+     *
+     * @return the new GetProfileTemplateVersionOptions instance
+     */
+    public GetProfileTemplateVersionOptions build() {
+      return new GetProfileTemplateVersionOptions(this);
+    }
+
+    /**
+     * Set the templateId.
+     *
+     * @param templateId the templateId
+     * @return the GetProfileTemplateVersionOptions builder
+     */
+    public Builder templateId(String templateId) {
+      this.templateId = templateId;
+      return this;
+    }
+
+    /**
+     * Set the version.
+     *
+     * @param version the version
+     * @return the GetProfileTemplateVersionOptions builder
+     */
+    public Builder version(String version) {
+      this.version = version;
+      return this;
+    }
+
+    /**
+     * Set the includeHistory.
+     *
+     * @param includeHistory the includeHistory
+     * @return the GetProfileTemplateVersionOptions builder
+     */
+    public Builder includeHistory(Boolean includeHistory) {
+      this.includeHistory = includeHistory;
+      return this;
+    }
+  }
+
+  protected GetProfileTemplateVersionOptions() { }
+
+  protected GetProfileTemplateVersionOptions(Builder builder) {
+    com.ibm.cloud.sdk.core.util.Validator.notEmpty(builder.templateId,
+      "templateId cannot be empty");
+    com.ibm.cloud.sdk.core.util.Validator.notEmpty(builder.version,
+      "version cannot be empty");
+    templateId = builder.templateId;
+    version = builder.version;
+    includeHistory = builder.includeHistory;
+  }
+
+  /**
+   * New builder.
+   *
+   * @return a GetProfileTemplateVersionOptions builder
+   */
+  public Builder newBuilder() {
+    return new Builder(this);
+  }
+
+  /**
+   * Gets the templateId.
+   *
+   * ID of the trusted profile template.
+   *
+   * @return the templateId
+   */
+  public String templateId() {
+    return templateId;
+  }
+
+  /**
+   * Gets the version.
+   *
+   * Version of the Profile Template.
+   *
+   * @return the version
+   */
+  public String version() {
+    return version;
+  }
+
+  /**
+   * Gets the includeHistory.
+   *
+   * Defines if the entity history is included in the response.
+   *
+   * @return the includeHistory
+   */
+  public Boolean includeHistory() {
+    return includeHistory;
+  }
+}
+

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/GetReportOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/GetReportOptions.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/GetServiceIdOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/GetServiceIdOptions.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -145,7 +145,7 @@ public class GetServiceIdOptions extends GenericModel {
    * Gets the includeActivity.
    *
    * Defines if the entity's activity is included in the response. Retrieving activity data is an expensive operation,
-   * so please only request this when needed.
+   * so only request this when needed.
    *
    * @return the includeActivity
    */

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/GetTrustedProfileAssignmentOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/GetTrustedProfileAssignmentOptions.java
@@ -1,0 +1,129 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import com.ibm.cloud.sdk.core.service.model.GenericModel;
+
+/**
+ * The getTrustedProfileAssignment options.
+ */
+public class GetTrustedProfileAssignmentOptions extends GenericModel {
+
+  protected String assignmentId;
+  protected Boolean includeHistory;
+
+  /**
+   * Builder.
+   */
+  public static class Builder {
+    private String assignmentId;
+    private Boolean includeHistory;
+
+    /**
+     * Instantiates a new Builder from an existing GetTrustedProfileAssignmentOptions instance.
+     *
+     * @param getTrustedProfileAssignmentOptions the instance to initialize the Builder with
+     */
+    private Builder(GetTrustedProfileAssignmentOptions getTrustedProfileAssignmentOptions) {
+      this.assignmentId = getTrustedProfileAssignmentOptions.assignmentId;
+      this.includeHistory = getTrustedProfileAssignmentOptions.includeHistory;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public Builder() {
+    }
+
+    /**
+     * Instantiates a new builder with required properties.
+     *
+     * @param assignmentId the assignmentId
+     */
+    public Builder(String assignmentId) {
+      this.assignmentId = assignmentId;
+    }
+
+    /**
+     * Builds a GetTrustedProfileAssignmentOptions.
+     *
+     * @return the new GetTrustedProfileAssignmentOptions instance
+     */
+    public GetTrustedProfileAssignmentOptions build() {
+      return new GetTrustedProfileAssignmentOptions(this);
+    }
+
+    /**
+     * Set the assignmentId.
+     *
+     * @param assignmentId the assignmentId
+     * @return the GetTrustedProfileAssignmentOptions builder
+     */
+    public Builder assignmentId(String assignmentId) {
+      this.assignmentId = assignmentId;
+      return this;
+    }
+
+    /**
+     * Set the includeHistory.
+     *
+     * @param includeHistory the includeHistory
+     * @return the GetTrustedProfileAssignmentOptions builder
+     */
+    public Builder includeHistory(Boolean includeHistory) {
+      this.includeHistory = includeHistory;
+      return this;
+    }
+  }
+
+  protected GetTrustedProfileAssignmentOptions() { }
+
+  protected GetTrustedProfileAssignmentOptions(Builder builder) {
+    com.ibm.cloud.sdk.core.util.Validator.notEmpty(builder.assignmentId,
+      "assignmentId cannot be empty");
+    assignmentId = builder.assignmentId;
+    includeHistory = builder.includeHistory;
+  }
+
+  /**
+   * New builder.
+   *
+   * @return a GetTrustedProfileAssignmentOptions builder
+   */
+  public Builder newBuilder() {
+    return new Builder(this);
+  }
+
+  /**
+   * Gets the assignmentId.
+   *
+   * ID of the Assignment Record.
+   *
+   * @return the assignmentId
+   */
+  public String assignmentId() {
+    return assignmentId;
+  }
+
+  /**
+   * Gets the includeHistory.
+   *
+   * Defines if the entity history is included in the response.
+   *
+   * @return the includeHistory
+   */
+  public Boolean includeHistory() {
+    return includeHistory;
+  }
+}
+

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ListAccountSettingsAssignmentsOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ListAccountSettingsAssignmentsOptions.java
@@ -1,0 +1,358 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import com.ibm.cloud.sdk.core.service.model.GenericModel;
+
+/**
+ * The listAccountSettingsAssignments options.
+ */
+public class ListAccountSettingsAssignmentsOptions extends GenericModel {
+
+  /**
+   * Filter results by the assignment's target type.
+   */
+  public interface TargetType {
+    /** Account. */
+    String ACCOUNT = "Account";
+    /** AccountGroup. */
+    String ACCOUNTGROUP = "AccountGroup";
+  }
+
+  /**
+   * If specified, the items are sorted by the value of this property.
+   */
+  public interface Sort {
+    /** template_id. */
+    String TEMPLATE_ID = "template_id";
+    /** created_at. */
+    String CREATED_AT = "created_at";
+    /** last_modified_at. */
+    String LAST_MODIFIED_AT = "last_modified_at";
+  }
+
+  /**
+   * Sort order.
+   */
+  public interface Order {
+    /** asc. */
+    String ASC = "asc";
+    /** desc. */
+    String DESC = "desc";
+  }
+
+  protected String accountId;
+  protected String templateId;
+  protected String templateVersion;
+  protected String target;
+  protected String targetType;
+  protected Long limit;
+  protected String pagetoken;
+  protected String sort;
+  protected String order;
+  protected Boolean includeHistory;
+
+  /**
+   * Builder.
+   */
+  public static class Builder {
+    private String accountId;
+    private String templateId;
+    private String templateVersion;
+    private String target;
+    private String targetType;
+    private Long limit;
+    private String pagetoken;
+    private String sort;
+    private String order;
+    private Boolean includeHistory;
+
+    /**
+     * Instantiates a new Builder from an existing ListAccountSettingsAssignmentsOptions instance.
+     *
+     * @param listAccountSettingsAssignmentsOptions the instance to initialize the Builder with
+     */
+    private Builder(ListAccountSettingsAssignmentsOptions listAccountSettingsAssignmentsOptions) {
+      this.accountId = listAccountSettingsAssignmentsOptions.accountId;
+      this.templateId = listAccountSettingsAssignmentsOptions.templateId;
+      this.templateVersion = listAccountSettingsAssignmentsOptions.templateVersion;
+      this.target = listAccountSettingsAssignmentsOptions.target;
+      this.targetType = listAccountSettingsAssignmentsOptions.targetType;
+      this.limit = listAccountSettingsAssignmentsOptions.limit;
+      this.pagetoken = listAccountSettingsAssignmentsOptions.pagetoken;
+      this.sort = listAccountSettingsAssignmentsOptions.sort;
+      this.order = listAccountSettingsAssignmentsOptions.order;
+      this.includeHistory = listAccountSettingsAssignmentsOptions.includeHistory;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public Builder() {
+    }
+
+    /**
+     * Builds a ListAccountSettingsAssignmentsOptions.
+     *
+     * @return the new ListAccountSettingsAssignmentsOptions instance
+     */
+    public ListAccountSettingsAssignmentsOptions build() {
+      return new ListAccountSettingsAssignmentsOptions(this);
+    }
+
+    /**
+     * Set the accountId.
+     *
+     * @param accountId the accountId
+     * @return the ListAccountSettingsAssignmentsOptions builder
+     */
+    public Builder accountId(String accountId) {
+      this.accountId = accountId;
+      return this;
+    }
+
+    /**
+     * Set the templateId.
+     *
+     * @param templateId the templateId
+     * @return the ListAccountSettingsAssignmentsOptions builder
+     */
+    public Builder templateId(String templateId) {
+      this.templateId = templateId;
+      return this;
+    }
+
+    /**
+     * Set the templateVersion.
+     *
+     * @param templateVersion the templateVersion
+     * @return the ListAccountSettingsAssignmentsOptions builder
+     */
+    public Builder templateVersion(String templateVersion) {
+      this.templateVersion = templateVersion;
+      return this;
+    }
+
+    /**
+     * Set the target.
+     *
+     * @param target the target
+     * @return the ListAccountSettingsAssignmentsOptions builder
+     */
+    public Builder target(String target) {
+      this.target = target;
+      return this;
+    }
+
+    /**
+     * Set the targetType.
+     *
+     * @param targetType the targetType
+     * @return the ListAccountSettingsAssignmentsOptions builder
+     */
+    public Builder targetType(String targetType) {
+      this.targetType = targetType;
+      return this;
+    }
+
+    /**
+     * Set the limit.
+     *
+     * @param limit the limit
+     * @return the ListAccountSettingsAssignmentsOptions builder
+     */
+    public Builder limit(long limit) {
+      this.limit = limit;
+      return this;
+    }
+
+    /**
+     * Set the pagetoken.
+     *
+     * @param pagetoken the pagetoken
+     * @return the ListAccountSettingsAssignmentsOptions builder
+     */
+    public Builder pagetoken(String pagetoken) {
+      this.pagetoken = pagetoken;
+      return this;
+    }
+
+    /**
+     * Set the sort.
+     *
+     * @param sort the sort
+     * @return the ListAccountSettingsAssignmentsOptions builder
+     */
+    public Builder sort(String sort) {
+      this.sort = sort;
+      return this;
+    }
+
+    /**
+     * Set the order.
+     *
+     * @param order the order
+     * @return the ListAccountSettingsAssignmentsOptions builder
+     */
+    public Builder order(String order) {
+      this.order = order;
+      return this;
+    }
+
+    /**
+     * Set the includeHistory.
+     *
+     * @param includeHistory the includeHistory
+     * @return the ListAccountSettingsAssignmentsOptions builder
+     */
+    public Builder includeHistory(Boolean includeHistory) {
+      this.includeHistory = includeHistory;
+      return this;
+    }
+  }
+
+  protected ListAccountSettingsAssignmentsOptions() { }
+
+  protected ListAccountSettingsAssignmentsOptions(Builder builder) {
+    accountId = builder.accountId;
+    templateId = builder.templateId;
+    templateVersion = builder.templateVersion;
+    target = builder.target;
+    targetType = builder.targetType;
+    limit = builder.limit;
+    pagetoken = builder.pagetoken;
+    sort = builder.sort;
+    order = builder.order;
+    includeHistory = builder.includeHistory;
+  }
+
+  /**
+   * New builder.
+   *
+   * @return a ListAccountSettingsAssignmentsOptions builder
+   */
+  public Builder newBuilder() {
+    return new Builder(this);
+  }
+
+  /**
+   * Gets the accountId.
+   *
+   * Account ID of the Assignments to query. This parameter is required unless using a pagetoken.
+   *
+   * @return the accountId
+   */
+  public String accountId() {
+    return accountId;
+  }
+
+  /**
+   * Gets the templateId.
+   *
+   * Filter results by Template Id.
+   *
+   * @return the templateId
+   */
+  public String templateId() {
+    return templateId;
+  }
+
+  /**
+   * Gets the templateVersion.
+   *
+   * Filter results Template Version.
+   *
+   * @return the templateVersion
+   */
+  public String templateVersion() {
+    return templateVersion;
+  }
+
+  /**
+   * Gets the target.
+   *
+   * Filter results by the assignment target.
+   *
+   * @return the target
+   */
+  public String target() {
+    return target;
+  }
+
+  /**
+   * Gets the targetType.
+   *
+   * Filter results by the assignment's target type.
+   *
+   * @return the targetType
+   */
+  public String targetType() {
+    return targetType;
+  }
+
+  /**
+   * Gets the limit.
+   *
+   * Optional size of a single page. Default is 20 items per page. Valid range is 1 to 100.
+   *
+   * @return the limit
+   */
+  public Long limit() {
+    return limit;
+  }
+
+  /**
+   * Gets the pagetoken.
+   *
+   * Optional Prev or Next page token returned from a previous query execution. Default is start with first page.
+   *
+   * @return the pagetoken
+   */
+  public String pagetoken() {
+    return pagetoken;
+  }
+
+  /**
+   * Gets the sort.
+   *
+   * If specified, the items are sorted by the value of this property.
+   *
+   * @return the sort
+   */
+  public String sort() {
+    return sort;
+  }
+
+  /**
+   * Gets the order.
+   *
+   * Sort order.
+   *
+   * @return the order
+   */
+  public String order() {
+    return order;
+  }
+
+  /**
+   * Gets the includeHistory.
+   *
+   * Defines if the entity history is included in the response.
+   *
+   * @return the includeHistory
+   */
+  public Boolean includeHistory() {
+    return includeHistory;
+  }
+}
+

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ListAccountSettingsTemplatesOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ListAccountSettingsTemplatesOptions.java
@@ -1,0 +1,244 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import com.ibm.cloud.sdk.core.service.model.GenericModel;
+
+/**
+ * The listAccountSettingsTemplates options.
+ */
+public class ListAccountSettingsTemplatesOptions extends GenericModel {
+
+  /**
+   * Optional sort property. If specified, the returned templated are sorted according to this property.
+   */
+  public interface Sort {
+    /** created_at. */
+    String CREATED_AT = "created_at";
+    /** last_modified_at. */
+    String LAST_MODIFIED_AT = "last_modified_at";
+    /** name. */
+    String NAME = "name";
+  }
+
+  /**
+   * Optional sort order.
+   */
+  public interface Order {
+    /** asc. */
+    String ASC = "asc";
+    /** desc. */
+    String DESC = "desc";
+  }
+
+  protected String accountId;
+  protected String limit;
+  protected String pagetoken;
+  protected String sort;
+  protected String order;
+  protected String includeHistory;
+
+  /**
+   * Builder.
+   */
+  public static class Builder {
+    private String accountId;
+    private String limit;
+    private String pagetoken;
+    private String sort;
+    private String order;
+    private String includeHistory;
+
+    /**
+     * Instantiates a new Builder from an existing ListAccountSettingsTemplatesOptions instance.
+     *
+     * @param listAccountSettingsTemplatesOptions the instance to initialize the Builder with
+     */
+    private Builder(ListAccountSettingsTemplatesOptions listAccountSettingsTemplatesOptions) {
+      this.accountId = listAccountSettingsTemplatesOptions.accountId;
+      this.limit = listAccountSettingsTemplatesOptions.limit;
+      this.pagetoken = listAccountSettingsTemplatesOptions.pagetoken;
+      this.sort = listAccountSettingsTemplatesOptions.sort;
+      this.order = listAccountSettingsTemplatesOptions.order;
+      this.includeHistory = listAccountSettingsTemplatesOptions.includeHistory;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public Builder() {
+    }
+
+    /**
+     * Builds a ListAccountSettingsTemplatesOptions.
+     *
+     * @return the new ListAccountSettingsTemplatesOptions instance
+     */
+    public ListAccountSettingsTemplatesOptions build() {
+      return new ListAccountSettingsTemplatesOptions(this);
+    }
+
+    /**
+     * Set the accountId.
+     *
+     * @param accountId the accountId
+     * @return the ListAccountSettingsTemplatesOptions builder
+     */
+    public Builder accountId(String accountId) {
+      this.accountId = accountId;
+      return this;
+    }
+
+    /**
+     * Set the limit.
+     *
+     * @param limit the limit
+     * @return the ListAccountSettingsTemplatesOptions builder
+     */
+    public Builder limit(String limit) {
+      this.limit = limit;
+      return this;
+    }
+
+    /**
+     * Set the pagetoken.
+     *
+     * @param pagetoken the pagetoken
+     * @return the ListAccountSettingsTemplatesOptions builder
+     */
+    public Builder pagetoken(String pagetoken) {
+      this.pagetoken = pagetoken;
+      return this;
+    }
+
+    /**
+     * Set the sort.
+     *
+     * @param sort the sort
+     * @return the ListAccountSettingsTemplatesOptions builder
+     */
+    public Builder sort(String sort) {
+      this.sort = sort;
+      return this;
+    }
+
+    /**
+     * Set the order.
+     *
+     * @param order the order
+     * @return the ListAccountSettingsTemplatesOptions builder
+     */
+    public Builder order(String order) {
+      this.order = order;
+      return this;
+    }
+
+    /**
+     * Set the includeHistory.
+     *
+     * @param includeHistory the includeHistory
+     * @return the ListAccountSettingsTemplatesOptions builder
+     */
+    public Builder includeHistory(String includeHistory) {
+      this.includeHistory = includeHistory;
+      return this;
+    }
+  }
+
+  protected ListAccountSettingsTemplatesOptions() { }
+
+  protected ListAccountSettingsTemplatesOptions(Builder builder) {
+    accountId = builder.accountId;
+    limit = builder.limit;
+    pagetoken = builder.pagetoken;
+    sort = builder.sort;
+    order = builder.order;
+    includeHistory = builder.includeHistory;
+  }
+
+  /**
+   * New builder.
+   *
+   * @return a ListAccountSettingsTemplatesOptions builder
+   */
+  public Builder newBuilder() {
+    return new Builder(this);
+  }
+
+  /**
+   * Gets the accountId.
+   *
+   * Account ID of the account settings templates to query. This parameter is required unless using a pagetoken.
+   *
+   * @return the accountId
+   */
+  public String accountId() {
+    return accountId;
+  }
+
+  /**
+   * Gets the limit.
+   *
+   * Optional size of a single page.
+   *
+   * @return the limit
+   */
+  public String limit() {
+    return limit;
+  }
+
+  /**
+   * Gets the pagetoken.
+   *
+   * Optional Prev or Next page token returned from a previous query execution. Default is start with first page.
+   *
+   * @return the pagetoken
+   */
+  public String pagetoken() {
+    return pagetoken;
+  }
+
+  /**
+   * Gets the sort.
+   *
+   * Optional sort property. If specified, the returned templated are sorted according to this property.
+   *
+   * @return the sort
+   */
+  public String sort() {
+    return sort;
+  }
+
+  /**
+   * Gets the order.
+   *
+   * Optional sort order.
+   *
+   * @return the order
+   */
+  public String order() {
+    return order;
+  }
+
+  /**
+   * Gets the includeHistory.
+   *
+   * Defines if the entity history is included in the response.
+   *
+   * @return the includeHistory
+   */
+  public String includeHistory() {
+    return includeHistory;
+  }
+}
+

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ListApiKeysOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ListApiKeysOptions.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ListClaimRulesOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ListClaimRulesOptions.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ListLinksOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ListLinksOptions.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ListProfileTemplatesOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ListProfileTemplatesOptions.java
@@ -1,0 +1,244 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import com.ibm.cloud.sdk.core.service.model.GenericModel;
+
+/**
+ * The listProfileTemplates options.
+ */
+public class ListProfileTemplatesOptions extends GenericModel {
+
+  /**
+   * Optional sort property. If specified, the returned templates are sorted according to this property.
+   */
+  public interface Sort {
+    /** created_at. */
+    String CREATED_AT = "created_at";
+    /** last_modified_at. */
+    String LAST_MODIFIED_AT = "last_modified_at";
+    /** name. */
+    String NAME = "name";
+  }
+
+  /**
+   * Optional sort order.
+   */
+  public interface Order {
+    /** asc. */
+    String ASC = "asc";
+    /** desc. */
+    String DESC = "desc";
+  }
+
+  protected String accountId;
+  protected String limit;
+  protected String pagetoken;
+  protected String sort;
+  protected String order;
+  protected String includeHistory;
+
+  /**
+   * Builder.
+   */
+  public static class Builder {
+    private String accountId;
+    private String limit;
+    private String pagetoken;
+    private String sort;
+    private String order;
+    private String includeHistory;
+
+    /**
+     * Instantiates a new Builder from an existing ListProfileTemplatesOptions instance.
+     *
+     * @param listProfileTemplatesOptions the instance to initialize the Builder with
+     */
+    private Builder(ListProfileTemplatesOptions listProfileTemplatesOptions) {
+      this.accountId = listProfileTemplatesOptions.accountId;
+      this.limit = listProfileTemplatesOptions.limit;
+      this.pagetoken = listProfileTemplatesOptions.pagetoken;
+      this.sort = listProfileTemplatesOptions.sort;
+      this.order = listProfileTemplatesOptions.order;
+      this.includeHistory = listProfileTemplatesOptions.includeHistory;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public Builder() {
+    }
+
+    /**
+     * Builds a ListProfileTemplatesOptions.
+     *
+     * @return the new ListProfileTemplatesOptions instance
+     */
+    public ListProfileTemplatesOptions build() {
+      return new ListProfileTemplatesOptions(this);
+    }
+
+    /**
+     * Set the accountId.
+     *
+     * @param accountId the accountId
+     * @return the ListProfileTemplatesOptions builder
+     */
+    public Builder accountId(String accountId) {
+      this.accountId = accountId;
+      return this;
+    }
+
+    /**
+     * Set the limit.
+     *
+     * @param limit the limit
+     * @return the ListProfileTemplatesOptions builder
+     */
+    public Builder limit(String limit) {
+      this.limit = limit;
+      return this;
+    }
+
+    /**
+     * Set the pagetoken.
+     *
+     * @param pagetoken the pagetoken
+     * @return the ListProfileTemplatesOptions builder
+     */
+    public Builder pagetoken(String pagetoken) {
+      this.pagetoken = pagetoken;
+      return this;
+    }
+
+    /**
+     * Set the sort.
+     *
+     * @param sort the sort
+     * @return the ListProfileTemplatesOptions builder
+     */
+    public Builder sort(String sort) {
+      this.sort = sort;
+      return this;
+    }
+
+    /**
+     * Set the order.
+     *
+     * @param order the order
+     * @return the ListProfileTemplatesOptions builder
+     */
+    public Builder order(String order) {
+      this.order = order;
+      return this;
+    }
+
+    /**
+     * Set the includeHistory.
+     *
+     * @param includeHistory the includeHistory
+     * @return the ListProfileTemplatesOptions builder
+     */
+    public Builder includeHistory(String includeHistory) {
+      this.includeHistory = includeHistory;
+      return this;
+    }
+  }
+
+  protected ListProfileTemplatesOptions() { }
+
+  protected ListProfileTemplatesOptions(Builder builder) {
+    accountId = builder.accountId;
+    limit = builder.limit;
+    pagetoken = builder.pagetoken;
+    sort = builder.sort;
+    order = builder.order;
+    includeHistory = builder.includeHistory;
+  }
+
+  /**
+   * New builder.
+   *
+   * @return a ListProfileTemplatesOptions builder
+   */
+  public Builder newBuilder() {
+    return new Builder(this);
+  }
+
+  /**
+   * Gets the accountId.
+   *
+   * Account ID of the trusted profile templates to query. This parameter is required unless using a pagetoken.
+   *
+   * @return the accountId
+   */
+  public String accountId() {
+    return accountId;
+  }
+
+  /**
+   * Gets the limit.
+   *
+   * Optional size of a single page.
+   *
+   * @return the limit
+   */
+  public String limit() {
+    return limit;
+  }
+
+  /**
+   * Gets the pagetoken.
+   *
+   * Optional Prev or Next page token returned from a previous query execution. Default is start with first page.
+   *
+   * @return the pagetoken
+   */
+  public String pagetoken() {
+    return pagetoken;
+  }
+
+  /**
+   * Gets the sort.
+   *
+   * Optional sort property. If specified, the returned templates are sorted according to this property.
+   *
+   * @return the sort
+   */
+  public String sort() {
+    return sort;
+  }
+
+  /**
+   * Gets the order.
+   *
+   * Optional sort order.
+   *
+   * @return the order
+   */
+  public String order() {
+    return order;
+  }
+
+  /**
+   * Gets the includeHistory.
+   *
+   * Defines if the entity history is included in the response.
+   *
+   * @return the includeHistory
+   */
+  public String includeHistory() {
+    return includeHistory;
+  }
+}
+

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ListProfilesOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ListProfilesOptions.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ListServiceIdsOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ListServiceIdsOptions.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ListTrustedProfileAssignmentsOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ListTrustedProfileAssignmentsOptions.java
@@ -1,0 +1,358 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import com.ibm.cloud.sdk.core.service.model.GenericModel;
+
+/**
+ * The listTrustedProfileAssignments options.
+ */
+public class ListTrustedProfileAssignmentsOptions extends GenericModel {
+
+  /**
+   * Filter results by the assignment's target type.
+   */
+  public interface TargetType {
+    /** Account. */
+    String ACCOUNT = "Account";
+    /** AccountGroup. */
+    String ACCOUNTGROUP = "AccountGroup";
+  }
+
+  /**
+   * If specified, the items are sorted by the value of this property.
+   */
+  public interface Sort {
+    /** template_id. */
+    String TEMPLATE_ID = "template_id";
+    /** created_at. */
+    String CREATED_AT = "created_at";
+    /** last_modified_at. */
+    String LAST_MODIFIED_AT = "last_modified_at";
+  }
+
+  /**
+   * Sort order.
+   */
+  public interface Order {
+    /** asc. */
+    String ASC = "asc";
+    /** desc. */
+    String DESC = "desc";
+  }
+
+  protected String accountId;
+  protected String templateId;
+  protected String templateVersion;
+  protected String target;
+  protected String targetType;
+  protected Long limit;
+  protected String pagetoken;
+  protected String sort;
+  protected String order;
+  protected Boolean includeHistory;
+
+  /**
+   * Builder.
+   */
+  public static class Builder {
+    private String accountId;
+    private String templateId;
+    private String templateVersion;
+    private String target;
+    private String targetType;
+    private Long limit;
+    private String pagetoken;
+    private String sort;
+    private String order;
+    private Boolean includeHistory;
+
+    /**
+     * Instantiates a new Builder from an existing ListTrustedProfileAssignmentsOptions instance.
+     *
+     * @param listTrustedProfileAssignmentsOptions the instance to initialize the Builder with
+     */
+    private Builder(ListTrustedProfileAssignmentsOptions listTrustedProfileAssignmentsOptions) {
+      this.accountId = listTrustedProfileAssignmentsOptions.accountId;
+      this.templateId = listTrustedProfileAssignmentsOptions.templateId;
+      this.templateVersion = listTrustedProfileAssignmentsOptions.templateVersion;
+      this.target = listTrustedProfileAssignmentsOptions.target;
+      this.targetType = listTrustedProfileAssignmentsOptions.targetType;
+      this.limit = listTrustedProfileAssignmentsOptions.limit;
+      this.pagetoken = listTrustedProfileAssignmentsOptions.pagetoken;
+      this.sort = listTrustedProfileAssignmentsOptions.sort;
+      this.order = listTrustedProfileAssignmentsOptions.order;
+      this.includeHistory = listTrustedProfileAssignmentsOptions.includeHistory;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public Builder() {
+    }
+
+    /**
+     * Builds a ListTrustedProfileAssignmentsOptions.
+     *
+     * @return the new ListTrustedProfileAssignmentsOptions instance
+     */
+    public ListTrustedProfileAssignmentsOptions build() {
+      return new ListTrustedProfileAssignmentsOptions(this);
+    }
+
+    /**
+     * Set the accountId.
+     *
+     * @param accountId the accountId
+     * @return the ListTrustedProfileAssignmentsOptions builder
+     */
+    public Builder accountId(String accountId) {
+      this.accountId = accountId;
+      return this;
+    }
+
+    /**
+     * Set the templateId.
+     *
+     * @param templateId the templateId
+     * @return the ListTrustedProfileAssignmentsOptions builder
+     */
+    public Builder templateId(String templateId) {
+      this.templateId = templateId;
+      return this;
+    }
+
+    /**
+     * Set the templateVersion.
+     *
+     * @param templateVersion the templateVersion
+     * @return the ListTrustedProfileAssignmentsOptions builder
+     */
+    public Builder templateVersion(String templateVersion) {
+      this.templateVersion = templateVersion;
+      return this;
+    }
+
+    /**
+     * Set the target.
+     *
+     * @param target the target
+     * @return the ListTrustedProfileAssignmentsOptions builder
+     */
+    public Builder target(String target) {
+      this.target = target;
+      return this;
+    }
+
+    /**
+     * Set the targetType.
+     *
+     * @param targetType the targetType
+     * @return the ListTrustedProfileAssignmentsOptions builder
+     */
+    public Builder targetType(String targetType) {
+      this.targetType = targetType;
+      return this;
+    }
+
+    /**
+     * Set the limit.
+     *
+     * @param limit the limit
+     * @return the ListTrustedProfileAssignmentsOptions builder
+     */
+    public Builder limit(long limit) {
+      this.limit = limit;
+      return this;
+    }
+
+    /**
+     * Set the pagetoken.
+     *
+     * @param pagetoken the pagetoken
+     * @return the ListTrustedProfileAssignmentsOptions builder
+     */
+    public Builder pagetoken(String pagetoken) {
+      this.pagetoken = pagetoken;
+      return this;
+    }
+
+    /**
+     * Set the sort.
+     *
+     * @param sort the sort
+     * @return the ListTrustedProfileAssignmentsOptions builder
+     */
+    public Builder sort(String sort) {
+      this.sort = sort;
+      return this;
+    }
+
+    /**
+     * Set the order.
+     *
+     * @param order the order
+     * @return the ListTrustedProfileAssignmentsOptions builder
+     */
+    public Builder order(String order) {
+      this.order = order;
+      return this;
+    }
+
+    /**
+     * Set the includeHistory.
+     *
+     * @param includeHistory the includeHistory
+     * @return the ListTrustedProfileAssignmentsOptions builder
+     */
+    public Builder includeHistory(Boolean includeHistory) {
+      this.includeHistory = includeHistory;
+      return this;
+    }
+  }
+
+  protected ListTrustedProfileAssignmentsOptions() { }
+
+  protected ListTrustedProfileAssignmentsOptions(Builder builder) {
+    accountId = builder.accountId;
+    templateId = builder.templateId;
+    templateVersion = builder.templateVersion;
+    target = builder.target;
+    targetType = builder.targetType;
+    limit = builder.limit;
+    pagetoken = builder.pagetoken;
+    sort = builder.sort;
+    order = builder.order;
+    includeHistory = builder.includeHistory;
+  }
+
+  /**
+   * New builder.
+   *
+   * @return a ListTrustedProfileAssignmentsOptions builder
+   */
+  public Builder newBuilder() {
+    return new Builder(this);
+  }
+
+  /**
+   * Gets the accountId.
+   *
+   * Account ID of the Assignments to query. This parameter is required unless using a pagetoken.
+   *
+   * @return the accountId
+   */
+  public String accountId() {
+    return accountId;
+  }
+
+  /**
+   * Gets the templateId.
+   *
+   * Filter results by Template Id.
+   *
+   * @return the templateId
+   */
+  public String templateId() {
+    return templateId;
+  }
+
+  /**
+   * Gets the templateVersion.
+   *
+   * Filter results Template Version.
+   *
+   * @return the templateVersion
+   */
+  public String templateVersion() {
+    return templateVersion;
+  }
+
+  /**
+   * Gets the target.
+   *
+   * Filter results by the assignment target.
+   *
+   * @return the target
+   */
+  public String target() {
+    return target;
+  }
+
+  /**
+   * Gets the targetType.
+   *
+   * Filter results by the assignment's target type.
+   *
+   * @return the targetType
+   */
+  public String targetType() {
+    return targetType;
+  }
+
+  /**
+   * Gets the limit.
+   *
+   * Optional size of a single page. Default is 20 items per page. Valid range is 1 to 100.
+   *
+   * @return the limit
+   */
+  public Long limit() {
+    return limit;
+  }
+
+  /**
+   * Gets the pagetoken.
+   *
+   * Optional Prev or Next page token returned from a previous query execution. Default is start with first page.
+   *
+   * @return the pagetoken
+   */
+  public String pagetoken() {
+    return pagetoken;
+  }
+
+  /**
+   * Gets the sort.
+   *
+   * If specified, the items are sorted by the value of this property.
+   *
+   * @return the sort
+   */
+  public String sort() {
+    return sort;
+  }
+
+  /**
+   * Gets the order.
+   *
+   * Sort order.
+   *
+   * @return the order
+   */
+  public String order() {
+    return order;
+  }
+
+  /**
+   * Gets the includeHistory.
+   *
+   * Defines if the entity history is included in the response.
+   *
+   * @return the includeHistory
+   */
+  public Boolean includeHistory() {
+    return includeHistory;
+  }
+}
+

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ListVersionsOfAccountSettingsTemplateOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ListVersionsOfAccountSettingsTemplateOptions.java
@@ -1,0 +1,255 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import com.ibm.cloud.sdk.core.service.model.GenericModel;
+
+/**
+ * The listVersionsOfAccountSettingsTemplate options.
+ */
+public class ListVersionsOfAccountSettingsTemplateOptions extends GenericModel {
+
+  /**
+   * Optional sort property. If specified, the returned templated are sorted according to this property.
+   */
+  public interface Sort {
+    /** created_at. */
+    String CREATED_AT = "created_at";
+    /** last_modified_at. */
+    String LAST_MODIFIED_AT = "last_modified_at";
+    /** name. */
+    String NAME = "name";
+  }
+
+  /**
+   * Optional sort order.
+   */
+  public interface Order {
+    /** asc. */
+    String ASC = "asc";
+    /** desc. */
+    String DESC = "desc";
+  }
+
+  protected String templateId;
+  protected String limit;
+  protected String pagetoken;
+  protected String sort;
+  protected String order;
+  protected String includeHistory;
+
+  /**
+   * Builder.
+   */
+  public static class Builder {
+    private String templateId;
+    private String limit;
+    private String pagetoken;
+    private String sort;
+    private String order;
+    private String includeHistory;
+
+    /**
+     * Instantiates a new Builder from an existing ListVersionsOfAccountSettingsTemplateOptions instance.
+     *
+     * @param listVersionsOfAccountSettingsTemplateOptions the instance to initialize the Builder with
+     */
+    private Builder(ListVersionsOfAccountSettingsTemplateOptions listVersionsOfAccountSettingsTemplateOptions) {
+      this.templateId = listVersionsOfAccountSettingsTemplateOptions.templateId;
+      this.limit = listVersionsOfAccountSettingsTemplateOptions.limit;
+      this.pagetoken = listVersionsOfAccountSettingsTemplateOptions.pagetoken;
+      this.sort = listVersionsOfAccountSettingsTemplateOptions.sort;
+      this.order = listVersionsOfAccountSettingsTemplateOptions.order;
+      this.includeHistory = listVersionsOfAccountSettingsTemplateOptions.includeHistory;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public Builder() {
+    }
+
+    /**
+     * Instantiates a new builder with required properties.
+     *
+     * @param templateId the templateId
+     */
+    public Builder(String templateId) {
+      this.templateId = templateId;
+    }
+
+    /**
+     * Builds a ListVersionsOfAccountSettingsTemplateOptions.
+     *
+     * @return the new ListVersionsOfAccountSettingsTemplateOptions instance
+     */
+    public ListVersionsOfAccountSettingsTemplateOptions build() {
+      return new ListVersionsOfAccountSettingsTemplateOptions(this);
+    }
+
+    /**
+     * Set the templateId.
+     *
+     * @param templateId the templateId
+     * @return the ListVersionsOfAccountSettingsTemplateOptions builder
+     */
+    public Builder templateId(String templateId) {
+      this.templateId = templateId;
+      return this;
+    }
+
+    /**
+     * Set the limit.
+     *
+     * @param limit the limit
+     * @return the ListVersionsOfAccountSettingsTemplateOptions builder
+     */
+    public Builder limit(String limit) {
+      this.limit = limit;
+      return this;
+    }
+
+    /**
+     * Set the pagetoken.
+     *
+     * @param pagetoken the pagetoken
+     * @return the ListVersionsOfAccountSettingsTemplateOptions builder
+     */
+    public Builder pagetoken(String pagetoken) {
+      this.pagetoken = pagetoken;
+      return this;
+    }
+
+    /**
+     * Set the sort.
+     *
+     * @param sort the sort
+     * @return the ListVersionsOfAccountSettingsTemplateOptions builder
+     */
+    public Builder sort(String sort) {
+      this.sort = sort;
+      return this;
+    }
+
+    /**
+     * Set the order.
+     *
+     * @param order the order
+     * @return the ListVersionsOfAccountSettingsTemplateOptions builder
+     */
+    public Builder order(String order) {
+      this.order = order;
+      return this;
+    }
+
+    /**
+     * Set the includeHistory.
+     *
+     * @param includeHistory the includeHistory
+     * @return the ListVersionsOfAccountSettingsTemplateOptions builder
+     */
+    public Builder includeHistory(String includeHistory) {
+      this.includeHistory = includeHistory;
+      return this;
+    }
+  }
+
+  protected ListVersionsOfAccountSettingsTemplateOptions() { }
+
+  protected ListVersionsOfAccountSettingsTemplateOptions(Builder builder) {
+    com.ibm.cloud.sdk.core.util.Validator.notEmpty(builder.templateId,
+      "templateId cannot be empty");
+    templateId = builder.templateId;
+    limit = builder.limit;
+    pagetoken = builder.pagetoken;
+    sort = builder.sort;
+    order = builder.order;
+    includeHistory = builder.includeHistory;
+  }
+
+  /**
+   * New builder.
+   *
+   * @return a ListVersionsOfAccountSettingsTemplateOptions builder
+   */
+  public Builder newBuilder() {
+    return new Builder(this);
+  }
+
+  /**
+   * Gets the templateId.
+   *
+   * ID of the account settings template.
+   *
+   * @return the templateId
+   */
+  public String templateId() {
+    return templateId;
+  }
+
+  /**
+   * Gets the limit.
+   *
+   * Optional size of a single page.
+   *
+   * @return the limit
+   */
+  public String limit() {
+    return limit;
+  }
+
+  /**
+   * Gets the pagetoken.
+   *
+   * Optional Prev or Next page token returned from a previous query execution. Default is start with first page.
+   *
+   * @return the pagetoken
+   */
+  public String pagetoken() {
+    return pagetoken;
+  }
+
+  /**
+   * Gets the sort.
+   *
+   * Optional sort property. If specified, the returned templated are sorted according to this property.
+   *
+   * @return the sort
+   */
+  public String sort() {
+    return sort;
+  }
+
+  /**
+   * Gets the order.
+   *
+   * Optional sort order.
+   *
+   * @return the order
+   */
+  public String order() {
+    return order;
+  }
+
+  /**
+   * Gets the includeHistory.
+   *
+   * Defines if the entity history is included in the response.
+   *
+   * @return the includeHistory
+   */
+  public String includeHistory() {
+    return includeHistory;
+  }
+}
+

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ListVersionsOfProfileTemplateOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ListVersionsOfProfileTemplateOptions.java
@@ -1,0 +1,255 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import com.ibm.cloud.sdk.core.service.model.GenericModel;
+
+/**
+ * The listVersionsOfProfileTemplate options.
+ */
+public class ListVersionsOfProfileTemplateOptions extends GenericModel {
+
+  /**
+   * Optional sort property. If specified, the returned templated are sorted according to this property.
+   */
+  public interface Sort {
+    /** created_at. */
+    String CREATED_AT = "created_at";
+    /** last_modified_at. */
+    String LAST_MODIFIED_AT = "last_modified_at";
+    /** name. */
+    String NAME = "name";
+  }
+
+  /**
+   * Optional sort order.
+   */
+  public interface Order {
+    /** asc. */
+    String ASC = "asc";
+    /** desc. */
+    String DESC = "desc";
+  }
+
+  protected String templateId;
+  protected String limit;
+  protected String pagetoken;
+  protected String sort;
+  protected String order;
+  protected String includeHistory;
+
+  /**
+   * Builder.
+   */
+  public static class Builder {
+    private String templateId;
+    private String limit;
+    private String pagetoken;
+    private String sort;
+    private String order;
+    private String includeHistory;
+
+    /**
+     * Instantiates a new Builder from an existing ListVersionsOfProfileTemplateOptions instance.
+     *
+     * @param listVersionsOfProfileTemplateOptions the instance to initialize the Builder with
+     */
+    private Builder(ListVersionsOfProfileTemplateOptions listVersionsOfProfileTemplateOptions) {
+      this.templateId = listVersionsOfProfileTemplateOptions.templateId;
+      this.limit = listVersionsOfProfileTemplateOptions.limit;
+      this.pagetoken = listVersionsOfProfileTemplateOptions.pagetoken;
+      this.sort = listVersionsOfProfileTemplateOptions.sort;
+      this.order = listVersionsOfProfileTemplateOptions.order;
+      this.includeHistory = listVersionsOfProfileTemplateOptions.includeHistory;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public Builder() {
+    }
+
+    /**
+     * Instantiates a new builder with required properties.
+     *
+     * @param templateId the templateId
+     */
+    public Builder(String templateId) {
+      this.templateId = templateId;
+    }
+
+    /**
+     * Builds a ListVersionsOfProfileTemplateOptions.
+     *
+     * @return the new ListVersionsOfProfileTemplateOptions instance
+     */
+    public ListVersionsOfProfileTemplateOptions build() {
+      return new ListVersionsOfProfileTemplateOptions(this);
+    }
+
+    /**
+     * Set the templateId.
+     *
+     * @param templateId the templateId
+     * @return the ListVersionsOfProfileTemplateOptions builder
+     */
+    public Builder templateId(String templateId) {
+      this.templateId = templateId;
+      return this;
+    }
+
+    /**
+     * Set the limit.
+     *
+     * @param limit the limit
+     * @return the ListVersionsOfProfileTemplateOptions builder
+     */
+    public Builder limit(String limit) {
+      this.limit = limit;
+      return this;
+    }
+
+    /**
+     * Set the pagetoken.
+     *
+     * @param pagetoken the pagetoken
+     * @return the ListVersionsOfProfileTemplateOptions builder
+     */
+    public Builder pagetoken(String pagetoken) {
+      this.pagetoken = pagetoken;
+      return this;
+    }
+
+    /**
+     * Set the sort.
+     *
+     * @param sort the sort
+     * @return the ListVersionsOfProfileTemplateOptions builder
+     */
+    public Builder sort(String sort) {
+      this.sort = sort;
+      return this;
+    }
+
+    /**
+     * Set the order.
+     *
+     * @param order the order
+     * @return the ListVersionsOfProfileTemplateOptions builder
+     */
+    public Builder order(String order) {
+      this.order = order;
+      return this;
+    }
+
+    /**
+     * Set the includeHistory.
+     *
+     * @param includeHistory the includeHistory
+     * @return the ListVersionsOfProfileTemplateOptions builder
+     */
+    public Builder includeHistory(String includeHistory) {
+      this.includeHistory = includeHistory;
+      return this;
+    }
+  }
+
+  protected ListVersionsOfProfileTemplateOptions() { }
+
+  protected ListVersionsOfProfileTemplateOptions(Builder builder) {
+    com.ibm.cloud.sdk.core.util.Validator.notEmpty(builder.templateId,
+      "templateId cannot be empty");
+    templateId = builder.templateId;
+    limit = builder.limit;
+    pagetoken = builder.pagetoken;
+    sort = builder.sort;
+    order = builder.order;
+    includeHistory = builder.includeHistory;
+  }
+
+  /**
+   * New builder.
+   *
+   * @return a ListVersionsOfProfileTemplateOptions builder
+   */
+  public Builder newBuilder() {
+    return new Builder(this);
+  }
+
+  /**
+   * Gets the templateId.
+   *
+   * ID of the trusted profile template.
+   *
+   * @return the templateId
+   */
+  public String templateId() {
+    return templateId;
+  }
+
+  /**
+   * Gets the limit.
+   *
+   * Optional size of a single page.
+   *
+   * @return the limit
+   */
+  public String limit() {
+    return limit;
+  }
+
+  /**
+   * Gets the pagetoken.
+   *
+   * Optional Prev or Next page token returned from a previous query execution. Default is start with first page.
+   *
+   * @return the pagetoken
+   */
+  public String pagetoken() {
+    return pagetoken;
+  }
+
+  /**
+   * Gets the sort.
+   *
+   * Optional sort property. If specified, the returned templated are sorted according to this property.
+   *
+   * @return the sort
+   */
+  public String sort() {
+    return sort;
+  }
+
+  /**
+   * Gets the order.
+   *
+   * Optional sort order.
+   *
+   * @return the order
+   */
+  public String order() {
+    return order;
+  }
+
+  /**
+   * Gets the includeHistory.
+   *
+   * Defines if the entity history is included in the response.
+   *
+   * @return the includeHistory
+   */
+  public String includeHistory() {
+    return includeHistory;
+  }
+}
+

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/LockApiKeyOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/LockApiKeyOptions.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/LockServiceIdOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/LockServiceIdOptions.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/PolicyTemplateReference.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/PolicyTemplateReference.java
@@ -1,0 +1,133 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import com.ibm.cloud.sdk.core.service.model.GenericModel;
+
+/**
+ * Metadata for external access policy.
+ */
+public class PolicyTemplateReference extends GenericModel {
+
+  protected String id;
+  protected String version;
+
+  /**
+   * Builder.
+   */
+  public static class Builder {
+    private String id;
+    private String version;
+
+    /**
+     * Instantiates a new Builder from an existing PolicyTemplateReference instance.
+     *
+     * @param policyTemplateReference the instance to initialize the Builder with
+     */
+    private Builder(PolicyTemplateReference policyTemplateReference) {
+      this.id = policyTemplateReference.id;
+      this.version = policyTemplateReference.version;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public Builder() {
+    }
+
+    /**
+     * Instantiates a new builder with required properties.
+     *
+     * @param id the id
+     * @param version the version
+     */
+    public Builder(String id, String version) {
+      this.id = id;
+      this.version = version;
+    }
+
+    /**
+     * Builds a PolicyTemplateReference.
+     *
+     * @return the new PolicyTemplateReference instance
+     */
+    public PolicyTemplateReference build() {
+      return new PolicyTemplateReference(this);
+    }
+
+    /**
+     * Set the id.
+     *
+     * @param id the id
+     * @return the PolicyTemplateReference builder
+     */
+    public Builder id(String id) {
+      this.id = id;
+      return this;
+    }
+
+    /**
+     * Set the version.
+     *
+     * @param version the version
+     * @return the PolicyTemplateReference builder
+     */
+    public Builder version(String version) {
+      this.version = version;
+      return this;
+    }
+  }
+
+  protected PolicyTemplateReference() { }
+
+  protected PolicyTemplateReference(Builder builder) {
+    com.ibm.cloud.sdk.core.util.Validator.notNull(builder.id,
+      "id cannot be null");
+    com.ibm.cloud.sdk.core.util.Validator.notNull(builder.version,
+      "version cannot be null");
+    id = builder.id;
+    version = builder.version;
+  }
+
+  /**
+   * New builder.
+   *
+   * @return a PolicyTemplateReference builder
+   */
+  public Builder newBuilder() {
+    return new Builder(this);
+  }
+
+  /**
+   * Gets the id.
+   *
+   * ID of Access Policy Template.
+   *
+   * @return the id
+   */
+  public String id() {
+    return id;
+  }
+
+  /**
+   * Gets the version.
+   *
+   * Version of Access Policy Template.
+   *
+   * @return the version
+   */
+  public String version() {
+    return version;
+  }
+}
+

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ProfileClaimRule.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ProfileClaimRule.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ProfileClaimRuleConditions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ProfileClaimRuleConditions.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -130,8 +130,7 @@ public class ProfileClaimRuleConditions extends GenericModel {
   /**
    * Gets the claim.
    *
-   * The claim to evaluate against. [Learn
-   * more](/docs/account?topic=account-iam-condition-properties&amp;interface=ui#cr-attribute-names).
+   * The claim to evaluate against.
    *
    * @return the claim
    */

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ProfileClaimRuleList.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ProfileClaimRuleList.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ProfileIdentitiesResponse.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ProfileIdentitiesResponse.java
@@ -24,7 +24,7 @@ public class ProfileIdentitiesResponse extends GenericModel {
 
   @SerializedName("entity_tag")
   protected String entityTag;
-  protected List<ProfileIdentity> identities;
+  protected List<ProfileIdentityResponse> identities;
 
   protected ProfileIdentitiesResponse() { }
 
@@ -46,7 +46,7 @@ public class ProfileIdentitiesResponse extends GenericModel {
    *
    * @return the identities
    */
-  public List<ProfileIdentity> getIdentities() {
+  public List<ProfileIdentityResponse> getIdentities() {
     return identities;
   }
 }

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ProfileIdentityRequest.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ProfileIdentityRequest.java
@@ -15,13 +15,12 @@ package com.ibm.cloud.platform_services.iam_identity.v1.model;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.google.gson.annotations.SerializedName;
 import com.ibm.cloud.sdk.core.service.model.GenericModel;
 
 /**
- * ProfileIdentity.
+ * ProfileIdentityRequest.
  */
-public class ProfileIdentity extends GenericModel {
+public class ProfileIdentityRequest extends GenericModel {
 
   /**
    * Type of the identity.
@@ -35,8 +34,6 @@ public class ProfileIdentity extends GenericModel {
     String CRN = "crn";
   }
 
-  @SerializedName("iam_id")
-  protected String iamId;
   protected String identifier;
   protected String type;
   protected List<String> accounts;
@@ -46,23 +43,21 @@ public class ProfileIdentity extends GenericModel {
    * Builder.
    */
   public static class Builder {
-    private String iamId;
     private String identifier;
     private String type;
     private List<String> accounts;
     private String description;
 
     /**
-     * Instantiates a new Builder from an existing ProfileIdentity instance.
+     * Instantiates a new Builder from an existing ProfileIdentityRequest instance.
      *
-     * @param profileIdentity the instance to initialize the Builder with
+     * @param profileIdentityRequest the instance to initialize the Builder with
      */
-    private Builder(ProfileIdentity profileIdentity) {
-      this.iamId = profileIdentity.iamId;
-      this.identifier = profileIdentity.identifier;
-      this.type = profileIdentity.type;
-      this.accounts = profileIdentity.accounts;
-      this.description = profileIdentity.description;
+    private Builder(ProfileIdentityRequest profileIdentityRequest) {
+      this.identifier = profileIdentityRequest.identifier;
+      this.type = profileIdentityRequest.type;
+      this.accounts = profileIdentityRequest.accounts;
+      this.description = profileIdentityRequest.description;
     }
 
     /**
@@ -83,19 +78,19 @@ public class ProfileIdentity extends GenericModel {
     }
 
     /**
-     * Builds a ProfileIdentity.
+     * Builds a ProfileIdentityRequest.
      *
-     * @return the new ProfileIdentity instance
+     * @return the new ProfileIdentityRequest instance
      */
-    public ProfileIdentity build() {
-      return new ProfileIdentity(this);
+    public ProfileIdentityRequest build() {
+      return new ProfileIdentityRequest(this);
     }
 
     /**
      * Adds an accounts to accounts.
      *
      * @param accounts the new accounts
-     * @return the ProfileIdentity builder
+     * @return the ProfileIdentityRequest builder
      */
     public Builder addAccounts(String accounts) {
       com.ibm.cloud.sdk.core.util.Validator.notNull(accounts,
@@ -108,21 +103,10 @@ public class ProfileIdentity extends GenericModel {
     }
 
     /**
-     * Set the iamId.
-     *
-     * @param iamId the iamId
-     * @return the ProfileIdentity builder
-     */
-    public Builder iamId(String iamId) {
-      this.iamId = iamId;
-      return this;
-    }
-
-    /**
      * Set the identifier.
      *
      * @param identifier the identifier
-     * @return the ProfileIdentity builder
+     * @return the ProfileIdentityRequest builder
      */
     public Builder identifier(String identifier) {
       this.identifier = identifier;
@@ -133,7 +117,7 @@ public class ProfileIdentity extends GenericModel {
      * Set the type.
      *
      * @param type the type
-     * @return the ProfileIdentity builder
+     * @return the ProfileIdentityRequest builder
      */
     public Builder type(String type) {
       this.type = type;
@@ -145,7 +129,7 @@ public class ProfileIdentity extends GenericModel {
      * Existing accounts will be replaced.
      *
      * @param accounts the accounts
-     * @return the ProfileIdentity builder
+     * @return the ProfileIdentityRequest builder
      */
     public Builder accounts(List<String> accounts) {
       this.accounts = accounts;
@@ -156,7 +140,7 @@ public class ProfileIdentity extends GenericModel {
      * Set the description.
      *
      * @param description the description
-     * @return the ProfileIdentity builder
+     * @return the ProfileIdentityRequest builder
      */
     public Builder description(String description) {
       this.description = description;
@@ -164,14 +148,13 @@ public class ProfileIdentity extends GenericModel {
     }
   }
 
-  protected ProfileIdentity() { }
+  protected ProfileIdentityRequest() { }
 
-  protected ProfileIdentity(Builder builder) {
+  protected ProfileIdentityRequest(Builder builder) {
     com.ibm.cloud.sdk.core.util.Validator.notNull(builder.identifier,
       "identifier cannot be null");
     com.ibm.cloud.sdk.core.util.Validator.notNull(builder.type,
       "type cannot be null");
-    iamId = builder.iamId;
     identifier = builder.identifier;
     type = builder.type;
     accounts = builder.accounts;
@@ -181,21 +164,10 @@ public class ProfileIdentity extends GenericModel {
   /**
    * New builder.
    *
-   * @return a ProfileIdentity builder
+   * @return a ProfileIdentityRequest builder
    */
   public Builder newBuilder() {
     return new Builder(this);
-  }
-
-  /**
-   * Gets the iamId.
-   *
-   * IAM ID of the identity.
-   *
-   * @return the iamId
-   */
-  public String iamId() {
-    return iamId;
   }
 
   /**

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ProfileIdentityResponse.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ProfileIdentityResponse.java
@@ -1,0 +1,105 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import java.util.List;
+
+import com.google.gson.annotations.SerializedName;
+import com.ibm.cloud.sdk.core.service.model.GenericModel;
+
+/**
+ * ProfileIdentityResponse.
+ */
+public class ProfileIdentityResponse extends GenericModel {
+
+  /**
+   * Type of the identity.
+   */
+  public interface Type {
+    /** user. */
+    String USER = "user";
+    /** serviceid. */
+    String SERVICEID = "serviceid";
+    /** crn. */
+    String CRN = "crn";
+  }
+
+  @SerializedName("iam_id")
+  protected String iamId;
+  protected String identifier;
+  protected String type;
+  protected List<String> accounts;
+  protected String description;
+
+  protected ProfileIdentityResponse() { }
+
+  /**
+   * Gets the iamId.
+   *
+   * IAM ID of the identity.
+   *
+   * @return the iamId
+   */
+  public String getIamId() {
+    return iamId;
+  }
+
+  /**
+   * Gets the identifier.
+   *
+   * Identifier of the identity that can assume the trusted profiles. This can be a user identifier (IAM id), serviceid
+   * or crn. Internally it uses account id of the service id for the identifier 'serviceid' and for the identifier 'crn'
+   * it uses account id contained in the CRN.
+   *
+   * @return the identifier
+   */
+  public String getIdentifier() {
+    return identifier;
+  }
+
+  /**
+   * Gets the type.
+   *
+   * Type of the identity.
+   *
+   * @return the type
+   */
+  public String getType() {
+    return type;
+  }
+
+  /**
+   * Gets the accounts.
+   *
+   * Only valid for the type user. Accounts from which a user can assume the trusted profile.
+   *
+   * @return the accounts
+   */
+  public List<String> getAccounts() {
+    return accounts;
+  }
+
+  /**
+   * Gets the description.
+   *
+   * Description of the identity that can assume the trusted profile. This is optional field for all the types of
+   * identities. When this field is not set for the identity type 'serviceid' then the description of the service id is
+   * used. Description is recommended for the identity type 'crn' E.g. 'Instance 1234 of IBM Cloud Service project'.
+   *
+   * @return the description
+   */
+  public String getDescription() {
+    return description;
+  }
+}
+

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ProfileLinkLink.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ProfileLinkLink.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ProfileLinkList.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ProfileLinkList.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/Report.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/Report.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ReportReference.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ReportReference.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ResponseContext.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ResponseContext.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ServiceId.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ServiceId.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ServiceIdList.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ServiceIdList.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/SetProfileIdentitiesOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/SetProfileIdentitiesOptions.java
@@ -24,7 +24,7 @@ public class SetProfileIdentitiesOptions extends GenericModel {
 
   protected String profileId;
   protected String ifMatch;
-  protected List<ProfileIdentity> identities;
+  protected List<ProfileIdentityRequest> identities;
 
   /**
    * Builder.
@@ -32,7 +32,7 @@ public class SetProfileIdentitiesOptions extends GenericModel {
   public static class Builder {
     private String profileId;
     private String ifMatch;
-    private List<ProfileIdentity> identities;
+    private List<ProfileIdentityRequest> identities;
 
     /**
      * Instantiates a new Builder from an existing SetProfileIdentitiesOptions instance.
@@ -77,11 +77,11 @@ public class SetProfileIdentitiesOptions extends GenericModel {
      * @param identities the new identities
      * @return the SetProfileIdentitiesOptions builder
      */
-    public Builder addIdentities(ProfileIdentity identities) {
+    public Builder addIdentities(ProfileIdentityRequest identities) {
       com.ibm.cloud.sdk.core.util.Validator.notNull(identities,
         "identities cannot be null");
       if (this.identities == null) {
-        this.identities = new ArrayList<ProfileIdentity>();
+        this.identities = new ArrayList<ProfileIdentityRequest>();
       }
       this.identities.add(identities);
       return this;
@@ -116,7 +116,7 @@ public class SetProfileIdentitiesOptions extends GenericModel {
      * @param identities the identities
      * @return the SetProfileIdentitiesOptions builder
      */
-    public Builder identities(List<ProfileIdentity> identities) {
+    public Builder identities(List<ProfileIdentityRequest> identities) {
       this.identities = identities;
       return this;
     }
@@ -174,7 +174,7 @@ public class SetProfileIdentitiesOptions extends GenericModel {
    *
    * @return the identities
    */
-  public List<ProfileIdentity> identities() {
+  public List<ProfileIdentityRequest> identities() {
     return identities;
   }
 }

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/SetProfileIdentityOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/SetProfileIdentityOptions.java
@@ -50,7 +50,6 @@ public class SetProfileIdentityOptions extends GenericModel {
   protected String identityType;
   protected String identifier;
   protected String type;
-  protected String iamId;
   protected List<String> accounts;
   protected String description;
 
@@ -62,7 +61,6 @@ public class SetProfileIdentityOptions extends GenericModel {
     private String identityType;
     private String identifier;
     private String type;
-    private String iamId;
     private List<String> accounts;
     private String description;
 
@@ -76,7 +74,6 @@ public class SetProfileIdentityOptions extends GenericModel {
       this.identityType = setProfileIdentityOptions.identityType;
       this.identifier = setProfileIdentityOptions.identifier;
       this.type = setProfileIdentityOptions.type;
-      this.iamId = setProfileIdentityOptions.iamId;
       this.accounts = setProfileIdentityOptions.accounts;
       this.description = setProfileIdentityOptions.description;
     }
@@ -172,17 +169,6 @@ public class SetProfileIdentityOptions extends GenericModel {
     }
 
     /**
-     * Set the iamId.
-     *
-     * @param iamId the iamId
-     * @return the SetProfileIdentityOptions builder
-     */
-    public Builder iamId(String iamId) {
-      this.iamId = iamId;
-      return this;
-    }
-
-    /**
      * Set the accounts.
      * Existing accounts will be replaced.
      *
@@ -204,21 +190,6 @@ public class SetProfileIdentityOptions extends GenericModel {
       this.description = description;
       return this;
     }
-
-    /**
-     * Set the profileIdentity.
-     *
-     * @param profileIdentity the profileIdentity
-     * @return the SetProfileIdentityOptions builder
-     */
-    public Builder profileIdentity(ProfileIdentity profileIdentity) {
-      this.identifier = profileIdentity.identifier();
-      this.type = profileIdentity.type();
-      this.iamId = profileIdentity.iamId();
-      this.accounts = profileIdentity.accounts();
-      this.description = profileIdentity.description();
-      return this;
-    }
   }
 
   protected SetProfileIdentityOptions() { }
@@ -236,7 +207,6 @@ public class SetProfileIdentityOptions extends GenericModel {
     identityType = builder.identityType;
     identifier = builder.identifier;
     type = builder.type;
-    iamId = builder.iamId;
     accounts = builder.accounts;
     description = builder.description;
   }
@@ -294,17 +264,6 @@ public class SetProfileIdentityOptions extends GenericModel {
    */
   public String type() {
     return type;
-  }
-
-  /**
-   * Gets the iamId.
-   *
-   * IAM ID of the identity.
-   *
-   * @return the iamId
-   */
-  public String iamId() {
-    return iamId;
   }
 
   /**

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/TemplateAssignmentListResponse.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/TemplateAssignmentListResponse.java
@@ -1,0 +1,113 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import java.util.List;
+
+import com.ibm.cloud.sdk.core.service.model.GenericModel;
+
+/**
+ * List Response body format for Template Assignments Records.
+ */
+public class TemplateAssignmentListResponse extends GenericModel {
+
+  protected ResponseContext context;
+  protected Long offset;
+  protected Long limit;
+  protected String first;
+  protected String previous;
+  protected String next;
+  protected List<TemplateAssignmentResponse> assignments;
+
+  protected TemplateAssignmentListResponse() { }
+
+  /**
+   * Gets the context.
+   *
+   * Context with key properties for problem determination.
+   *
+   * @return the context
+   */
+  public ResponseContext getContext() {
+    return context;
+  }
+
+  /**
+   * Gets the offset.
+   *
+   * The offset of the current page.
+   *
+   * @return the offset
+   */
+  public Long getOffset() {
+    return offset;
+  }
+
+  /**
+   * Gets the limit.
+   *
+   * Optional size of a single page. Default is 20 items per page. Valid range is 1 to 100.
+   *
+   * @return the limit
+   */
+  public Long getLimit() {
+    return limit;
+  }
+
+  /**
+   * Gets the first.
+   *
+   * Link to the first page.
+   *
+   * @return the first
+   */
+  public String getFirst() {
+    return first;
+  }
+
+  /**
+   * Gets the previous.
+   *
+   * Link to the previous available page. If 'previous' property is not part of the response no previous page is
+   * available.
+   *
+   * @return the previous
+   */
+  public String getPrevious() {
+    return previous;
+  }
+
+  /**
+   * Gets the next.
+   *
+   * Link to the next available page. If 'next' property is not part of the response no next page is available.
+   *
+   * @return the next
+   */
+  public String getNext() {
+    return next;
+  }
+
+  /**
+   * Gets the assignments.
+   *
+   * List of Assignments based on the query paramters and the page size. The assignments array is always part of the
+   * response but might be empty depending on the query parameter values provided.
+   *
+   * @return the assignments
+   */
+  public List<TemplateAssignmentResponse> getAssignments() {
+    return assignments;
+  }
+}
+

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/TemplateAssignmentResource.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/TemplateAssignmentResource.java
@@ -1,0 +1,37 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import com.ibm.cloud.sdk.core.service.model.GenericModel;
+
+/**
+ * Body parameters for created resource.
+ */
+public class TemplateAssignmentResource extends GenericModel {
+
+  protected String id;
+
+  protected TemplateAssignmentResource() { }
+
+  /**
+   * Gets the id.
+   *
+   * Id of the created resource.
+   *
+   * @return the id
+   */
+  public String getId() {
+    return id;
+  }
+}
+

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/TemplateAssignmentResourceError.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/TemplateAssignmentResourceError.java
@@ -1,0 +1,73 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import com.ibm.cloud.sdk.core.service.model.GenericModel;
+
+/**
+ * Body parameters for assignment error.
+ */
+public class TemplateAssignmentResourceError extends GenericModel {
+
+  protected String name;
+  protected String errorCode;
+  protected String message;
+  protected String statusCode;
+
+  protected TemplateAssignmentResourceError() { }
+
+  /**
+   * Gets the name.
+   *
+   * Name of the error.
+   *
+   * @return the name
+   */
+  public String getName() {
+    return name;
+  }
+
+  /**
+   * Gets the errorCode.
+   *
+   * Internal error code.
+   *
+   * @return the errorCode
+   */
+  public String getErrorCode() {
+    return errorCode;
+  }
+
+  /**
+   * Gets the message.
+   *
+   * Error message detailing the nature of the error.
+   *
+   * @return the message
+   */
+  public String getMessage() {
+    return message;
+  }
+
+  /**
+   * Gets the statusCode.
+   *
+   * Internal status code for the error.
+   *
+   * @return the statusCode
+   */
+  public String getStatusCode() {
+    return statusCode;
+  }
+}
+

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/TemplateAssignmentResponse.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/TemplateAssignmentResponse.java
@@ -1,0 +1,231 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import java.util.List;
+
+import com.google.gson.annotations.SerializedName;
+import com.ibm.cloud.sdk.core.service.model.GenericModel;
+
+/**
+ * Response body format for Template Assignment Record.
+ */
+public class TemplateAssignmentResponse extends GenericModel {
+
+  protected ResponseContext context;
+  protected String id;
+  @SerializedName("account_id")
+  protected String accountId;
+  @SerializedName("template_id")
+  protected String templateId;
+  @SerializedName("template_version")
+  protected Long templateVersion;
+  @SerializedName("target_type")
+  protected String targetType;
+  protected String target;
+  protected String status;
+  protected List<TemplateAssignmentResponseResource> resources;
+  protected List<EnityHistoryRecord> history;
+  protected String href;
+  @SerializedName("created_at")
+  protected String createdAt;
+  @SerializedName("created_by_id")
+  protected String createdById;
+  @SerializedName("last_modified_at")
+  protected String lastModifiedAt;
+  @SerializedName("last_modified_by_id")
+  protected String lastModifiedById;
+  @SerializedName("entity_tag")
+  protected String entityTag;
+
+  protected TemplateAssignmentResponse() { }
+
+  /**
+   * Gets the context.
+   *
+   * Context with key properties for problem determination.
+   *
+   * @return the context
+   */
+  public ResponseContext getContext() {
+    return context;
+  }
+
+  /**
+   * Gets the id.
+   *
+   * Assignment record Id.
+   *
+   * @return the id
+   */
+  public String getId() {
+    return id;
+  }
+
+  /**
+   * Gets the accountId.
+   *
+   * Enterprise account Id.
+   *
+   * @return the accountId
+   */
+  public String getAccountId() {
+    return accountId;
+  }
+
+  /**
+   * Gets the templateId.
+   *
+   * Template Id.
+   *
+   * @return the templateId
+   */
+  public String getTemplateId() {
+    return templateId;
+  }
+
+  /**
+   * Gets the templateVersion.
+   *
+   * Template version.
+   *
+   * @return the templateVersion
+   */
+  public Long getTemplateVersion() {
+    return templateVersion;
+  }
+
+  /**
+   * Gets the targetType.
+   *
+   * Assignment target type.
+   *
+   * @return the targetType
+   */
+  public String getTargetType() {
+    return targetType;
+  }
+
+  /**
+   * Gets the target.
+   *
+   * Assignment target.
+   *
+   * @return the target
+   */
+  public String getTarget() {
+    return target;
+  }
+
+  /**
+   * Gets the status.
+   *
+   * Assignment status.
+   *
+   * @return the status
+   */
+  public String getStatus() {
+    return status;
+  }
+
+  /**
+   * Gets the resources.
+   *
+   * Status breakdown per target account of IAM resources created or errors encountered in attempting to create those
+   * IAM resources. IAM resources are only included in the response providing the assignment is not in progress. IAM
+   * resources are also only included when getting a single assignment, and excluded by list APIs.
+   *
+   * @return the resources
+   */
+  public List<TemplateAssignmentResponseResource> getResources() {
+    return resources;
+  }
+
+  /**
+   * Gets the history.
+   *
+   * Assignment history.
+   *
+   * @return the history
+   */
+  public List<EnityHistoryRecord> getHistory() {
+    return history;
+  }
+
+  /**
+   * Gets the href.
+   *
+   * Href.
+   *
+   * @return the href
+   */
+  public String getHref() {
+    return href;
+  }
+
+  /**
+   * Gets the createdAt.
+   *
+   * Assignment created at.
+   *
+   * @return the createdAt
+   */
+  public String getCreatedAt() {
+    return createdAt;
+  }
+
+  /**
+   * Gets the createdById.
+   *
+   * IAMid of the identity that created the assignment.
+   *
+   * @return the createdById
+   */
+  public String getCreatedById() {
+    return createdById;
+  }
+
+  /**
+   * Gets the lastModifiedAt.
+   *
+   * Assignment modified at.
+   *
+   * @return the lastModifiedAt
+   */
+  public String getLastModifiedAt() {
+    return lastModifiedAt;
+  }
+
+  /**
+   * Gets the lastModifiedById.
+   *
+   * IAMid of the identity that last modified the assignment.
+   *
+   * @return the lastModifiedById
+   */
+  public String getLastModifiedById() {
+    return lastModifiedById;
+  }
+
+  /**
+   * Gets the entityTag.
+   *
+   * Entity tag for this assignment record.
+   *
+   * @return the entityTag
+   */
+  public String getEntityTag() {
+    return entityTag;
+  }
+}
+

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/TemplateAssignmentResponseResource.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/TemplateAssignmentResponseResource.java
@@ -1,0 +1,74 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import java.util.List;
+
+import com.google.gson.annotations.SerializedName;
+import com.ibm.cloud.sdk.core.service.model.GenericModel;
+
+/**
+ * Overview of resources assignment per target account.
+ */
+public class TemplateAssignmentResponseResource extends GenericModel {
+
+  protected String target;
+  protected TemplateAssignmentResponseResourceDetail profile;
+  @SerializedName("account_settings")
+  protected TemplateAssignmentResponseResourceDetail accountSettings;
+  @SerializedName("policy_template_refs")
+  protected List<TemplateAssignmentResponseResourceDetail> policyTemplateRefs;
+
+  protected TemplateAssignmentResponseResource() { }
+
+  /**
+   * Gets the target.
+   *
+   * Target account where the IAM resource is created.
+   *
+   * @return the target
+   */
+  public String getTarget() {
+    return target;
+  }
+
+  /**
+   * Gets the profile.
+   *
+   * @return the profile
+   */
+  public TemplateAssignmentResponseResourceDetail getProfile() {
+    return profile;
+  }
+
+  /**
+   * Gets the accountSettings.
+   *
+   * @return the accountSettings
+   */
+  public TemplateAssignmentResponseResourceDetail getAccountSettings() {
+    return accountSettings;
+  }
+
+  /**
+   * Gets the policyTemplateRefs.
+   *
+   * Policy resource(s) included only for trusted profile assignments with policy references.
+   *
+   * @return the policyTemplateRefs
+   */
+  public List<TemplateAssignmentResponseResourceDetail> getPolicyTemplateRefs() {
+    return policyTemplateRefs;
+  }
+}
+

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/TemplateAssignmentResponseResourceDetail.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/TemplateAssignmentResponseResourceDetail.java
@@ -1,0 +1,88 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import com.google.gson.annotations.SerializedName;
+import com.ibm.cloud.sdk.core.service.model.GenericModel;
+
+/**
+ * TemplateAssignmentResponseResourceDetail.
+ */
+public class TemplateAssignmentResponseResourceDetail extends GenericModel {
+
+  protected String id;
+  protected String version;
+  @SerializedName("resource_created")
+  protected TemplateAssignmentResource resourceCreated;
+  @SerializedName("error_message")
+  protected TemplateAssignmentResourceError errorMessage;
+  protected String status;
+
+  protected TemplateAssignmentResponseResourceDetail() { }
+
+  /**
+   * Gets the id.
+   *
+   * Policy Template Id, only returned for a profile assignment with policy references.
+   *
+   * @return the id
+   */
+  public String getId() {
+    return id;
+  }
+
+  /**
+   * Gets the version.
+   *
+   * Policy version, only returned for a profile assignment with policy references.
+   *
+   * @return the version
+   */
+  public String getVersion() {
+    return version;
+  }
+
+  /**
+   * Gets the resourceCreated.
+   *
+   * Body parameters for created resource.
+   *
+   * @return the resourceCreated
+   */
+  public TemplateAssignmentResource getResourceCreated() {
+    return resourceCreated;
+  }
+
+  /**
+   * Gets the errorMessage.
+   *
+   * Body parameters for assignment error.
+   *
+   * @return the errorMessage
+   */
+  public TemplateAssignmentResourceError getErrorMessage() {
+    return errorMessage;
+  }
+
+  /**
+   * Gets the status.
+   *
+   * Status for the target account's assignment.
+   *
+   * @return the status
+   */
+  public String getStatus() {
+    return status;
+  }
+}
+

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/TemplateProfileComponentRequest.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/TemplateProfileComponentRequest.java
@@ -1,0 +1,218 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.ibm.cloud.sdk.core.service.model.GenericModel;
+
+/**
+ * Input body parameters for the TemplateProfileComponent.
+ */
+public class TemplateProfileComponentRequest extends GenericModel {
+
+  protected String name;
+  protected String description;
+  protected List<TrustedProfileTemplateClaimRule> rules;
+  protected List<ProfileIdentityRequest> identities;
+
+  /**
+   * Builder.
+   */
+  public static class Builder {
+    private String name;
+    private String description;
+    private List<TrustedProfileTemplateClaimRule> rules;
+    private List<ProfileIdentityRequest> identities;
+
+    /**
+     * Instantiates a new Builder from an existing TemplateProfileComponentRequest instance.
+     *
+     * @param templateProfileComponentRequest the instance to initialize the Builder with
+     */
+    private Builder(TemplateProfileComponentRequest templateProfileComponentRequest) {
+      this.name = templateProfileComponentRequest.name;
+      this.description = templateProfileComponentRequest.description;
+      this.rules = templateProfileComponentRequest.rules;
+      this.identities = templateProfileComponentRequest.identities;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public Builder() {
+    }
+
+    /**
+     * Instantiates a new builder with required properties.
+     *
+     * @param name the name
+     */
+    public Builder(String name) {
+      this.name = name;
+    }
+
+    /**
+     * Builds a TemplateProfileComponentRequest.
+     *
+     * @return the new TemplateProfileComponentRequest instance
+     */
+    public TemplateProfileComponentRequest build() {
+      return new TemplateProfileComponentRequest(this);
+    }
+
+    /**
+     * Adds an rules to rules.
+     *
+     * @param rules the new rules
+     * @return the TemplateProfileComponentRequest builder
+     */
+    public Builder addRules(TrustedProfileTemplateClaimRule rules) {
+      com.ibm.cloud.sdk.core.util.Validator.notNull(rules,
+        "rules cannot be null");
+      if (this.rules == null) {
+        this.rules = new ArrayList<TrustedProfileTemplateClaimRule>();
+      }
+      this.rules.add(rules);
+      return this;
+    }
+
+    /**
+     * Adds an identities to identities.
+     *
+     * @param identities the new identities
+     * @return the TemplateProfileComponentRequest builder
+     */
+    public Builder addIdentities(ProfileIdentityRequest identities) {
+      com.ibm.cloud.sdk.core.util.Validator.notNull(identities,
+        "identities cannot be null");
+      if (this.identities == null) {
+        this.identities = new ArrayList<ProfileIdentityRequest>();
+      }
+      this.identities.add(identities);
+      return this;
+    }
+
+    /**
+     * Set the name.
+     *
+     * @param name the name
+     * @return the TemplateProfileComponentRequest builder
+     */
+    public Builder name(String name) {
+      this.name = name;
+      return this;
+    }
+
+    /**
+     * Set the description.
+     *
+     * @param description the description
+     * @return the TemplateProfileComponentRequest builder
+     */
+    public Builder description(String description) {
+      this.description = description;
+      return this;
+    }
+
+    /**
+     * Set the rules.
+     * Existing rules will be replaced.
+     *
+     * @param rules the rules
+     * @return the TemplateProfileComponentRequest builder
+     */
+    public Builder rules(List<TrustedProfileTemplateClaimRule> rules) {
+      this.rules = rules;
+      return this;
+    }
+
+    /**
+     * Set the identities.
+     * Existing identities will be replaced.
+     *
+     * @param identities the identities
+     * @return the TemplateProfileComponentRequest builder
+     */
+    public Builder identities(List<ProfileIdentityRequest> identities) {
+      this.identities = identities;
+      return this;
+    }
+  }
+
+  protected TemplateProfileComponentRequest() { }
+
+  protected TemplateProfileComponentRequest(Builder builder) {
+    com.ibm.cloud.sdk.core.util.Validator.notNull(builder.name,
+      "name cannot be null");
+    name = builder.name;
+    description = builder.description;
+    rules = builder.rules;
+    identities = builder.identities;
+  }
+
+  /**
+   * New builder.
+   *
+   * @return a TemplateProfileComponentRequest builder
+   */
+  public Builder newBuilder() {
+    return new Builder(this);
+  }
+
+  /**
+   * Gets the name.
+   *
+   * Name of the Profile.
+   *
+   * @return the name
+   */
+  public String name() {
+    return name;
+  }
+
+  /**
+   * Gets the description.
+   *
+   * Description of the Profile.
+   *
+   * @return the description
+   */
+  public String description() {
+    return description;
+  }
+
+  /**
+   * Gets the rules.
+   *
+   * Rules for the Profile.
+   *
+   * @return the rules
+   */
+  public List<TrustedProfileTemplateClaimRule> rules() {
+    return rules;
+  }
+
+  /**
+   * Gets the identities.
+   *
+   * Identities for the Profile.
+   *
+   * @return the identities
+   */
+  public List<ProfileIdentityRequest> identities() {
+    return identities;
+  }
+}
+

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/TemplateProfileComponentResponse.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/TemplateProfileComponentResponse.java
@@ -1,0 +1,75 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import java.util.List;
+
+import com.ibm.cloud.sdk.core.service.model.GenericModel;
+
+/**
+ * Input body parameters for the TemplateProfileComponent.
+ */
+public class TemplateProfileComponentResponse extends GenericModel {
+
+  protected String name;
+  protected String description;
+  protected List<TrustedProfileTemplateClaimRule> rules;
+  protected List<ProfileIdentityResponse> identities;
+
+  protected TemplateProfileComponentResponse() { }
+
+  /**
+   * Gets the name.
+   *
+   * Name of the Profile.
+   *
+   * @return the name
+   */
+  public String getName() {
+    return name;
+  }
+
+  /**
+   * Gets the description.
+   *
+   * Description of the Profile.
+   *
+   * @return the description
+   */
+  public String getDescription() {
+    return description;
+  }
+
+  /**
+   * Gets the rules.
+   *
+   * Rules for the Profile.
+   *
+   * @return the rules
+   */
+  public List<TrustedProfileTemplateClaimRule> getRules() {
+    return rules;
+  }
+
+  /**
+   * Gets the identities.
+   *
+   * Identities for the Profile.
+   *
+   * @return the identities
+   */
+  public List<ProfileIdentityResponse> getIdentities() {
+    return identities;
+  }
+}
+

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/TrustedProfile.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/TrustedProfile.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -38,6 +38,10 @@ public class TrustedProfile extends GenericModel {
   protected String iamId;
   @SerializedName("account_id")
   protected String accountId;
+  @SerializedName("template_id")
+  protected String templateId;
+  @SerializedName("assignment_id")
+  protected String assignmentId;
   @SerializedName("ims_account_id")
   protected Long imsAccountId;
   @SerializedName("ims_user_id")
@@ -159,6 +163,31 @@ public class TrustedProfile extends GenericModel {
    */
   public String getAccountId() {
     return accountId;
+  }
+
+  /**
+   * Gets the templateId.
+   *
+   * ID of the IAM template that was used to create an enterprise-managed trusted profile in your account. When
+   * returned, this indicates that the trusted profile is created from and managed by a template in the root enterprise
+   * account.
+   *
+   * @return the templateId
+   */
+  public String getTemplateId() {
+    return templateId;
+  }
+
+  /**
+   * Gets the assignmentId.
+   *
+   * ID of the assignment that was used to create an enterprise-managed trusted profile in your account. When returned,
+   * this indicates that the trusted profile is created from and managed by a template in the root enterprise account.
+   *
+   * @return the assignmentId
+   */
+  public String getAssignmentId() {
+    return assignmentId;
   }
 
   /**

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/TrustedProfileTemplateClaimRule.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/TrustedProfileTemplateClaimRule.java
@@ -1,0 +1,242 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.google.gson.annotations.SerializedName;
+import com.ibm.cloud.sdk.core.service.model.GenericModel;
+
+/**
+ * TrustedProfileTemplateClaimRule.
+ */
+public class TrustedProfileTemplateClaimRule extends GenericModel {
+
+  /**
+   * Type of the claim rule.
+   */
+  public interface Type {
+    /** Profile-SAML. */
+    String PROFILE_SAML = "Profile-SAML";
+  }
+
+  protected String name;
+  protected String type;
+  @SerializedName("realm_name")
+  protected String realmName;
+  protected Long expiration;
+  protected List<ProfileClaimRuleConditions> conditions;
+
+  /**
+   * Builder.
+   */
+  public static class Builder {
+    private String name;
+    private String type;
+    private String realmName;
+    private Long expiration;
+    private List<ProfileClaimRuleConditions> conditions;
+
+    /**
+     * Instantiates a new Builder from an existing TrustedProfileTemplateClaimRule instance.
+     *
+     * @param trustedProfileTemplateClaimRule the instance to initialize the Builder with
+     */
+    private Builder(TrustedProfileTemplateClaimRule trustedProfileTemplateClaimRule) {
+      this.name = trustedProfileTemplateClaimRule.name;
+      this.type = trustedProfileTemplateClaimRule.type;
+      this.realmName = trustedProfileTemplateClaimRule.realmName;
+      this.expiration = trustedProfileTemplateClaimRule.expiration;
+      this.conditions = trustedProfileTemplateClaimRule.conditions;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public Builder() {
+    }
+
+    /**
+     * Instantiates a new builder with required properties.
+     *
+     * @param type the type
+     * @param conditions the conditions
+     */
+    public Builder(String type, List<ProfileClaimRuleConditions> conditions) {
+      this.type = type;
+      this.conditions = conditions;
+    }
+
+    /**
+     * Builds a TrustedProfileTemplateClaimRule.
+     *
+     * @return the new TrustedProfileTemplateClaimRule instance
+     */
+    public TrustedProfileTemplateClaimRule build() {
+      return new TrustedProfileTemplateClaimRule(this);
+    }
+
+    /**
+     * Adds an conditions to conditions.
+     *
+     * @param conditions the new conditions
+     * @return the TrustedProfileTemplateClaimRule builder
+     */
+    public Builder addConditions(ProfileClaimRuleConditions conditions) {
+      com.ibm.cloud.sdk.core.util.Validator.notNull(conditions,
+        "conditions cannot be null");
+      if (this.conditions == null) {
+        this.conditions = new ArrayList<ProfileClaimRuleConditions>();
+      }
+      this.conditions.add(conditions);
+      return this;
+    }
+
+    /**
+     * Set the name.
+     *
+     * @param name the name
+     * @return the TrustedProfileTemplateClaimRule builder
+     */
+    public Builder name(String name) {
+      this.name = name;
+      return this;
+    }
+
+    /**
+     * Set the type.
+     *
+     * @param type the type
+     * @return the TrustedProfileTemplateClaimRule builder
+     */
+    public Builder type(String type) {
+      this.type = type;
+      return this;
+    }
+
+    /**
+     * Set the realmName.
+     *
+     * @param realmName the realmName
+     * @return the TrustedProfileTemplateClaimRule builder
+     */
+    public Builder realmName(String realmName) {
+      this.realmName = realmName;
+      return this;
+    }
+
+    /**
+     * Set the expiration.
+     *
+     * @param expiration the expiration
+     * @return the TrustedProfileTemplateClaimRule builder
+     */
+    public Builder expiration(long expiration) {
+      this.expiration = expiration;
+      return this;
+    }
+
+    /**
+     * Set the conditions.
+     * Existing conditions will be replaced.
+     *
+     * @param conditions the conditions
+     * @return the TrustedProfileTemplateClaimRule builder
+     */
+    public Builder conditions(List<ProfileClaimRuleConditions> conditions) {
+      this.conditions = conditions;
+      return this;
+    }
+  }
+
+  protected TrustedProfileTemplateClaimRule() { }
+
+  protected TrustedProfileTemplateClaimRule(Builder builder) {
+    com.ibm.cloud.sdk.core.util.Validator.notNull(builder.type,
+      "type cannot be null");
+    com.ibm.cloud.sdk.core.util.Validator.notNull(builder.conditions,
+      "conditions cannot be null");
+    name = builder.name;
+    type = builder.type;
+    realmName = builder.realmName;
+    expiration = builder.expiration;
+    conditions = builder.conditions;
+  }
+
+  /**
+   * New builder.
+   *
+   * @return a TrustedProfileTemplateClaimRule builder
+   */
+  public Builder newBuilder() {
+    return new Builder(this);
+  }
+
+  /**
+   * Gets the name.
+   *
+   * Name of the claim rule to be created or updated.
+   *
+   * @return the name
+   */
+  public String name() {
+    return name;
+  }
+
+  /**
+   * Gets the type.
+   *
+   * Type of the claim rule.
+   *
+   * @return the type
+   */
+  public String type() {
+    return type;
+  }
+
+  /**
+   * Gets the realmName.
+   *
+   * The realm name of the Idp this claim rule applies to. This field is required only if the type is specified as
+   * 'Profile-SAML'.
+   *
+   * @return the realmName
+   */
+  public String realmName() {
+    return realmName;
+  }
+
+  /**
+   * Gets the expiration.
+   *
+   * Session expiration in seconds, only required if type is 'Profile-SAML'.
+   *
+   * @return the expiration
+   */
+  public Long expiration() {
+    return expiration;
+  }
+
+  /**
+   * Gets the conditions.
+   *
+   * Conditions of this claim rule.
+   *
+   * @return the conditions
+   */
+  public List<ProfileClaimRuleConditions> conditions() {
+    return conditions;
+  }
+}
+

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/TrustedProfileTemplateList.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/TrustedProfileTemplateList.java
@@ -1,0 +1,115 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import java.util.List;
+
+import com.google.gson.annotations.SerializedName;
+import com.ibm.cloud.sdk.core.service.model.GenericModel;
+
+/**
+ * TrustedProfileTemplateList.
+ */
+public class TrustedProfileTemplateList extends GenericModel {
+
+  protected ResponseContext context;
+  protected Long offset;
+  protected Long limit;
+  protected String first;
+  protected String previous;
+  protected String next;
+  @SerializedName("profile_templates")
+  protected List<TrustedProfileTemplateResponse> profileTemplates;
+
+  protected TrustedProfileTemplateList() { }
+
+  /**
+   * Gets the context.
+   *
+   * Context with key properties for problem determination.
+   *
+   * @return the context
+   */
+  public ResponseContext getContext() {
+    return context;
+  }
+
+  /**
+   * Gets the offset.
+   *
+   * The offset of the current page.
+   *
+   * @return the offset
+   */
+  public Long getOffset() {
+    return offset;
+  }
+
+  /**
+   * Gets the limit.
+   *
+   * Optional size of a single page.
+   *
+   * @return the limit
+   */
+  public Long getLimit() {
+    return limit;
+  }
+
+  /**
+   * Gets the first.
+   *
+   * Link to the first page.
+   *
+   * @return the first
+   */
+  public String getFirst() {
+    return first;
+  }
+
+  /**
+   * Gets the previous.
+   *
+   * Link to the previous available page. If 'previous' property is not part of the response no previous page is
+   * available.
+   *
+   * @return the previous
+   */
+  public String getPrevious() {
+    return previous;
+  }
+
+  /**
+   * Gets the next.
+   *
+   * Link to the next available page. If 'next' property is not part of the response no next page is available.
+   *
+   * @return the next
+   */
+  public String getNext() {
+    return next;
+  }
+
+  /**
+   * Gets the profileTemplates.
+   *
+   * List of Profile Templates based on the query paramters and the page size. The profile_templates array is always
+   * part of the response but might be empty depending on the query parameter values provided.
+   *
+   * @return the profileTemplates
+   */
+  public List<TrustedProfileTemplateResponse> getProfileTemplates() {
+    return profileTemplates;
+  }
+}
+

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/TrustedProfileTemplateResponse.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/TrustedProfileTemplateResponse.java
@@ -1,0 +1,215 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import java.util.List;
+
+import com.google.gson.annotations.SerializedName;
+import com.ibm.cloud.sdk.core.service.model.GenericModel;
+
+/**
+ * Response body format for Trusted Profile Template REST requests.
+ */
+public class TrustedProfileTemplateResponse extends GenericModel {
+
+  protected String id;
+  protected Long version;
+  @SerializedName("account_id")
+  protected String accountId;
+  protected String name;
+  protected String description;
+  protected Boolean committed;
+  protected TemplateProfileComponentResponse profile;
+  @SerializedName("policy_template_references")
+  protected List<PolicyTemplateReference> policyTemplateReferences;
+  protected List<EnityHistoryRecord> history;
+  @SerializedName("entity_tag")
+  protected String entityTag;
+  protected String crn;
+  @SerializedName("created_at")
+  protected String createdAt;
+  @SerializedName("created_by_id")
+  protected String createdById;
+  @SerializedName("last_modified_at")
+  protected String lastModifiedAt;
+  @SerializedName("last_modified_by_id")
+  protected String lastModifiedById;
+
+  protected TrustedProfileTemplateResponse() { }
+
+  /**
+   * Gets the id.
+   *
+   * ID of the the template.
+   *
+   * @return the id
+   */
+  public String getId() {
+    return id;
+  }
+
+  /**
+   * Gets the version.
+   *
+   * Version of the the template.
+   *
+   * @return the version
+   */
+  public Long getVersion() {
+    return version;
+  }
+
+  /**
+   * Gets the accountId.
+   *
+   * ID of the account where the template resides.
+   *
+   * @return the accountId
+   */
+  public String getAccountId() {
+    return accountId;
+  }
+
+  /**
+   * Gets the name.
+   *
+   * The name of the trusted profile template. This is visible only in the enterprise account.
+   *
+   * @return the name
+   */
+  public String getName() {
+    return name;
+  }
+
+  /**
+   * Gets the description.
+   *
+   * The description of the trusted profile template. Describe the template for enterprise account users.
+   *
+   * @return the description
+   */
+  public String getDescription() {
+    return description;
+  }
+
+  /**
+   * Gets the committed.
+   *
+   * Committed flag determines if the template is ready for assignment.
+   *
+   * @return the committed
+   */
+  public Boolean isCommitted() {
+    return committed;
+  }
+
+  /**
+   * Gets the profile.
+   *
+   * Input body parameters for the TemplateProfileComponent.
+   *
+   * @return the profile
+   */
+  public TemplateProfileComponentResponse getProfile() {
+    return profile;
+  }
+
+  /**
+   * Gets the policyTemplateReferences.
+   *
+   * Existing policy templates that you can reference to assign access in the trusted profile component.
+   *
+   * @return the policyTemplateReferences
+   */
+  public List<PolicyTemplateReference> getPolicyTemplateReferences() {
+    return policyTemplateReferences;
+  }
+
+  /**
+   * Gets the history.
+   *
+   * History of the trusted profile template.
+   *
+   * @return the history
+   */
+  public List<EnityHistoryRecord> getHistory() {
+    return history;
+  }
+
+  /**
+   * Gets the entityTag.
+   *
+   * Entity tag for this templateId-version combination.
+   *
+   * @return the entityTag
+   */
+  public String getEntityTag() {
+    return entityTag;
+  }
+
+  /**
+   * Gets the crn.
+   *
+   * Cloud resource name.
+   *
+   * @return the crn
+   */
+  public String getCrn() {
+    return crn;
+  }
+
+  /**
+   * Gets the createdAt.
+   *
+   * Timestamp of when the template was created.
+   *
+   * @return the createdAt
+   */
+  public String getCreatedAt() {
+    return createdAt;
+  }
+
+  /**
+   * Gets the createdById.
+   *
+   * IAMid of the creator.
+   *
+   * @return the createdById
+   */
+  public String getCreatedById() {
+    return createdById;
+  }
+
+  /**
+   * Gets the lastModifiedAt.
+   *
+   * Timestamp of when the template was last modified.
+   *
+   * @return the lastModifiedAt
+   */
+  public String getLastModifiedAt() {
+    return lastModifiedAt;
+  }
+
+  /**
+   * Gets the lastModifiedById.
+   *
+   * IAMid of the identity that made the latest modification.
+   *
+   * @return the lastModifiedById
+   */
+  public String getLastModifiedById() {
+    return lastModifiedById;
+  }
+}
+

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/TrustedProfilesList.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/TrustedProfilesList.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/UnlockApiKeyOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/UnlockApiKeyOptions.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/UnlockServiceIdOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/UnlockServiceIdOptions.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/UpdateAccountSettingsAssignmentOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/UpdateAccountSettingsAssignmentOptions.java
@@ -1,0 +1,166 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import com.ibm.cloud.sdk.core.service.model.GenericModel;
+
+/**
+ * The updateAccountSettingsAssignment options.
+ */
+public class UpdateAccountSettingsAssignmentOptions extends GenericModel {
+
+  protected String assignmentId;
+  protected String ifMatch;
+  protected Long templateVersion;
+
+  /**
+   * Builder.
+   */
+  public static class Builder {
+    private String assignmentId;
+    private String ifMatch;
+    private Long templateVersion;
+
+    /**
+     * Instantiates a new Builder from an existing UpdateAccountSettingsAssignmentOptions instance.
+     *
+     * @param updateAccountSettingsAssignmentOptions the instance to initialize the Builder with
+     */
+    private Builder(UpdateAccountSettingsAssignmentOptions updateAccountSettingsAssignmentOptions) {
+      this.assignmentId = updateAccountSettingsAssignmentOptions.assignmentId;
+      this.ifMatch = updateAccountSettingsAssignmentOptions.ifMatch;
+      this.templateVersion = updateAccountSettingsAssignmentOptions.templateVersion;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public Builder() {
+    }
+
+    /**
+     * Instantiates a new builder with required properties.
+     *
+     * @param assignmentId the assignmentId
+     * @param ifMatch the ifMatch
+     * @param templateVersion the templateVersion
+     */
+    public Builder(String assignmentId, String ifMatch, Long templateVersion) {
+      this.assignmentId = assignmentId;
+      this.ifMatch = ifMatch;
+      this.templateVersion = templateVersion;
+    }
+
+    /**
+     * Builds a UpdateAccountSettingsAssignmentOptions.
+     *
+     * @return the new UpdateAccountSettingsAssignmentOptions instance
+     */
+    public UpdateAccountSettingsAssignmentOptions build() {
+      return new UpdateAccountSettingsAssignmentOptions(this);
+    }
+
+    /**
+     * Set the assignmentId.
+     *
+     * @param assignmentId the assignmentId
+     * @return the UpdateAccountSettingsAssignmentOptions builder
+     */
+    public Builder assignmentId(String assignmentId) {
+      this.assignmentId = assignmentId;
+      return this;
+    }
+
+    /**
+     * Set the ifMatch.
+     *
+     * @param ifMatch the ifMatch
+     * @return the UpdateAccountSettingsAssignmentOptions builder
+     */
+    public Builder ifMatch(String ifMatch) {
+      this.ifMatch = ifMatch;
+      return this;
+    }
+
+    /**
+     * Set the templateVersion.
+     *
+     * @param templateVersion the templateVersion
+     * @return the UpdateAccountSettingsAssignmentOptions builder
+     */
+    public Builder templateVersion(long templateVersion) {
+      this.templateVersion = templateVersion;
+      return this;
+    }
+  }
+
+  protected UpdateAccountSettingsAssignmentOptions() { }
+
+  protected UpdateAccountSettingsAssignmentOptions(Builder builder) {
+    com.ibm.cloud.sdk.core.util.Validator.notEmpty(builder.assignmentId,
+      "assignmentId cannot be empty");
+    com.ibm.cloud.sdk.core.util.Validator.notNull(builder.ifMatch,
+      "ifMatch cannot be null");
+    com.ibm.cloud.sdk.core.util.Validator.notNull(builder.templateVersion,
+      "templateVersion cannot be null");
+    assignmentId = builder.assignmentId;
+    ifMatch = builder.ifMatch;
+    templateVersion = builder.templateVersion;
+  }
+
+  /**
+   * New builder.
+   *
+   * @return a UpdateAccountSettingsAssignmentOptions builder
+   */
+  public Builder newBuilder() {
+    return new Builder(this);
+  }
+
+  /**
+   * Gets the assignmentId.
+   *
+   * ID of the Assignment Record.
+   *
+   * @return the assignmentId
+   */
+  public String assignmentId() {
+    return assignmentId;
+  }
+
+  /**
+   * Gets the ifMatch.
+   *
+   * Version of the assignment to be updated. Specify the version that you retrieved when reading the assignment. This
+   * value  helps identifying parallel usage of this API. Pass * to indicate to update any version available. This might
+   * result in stale updates.
+   *
+   * @return the ifMatch
+   */
+  public String ifMatch() {
+    return ifMatch;
+  }
+
+  /**
+   * Gets the templateVersion.
+   *
+   * Template version to be applied to the assignment. To retry all failed assignemtns, provide the existing version. To
+   * migrate to a different version, provide the new version number.
+   *
+   * @return the templateVersion
+   */
+  public Long templateVersion() {
+    return templateVersion;
+  }
+}
+

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/UpdateAccountSettingsOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/UpdateAccountSettingsOptions.java
@@ -23,10 +23,11 @@ import com.ibm.cloud.sdk.core.service.model.GenericModel;
 public class UpdateAccountSettingsOptions extends GenericModel {
 
   /**
-   * Defines whether or not creating a Service Id is access controlled. Valid values:
-   *   * RESTRICTED - to apply access control
-   *   * NOT_RESTRICTED - to remove access control
-   *   * NOT_SET - to unset a previously set value.
+   * Defines whether or not creating a service ID is access controlled. Valid values:
+   *   * RESTRICTED - only users assigned the 'Service ID creator' role on the IAM Identity Service can create service
+   * IDs, including the account owner
+   *   * NOT_RESTRICTED - all members of an account can create service IDs
+   *   * NOT_SET - to 'unset' a previous set value.
    */
   public interface RestrictCreateServiceId {
     /** RESTRICTED. */
@@ -39,8 +40,9 @@ public class UpdateAccountSettingsOptions extends GenericModel {
 
   /**
    * Defines whether or not creating platform API keys is access controlled. Valid values:
-   *   * RESTRICTED - to apply access control
-   *   * NOT_RESTRICTED - to remove access control
+   *   * RESTRICTED - only users assigned the 'User API key creator' role on the IAM Identity Service can create API
+   * keys, including the account owner
+   *   * NOT_RESTRICTED - all members of an account can create platform API keys
    *   * NOT_SET - to 'unset' a previous set value.
    */
   public interface RestrictCreatePlatformApikey {
@@ -362,10 +364,11 @@ public class UpdateAccountSettingsOptions extends GenericModel {
   /**
    * Gets the restrictCreateServiceId.
    *
-   * Defines whether or not creating a Service Id is access controlled. Valid values:
-   *   * RESTRICTED - to apply access control
-   *   * NOT_RESTRICTED - to remove access control
-   *   * NOT_SET - to unset a previously set value.
+   * Defines whether or not creating a service ID is access controlled. Valid values:
+   *   * RESTRICTED - only users assigned the 'Service ID creator' role on the IAM Identity Service can create service
+   * IDs, including the account owner
+   *   * NOT_RESTRICTED - all members of an account can create service IDs
+   *   * NOT_SET - to 'unset' a previous set value.
    *
    * @return the restrictCreateServiceId
    */
@@ -377,8 +380,9 @@ public class UpdateAccountSettingsOptions extends GenericModel {
    * Gets the restrictCreatePlatformApikey.
    *
    * Defines whether or not creating platform API keys is access controlled. Valid values:
-   *   * RESTRICTED - to apply access control
-   *   * NOT_RESTRICTED - to remove access control
+   *   * RESTRICTED - only users assigned the 'User API key creator' role on the IAM Identity Service can create API
+   * keys, including the account owner
+   *   * NOT_RESTRICTED - all members of an account can create platform API keys
    *   * NOT_SET - to 'unset' a previous set value.
    *
    * @return the restrictCreatePlatformApikey

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/UpdateAccountSettingsTemplateVersionOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/UpdateAccountSettingsTemplateVersionOptions.java
@@ -1,0 +1,267 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import com.ibm.cloud.sdk.core.service.model.GenericModel;
+
+/**
+ * The updateAccountSettingsTemplateVersion options.
+ */
+public class UpdateAccountSettingsTemplateVersionOptions extends GenericModel {
+
+  protected String ifMatch;
+  protected String templateId;
+  protected String version;
+  protected String accountId;
+  protected String name;
+  protected String description;
+  protected AccountSettingsComponent accountSettings;
+
+  /**
+   * Builder.
+   */
+  public static class Builder {
+    private String ifMatch;
+    private String templateId;
+    private String version;
+    private String accountId;
+    private String name;
+    private String description;
+    private AccountSettingsComponent accountSettings;
+
+    /**
+     * Instantiates a new Builder from an existing UpdateAccountSettingsTemplateVersionOptions instance.
+     *
+     * @param updateAccountSettingsTemplateVersionOptions the instance to initialize the Builder with
+     */
+    private Builder(UpdateAccountSettingsTemplateVersionOptions updateAccountSettingsTemplateVersionOptions) {
+      this.ifMatch = updateAccountSettingsTemplateVersionOptions.ifMatch;
+      this.templateId = updateAccountSettingsTemplateVersionOptions.templateId;
+      this.version = updateAccountSettingsTemplateVersionOptions.version;
+      this.accountId = updateAccountSettingsTemplateVersionOptions.accountId;
+      this.name = updateAccountSettingsTemplateVersionOptions.name;
+      this.description = updateAccountSettingsTemplateVersionOptions.description;
+      this.accountSettings = updateAccountSettingsTemplateVersionOptions.accountSettings;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public Builder() {
+    }
+
+    /**
+     * Instantiates a new builder with required properties.
+     *
+     * @param ifMatch the ifMatch
+     * @param templateId the templateId
+     * @param version the version
+     */
+    public Builder(String ifMatch, String templateId, String version) {
+      this.ifMatch = ifMatch;
+      this.templateId = templateId;
+      this.version = version;
+    }
+
+    /**
+     * Builds a UpdateAccountSettingsTemplateVersionOptions.
+     *
+     * @return the new UpdateAccountSettingsTemplateVersionOptions instance
+     */
+    public UpdateAccountSettingsTemplateVersionOptions build() {
+      return new UpdateAccountSettingsTemplateVersionOptions(this);
+    }
+
+    /**
+     * Set the ifMatch.
+     *
+     * @param ifMatch the ifMatch
+     * @return the UpdateAccountSettingsTemplateVersionOptions builder
+     */
+    public Builder ifMatch(String ifMatch) {
+      this.ifMatch = ifMatch;
+      return this;
+    }
+
+    /**
+     * Set the templateId.
+     *
+     * @param templateId the templateId
+     * @return the UpdateAccountSettingsTemplateVersionOptions builder
+     */
+    public Builder templateId(String templateId) {
+      this.templateId = templateId;
+      return this;
+    }
+
+    /**
+     * Set the version.
+     *
+     * @param version the version
+     * @return the UpdateAccountSettingsTemplateVersionOptions builder
+     */
+    public Builder version(String version) {
+      this.version = version;
+      return this;
+    }
+
+    /**
+     * Set the accountId.
+     *
+     * @param accountId the accountId
+     * @return the UpdateAccountSettingsTemplateVersionOptions builder
+     */
+    public Builder accountId(String accountId) {
+      this.accountId = accountId;
+      return this;
+    }
+
+    /**
+     * Set the name.
+     *
+     * @param name the name
+     * @return the UpdateAccountSettingsTemplateVersionOptions builder
+     */
+    public Builder name(String name) {
+      this.name = name;
+      return this;
+    }
+
+    /**
+     * Set the description.
+     *
+     * @param description the description
+     * @return the UpdateAccountSettingsTemplateVersionOptions builder
+     */
+    public Builder description(String description) {
+      this.description = description;
+      return this;
+    }
+
+    /**
+     * Set the accountSettings.
+     *
+     * @param accountSettings the accountSettings
+     * @return the UpdateAccountSettingsTemplateVersionOptions builder
+     */
+    public Builder accountSettings(AccountSettingsComponent accountSettings) {
+      this.accountSettings = accountSettings;
+      return this;
+    }
+  }
+
+  protected UpdateAccountSettingsTemplateVersionOptions() { }
+
+  protected UpdateAccountSettingsTemplateVersionOptions(Builder builder) {
+    com.ibm.cloud.sdk.core.util.Validator.notNull(builder.ifMatch,
+      "ifMatch cannot be null");
+    com.ibm.cloud.sdk.core.util.Validator.notEmpty(builder.templateId,
+      "templateId cannot be empty");
+    com.ibm.cloud.sdk.core.util.Validator.notEmpty(builder.version,
+      "version cannot be empty");
+    ifMatch = builder.ifMatch;
+    templateId = builder.templateId;
+    version = builder.version;
+    accountId = builder.accountId;
+    name = builder.name;
+    description = builder.description;
+    accountSettings = builder.accountSettings;
+  }
+
+  /**
+   * New builder.
+   *
+   * @return a UpdateAccountSettingsTemplateVersionOptions builder
+   */
+  public Builder newBuilder() {
+    return new Builder(this);
+  }
+
+  /**
+   * Gets the ifMatch.
+   *
+   * Entity tag of the Template to be updated. Specify the tag that you retrieved when reading the account settings
+   * template. This value helps identifying parallel usage of this API. Pass * to indicate to update any version
+   * available. This might result in stale updates.
+   *
+   * @return the ifMatch
+   */
+  public String ifMatch() {
+    return ifMatch;
+  }
+
+  /**
+   * Gets the templateId.
+   *
+   * ID of the account settings template.
+   *
+   * @return the templateId
+   */
+  public String templateId() {
+    return templateId;
+  }
+
+  /**
+   * Gets the version.
+   *
+   * Version of the account settings template.
+   *
+   * @return the version
+   */
+  public String version() {
+    return version;
+  }
+
+  /**
+   * Gets the accountId.
+   *
+   * ID of the account where the template resides.
+   *
+   * @return the accountId
+   */
+  public String accountId() {
+    return accountId;
+  }
+
+  /**
+   * Gets the name.
+   *
+   * The name of the trusted profile template. This is visible only in the enterprise account.
+   *
+   * @return the name
+   */
+  public String name() {
+    return name;
+  }
+
+  /**
+   * Gets the description.
+   *
+   * The description of the trusted profile template. Describe the template for enterprise account users.
+   *
+   * @return the description
+   */
+  public String description() {
+    return description;
+  }
+
+  /**
+   * Gets the accountSettings.
+   *
+   * @return the accountSettings
+   */
+  public AccountSettingsComponent accountSettings() {
+    return accountSettings;
+  }
+}
+

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/UpdateApiKeyOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/UpdateApiKeyOptions.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/UpdateClaimRuleOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/UpdateClaimRuleOptions.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/UpdateProfileOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/UpdateProfileOptions.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/UpdateProfileTemplateVersionOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/UpdateProfileTemplateVersionOptions.java
@@ -1,0 +1,317 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.ibm.cloud.sdk.core.service.model.GenericModel;
+
+/**
+ * The updateProfileTemplateVersion options.
+ */
+public class UpdateProfileTemplateVersionOptions extends GenericModel {
+
+  protected String ifMatch;
+  protected String templateId;
+  protected String version;
+  protected String accountId;
+  protected String name;
+  protected String description;
+  protected TemplateProfileComponentRequest profile;
+  protected List<PolicyTemplateReference> policyTemplateReferences;
+
+  /**
+   * Builder.
+   */
+  public static class Builder {
+    private String ifMatch;
+    private String templateId;
+    private String version;
+    private String accountId;
+    private String name;
+    private String description;
+    private TemplateProfileComponentRequest profile;
+    private List<PolicyTemplateReference> policyTemplateReferences;
+
+    /**
+     * Instantiates a new Builder from an existing UpdateProfileTemplateVersionOptions instance.
+     *
+     * @param updateProfileTemplateVersionOptions the instance to initialize the Builder with
+     */
+    private Builder(UpdateProfileTemplateVersionOptions updateProfileTemplateVersionOptions) {
+      this.ifMatch = updateProfileTemplateVersionOptions.ifMatch;
+      this.templateId = updateProfileTemplateVersionOptions.templateId;
+      this.version = updateProfileTemplateVersionOptions.version;
+      this.accountId = updateProfileTemplateVersionOptions.accountId;
+      this.name = updateProfileTemplateVersionOptions.name;
+      this.description = updateProfileTemplateVersionOptions.description;
+      this.profile = updateProfileTemplateVersionOptions.profile;
+      this.policyTemplateReferences = updateProfileTemplateVersionOptions.policyTemplateReferences;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public Builder() {
+    }
+
+    /**
+     * Instantiates a new builder with required properties.
+     *
+     * @param ifMatch the ifMatch
+     * @param templateId the templateId
+     * @param version the version
+     */
+    public Builder(String ifMatch, String templateId, String version) {
+      this.ifMatch = ifMatch;
+      this.templateId = templateId;
+      this.version = version;
+    }
+
+    /**
+     * Builds a UpdateProfileTemplateVersionOptions.
+     *
+     * @return the new UpdateProfileTemplateVersionOptions instance
+     */
+    public UpdateProfileTemplateVersionOptions build() {
+      return new UpdateProfileTemplateVersionOptions(this);
+    }
+
+    /**
+     * Adds an policyTemplateReferences to policyTemplateReferences.
+     *
+     * @param policyTemplateReferences the new policyTemplateReferences
+     * @return the UpdateProfileTemplateVersionOptions builder
+     */
+    public Builder addPolicyTemplateReferences(PolicyTemplateReference policyTemplateReferences) {
+      com.ibm.cloud.sdk.core.util.Validator.notNull(policyTemplateReferences,
+        "policyTemplateReferences cannot be null");
+      if (this.policyTemplateReferences == null) {
+        this.policyTemplateReferences = new ArrayList<PolicyTemplateReference>();
+      }
+      this.policyTemplateReferences.add(policyTemplateReferences);
+      return this;
+    }
+
+    /**
+     * Set the ifMatch.
+     *
+     * @param ifMatch the ifMatch
+     * @return the UpdateProfileTemplateVersionOptions builder
+     */
+    public Builder ifMatch(String ifMatch) {
+      this.ifMatch = ifMatch;
+      return this;
+    }
+
+    /**
+     * Set the templateId.
+     *
+     * @param templateId the templateId
+     * @return the UpdateProfileTemplateVersionOptions builder
+     */
+    public Builder templateId(String templateId) {
+      this.templateId = templateId;
+      return this;
+    }
+
+    /**
+     * Set the version.
+     *
+     * @param version the version
+     * @return the UpdateProfileTemplateVersionOptions builder
+     */
+    public Builder version(String version) {
+      this.version = version;
+      return this;
+    }
+
+    /**
+     * Set the accountId.
+     *
+     * @param accountId the accountId
+     * @return the UpdateProfileTemplateVersionOptions builder
+     */
+    public Builder accountId(String accountId) {
+      this.accountId = accountId;
+      return this;
+    }
+
+    /**
+     * Set the name.
+     *
+     * @param name the name
+     * @return the UpdateProfileTemplateVersionOptions builder
+     */
+    public Builder name(String name) {
+      this.name = name;
+      return this;
+    }
+
+    /**
+     * Set the description.
+     *
+     * @param description the description
+     * @return the UpdateProfileTemplateVersionOptions builder
+     */
+    public Builder description(String description) {
+      this.description = description;
+      return this;
+    }
+
+    /**
+     * Set the profile.
+     *
+     * @param profile the profile
+     * @return the UpdateProfileTemplateVersionOptions builder
+     */
+    public Builder profile(TemplateProfileComponentRequest profile) {
+      this.profile = profile;
+      return this;
+    }
+
+    /**
+     * Set the policyTemplateReferences.
+     * Existing policyTemplateReferences will be replaced.
+     *
+     * @param policyTemplateReferences the policyTemplateReferences
+     * @return the UpdateProfileTemplateVersionOptions builder
+     */
+    public Builder policyTemplateReferences(List<PolicyTemplateReference> policyTemplateReferences) {
+      this.policyTemplateReferences = policyTemplateReferences;
+      return this;
+    }
+  }
+
+  protected UpdateProfileTemplateVersionOptions() { }
+
+  protected UpdateProfileTemplateVersionOptions(Builder builder) {
+    com.ibm.cloud.sdk.core.util.Validator.notNull(builder.ifMatch,
+      "ifMatch cannot be null");
+    com.ibm.cloud.sdk.core.util.Validator.notEmpty(builder.templateId,
+      "templateId cannot be empty");
+    com.ibm.cloud.sdk.core.util.Validator.notEmpty(builder.version,
+      "version cannot be empty");
+    ifMatch = builder.ifMatch;
+    templateId = builder.templateId;
+    version = builder.version;
+    accountId = builder.accountId;
+    name = builder.name;
+    description = builder.description;
+    profile = builder.profile;
+    policyTemplateReferences = builder.policyTemplateReferences;
+  }
+
+  /**
+   * New builder.
+   *
+   * @return a UpdateProfileTemplateVersionOptions builder
+   */
+  public Builder newBuilder() {
+    return new Builder(this);
+  }
+
+  /**
+   * Gets the ifMatch.
+   *
+   * Entity tag of the Template to be updated. Specify the tag that you retrieved when reading the Profile Template.
+   * This value helps identifying parallel usage of this API. Pass * to indicate to update any version available. This
+   * might result in stale updates.
+   *
+   * @return the ifMatch
+   */
+  public String ifMatch() {
+    return ifMatch;
+  }
+
+  /**
+   * Gets the templateId.
+   *
+   * ID of the trusted profile template.
+   *
+   * @return the templateId
+   */
+  public String templateId() {
+    return templateId;
+  }
+
+  /**
+   * Gets the version.
+   *
+   * Version of the Profile Template.
+   *
+   * @return the version
+   */
+  public String version() {
+    return version;
+  }
+
+  /**
+   * Gets the accountId.
+   *
+   * ID of the account where the template resides.
+   *
+   * @return the accountId
+   */
+  public String accountId() {
+    return accountId;
+  }
+
+  /**
+   * Gets the name.
+   *
+   * The name of the trusted profile template. This is visible only in the enterprise account. Required field when
+   * creating a new template. Otherwise this field is optional. If the field is included it will change the name value
+   * for all existing versions of the template.
+   *
+   * @return the name
+   */
+  public String name() {
+    return name;
+  }
+
+  /**
+   * Gets the description.
+   *
+   * The description of the trusted profile template. Describe the template for enterprise account users.
+   *
+   * @return the description
+   */
+  public String description() {
+    return description;
+  }
+
+  /**
+   * Gets the profile.
+   *
+   * Input body parameters for the TemplateProfileComponent.
+   *
+   * @return the profile
+   */
+  public TemplateProfileComponentRequest profile() {
+    return profile;
+  }
+
+  /**
+   * Gets the policyTemplateReferences.
+   *
+   * Existing policy templates that you can reference to assign access in the trusted profile component.
+   *
+   * @return the policyTemplateReferences
+   */
+  public List<PolicyTemplateReference> policyTemplateReferences() {
+    return policyTemplateReferences;
+  }
+}
+

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/UpdateServiceIdOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/UpdateServiceIdOptions.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/UpdateTrustedProfileAssignmentOptions.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/UpdateTrustedProfileAssignmentOptions.java
@@ -1,0 +1,166 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import com.ibm.cloud.sdk.core.service.model.GenericModel;
+
+/**
+ * The updateTrustedProfileAssignment options.
+ */
+public class UpdateTrustedProfileAssignmentOptions extends GenericModel {
+
+  protected String assignmentId;
+  protected String ifMatch;
+  protected Long templateVersion;
+
+  /**
+   * Builder.
+   */
+  public static class Builder {
+    private String assignmentId;
+    private String ifMatch;
+    private Long templateVersion;
+
+    /**
+     * Instantiates a new Builder from an existing UpdateTrustedProfileAssignmentOptions instance.
+     *
+     * @param updateTrustedProfileAssignmentOptions the instance to initialize the Builder with
+     */
+    private Builder(UpdateTrustedProfileAssignmentOptions updateTrustedProfileAssignmentOptions) {
+      this.assignmentId = updateTrustedProfileAssignmentOptions.assignmentId;
+      this.ifMatch = updateTrustedProfileAssignmentOptions.ifMatch;
+      this.templateVersion = updateTrustedProfileAssignmentOptions.templateVersion;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public Builder() {
+    }
+
+    /**
+     * Instantiates a new builder with required properties.
+     *
+     * @param assignmentId the assignmentId
+     * @param ifMatch the ifMatch
+     * @param templateVersion the templateVersion
+     */
+    public Builder(String assignmentId, String ifMatch, Long templateVersion) {
+      this.assignmentId = assignmentId;
+      this.ifMatch = ifMatch;
+      this.templateVersion = templateVersion;
+    }
+
+    /**
+     * Builds a UpdateTrustedProfileAssignmentOptions.
+     *
+     * @return the new UpdateTrustedProfileAssignmentOptions instance
+     */
+    public UpdateTrustedProfileAssignmentOptions build() {
+      return new UpdateTrustedProfileAssignmentOptions(this);
+    }
+
+    /**
+     * Set the assignmentId.
+     *
+     * @param assignmentId the assignmentId
+     * @return the UpdateTrustedProfileAssignmentOptions builder
+     */
+    public Builder assignmentId(String assignmentId) {
+      this.assignmentId = assignmentId;
+      return this;
+    }
+
+    /**
+     * Set the ifMatch.
+     *
+     * @param ifMatch the ifMatch
+     * @return the UpdateTrustedProfileAssignmentOptions builder
+     */
+    public Builder ifMatch(String ifMatch) {
+      this.ifMatch = ifMatch;
+      return this;
+    }
+
+    /**
+     * Set the templateVersion.
+     *
+     * @param templateVersion the templateVersion
+     * @return the UpdateTrustedProfileAssignmentOptions builder
+     */
+    public Builder templateVersion(long templateVersion) {
+      this.templateVersion = templateVersion;
+      return this;
+    }
+  }
+
+  protected UpdateTrustedProfileAssignmentOptions() { }
+
+  protected UpdateTrustedProfileAssignmentOptions(Builder builder) {
+    com.ibm.cloud.sdk.core.util.Validator.notEmpty(builder.assignmentId,
+      "assignmentId cannot be empty");
+    com.ibm.cloud.sdk.core.util.Validator.notNull(builder.ifMatch,
+      "ifMatch cannot be null");
+    com.ibm.cloud.sdk.core.util.Validator.notNull(builder.templateVersion,
+      "templateVersion cannot be null");
+    assignmentId = builder.assignmentId;
+    ifMatch = builder.ifMatch;
+    templateVersion = builder.templateVersion;
+  }
+
+  /**
+   * New builder.
+   *
+   * @return a UpdateTrustedProfileAssignmentOptions builder
+   */
+  public Builder newBuilder() {
+    return new Builder(this);
+  }
+
+  /**
+   * Gets the assignmentId.
+   *
+   * ID of the Assignment Record.
+   *
+   * @return the assignmentId
+   */
+  public String assignmentId() {
+    return assignmentId;
+  }
+
+  /**
+   * Gets the ifMatch.
+   *
+   * Version of the Assignment to be updated. Specify the version that you retrieved when reading the Assignment. This
+   * value  helps identifying parallel usage of this API. Pass * to indicate to update any version available. This might
+   * result in stale updates.
+   *
+   * @return the ifMatch
+   */
+  public String ifMatch() {
+    return ifMatch;
+  }
+
+  /**
+   * Gets the templateVersion.
+   *
+   * Template version to be applied to the assignment. To retry all failed assignemtns, provide the existing version. To
+   * migrate to a different version, provide the new version number.
+   *
+   * @return the templateVersion
+   */
+  public Long templateVersion() {
+    return templateVersion;
+  }
+}
+

--- a/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/UserActivity.java
+++ b/modules/iam-identity/src/main/java/com/ibm/cloud/platform_services/iam_identity/v1/model/UserActivity.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/IamIdentityIT.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/IamIdentityIT.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2020, 2021.
+ * (C) Copyright IBM Corp. 2020, 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -29,67 +29,7 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import com.ibm.cloud.platform_services.iam_identity.v1.model.AccountSettingsResponse;
-import com.ibm.cloud.platform_services.iam_identity.v1.model.AccountSettingsUserMFA;
-import com.ibm.cloud.platform_services.iam_identity.v1.model.ApiKey;
-import com.ibm.cloud.platform_services.iam_identity.v1.model.ApiKeyList;
-import com.ibm.cloud.platform_services.iam_identity.v1.model.CreateApiKeyOptions;
-import com.ibm.cloud.platform_services.iam_identity.v1.model.CreateClaimRuleOptions;
-import com.ibm.cloud.platform_services.iam_identity.v1.model.CreateLinkOptions;
-import com.ibm.cloud.platform_services.iam_identity.v1.model.CreateMfaReportOptions;
-import com.ibm.cloud.platform_services.iam_identity.v1.model.CreateProfileLinkRequestLink;
-import com.ibm.cloud.platform_services.iam_identity.v1.model.CreateProfileOptions;
-import com.ibm.cloud.platform_services.iam_identity.v1.model.CreateReportOptions;
-import com.ibm.cloud.platform_services.iam_identity.v1.model.CreateServiceIdOptions;
-import com.ibm.cloud.platform_services.iam_identity.v1.model.DeleteApiKeyOptions;
-import com.ibm.cloud.platform_services.iam_identity.v1.model.DeleteClaimRuleOptions;
-import com.ibm.cloud.platform_services.iam_identity.v1.model.DeleteLinkOptions;
-import com.ibm.cloud.platform_services.iam_identity.v1.model.DeleteProfileIdentityOptions;
-import com.ibm.cloud.platform_services.iam_identity.v1.model.DeleteProfileOptions;
-import com.ibm.cloud.platform_services.iam_identity.v1.model.DeleteServiceIdOptions;
-import com.ibm.cloud.platform_services.iam_identity.v1.model.GetAccountSettingsOptions;
-import com.ibm.cloud.platform_services.iam_identity.v1.model.GetApiKeyOptions;
-import com.ibm.cloud.platform_services.iam_identity.v1.model.GetApiKeysDetailsOptions;
-import com.ibm.cloud.platform_services.iam_identity.v1.model.GetClaimRuleOptions;
-import com.ibm.cloud.platform_services.iam_identity.v1.model.GetLinkOptions;
-import com.ibm.cloud.platform_services.iam_identity.v1.model.GetMfaReportOptions;
-import com.ibm.cloud.platform_services.iam_identity.v1.model.GetMfaStatusOptions;
-import com.ibm.cloud.platform_services.iam_identity.v1.model.GetProfileIdentitiesOptions;
-import com.ibm.cloud.platform_services.iam_identity.v1.model.GetProfileIdentityOptions;
-import com.ibm.cloud.platform_services.iam_identity.v1.model.GetProfileOptions;
-import com.ibm.cloud.platform_services.iam_identity.v1.model.GetReportOptions;
-import com.ibm.cloud.platform_services.iam_identity.v1.model.GetServiceIdOptions;
-import com.ibm.cloud.platform_services.iam_identity.v1.model.ListApiKeysOptions;
-import com.ibm.cloud.platform_services.iam_identity.v1.model.ListClaimRulesOptions;
-import com.ibm.cloud.platform_services.iam_identity.v1.model.ListLinksOptions;
-import com.ibm.cloud.platform_services.iam_identity.v1.model.ListProfilesOptions;
-import com.ibm.cloud.platform_services.iam_identity.v1.model.ListServiceIdsOptions;
-import com.ibm.cloud.platform_services.iam_identity.v1.model.LockApiKeyOptions;
-import com.ibm.cloud.platform_services.iam_identity.v1.model.LockServiceIdOptions;
-import com.ibm.cloud.platform_services.iam_identity.v1.model.ProfileClaimRule;
-import com.ibm.cloud.platform_services.iam_identity.v1.model.ProfileClaimRuleConditions;
-import com.ibm.cloud.platform_services.iam_identity.v1.model.ProfileClaimRuleList;
-import com.ibm.cloud.platform_services.iam_identity.v1.model.ProfileIdentitiesResponse;
-import com.ibm.cloud.platform_services.iam_identity.v1.model.ProfileIdentity;
-import com.ibm.cloud.platform_services.iam_identity.v1.model.ProfileLink;
-import com.ibm.cloud.platform_services.iam_identity.v1.model.ProfileLinkList;
-import com.ibm.cloud.platform_services.iam_identity.v1.model.Report;
-import com.ibm.cloud.platform_services.iam_identity.v1.model.ReportMfaEnrollmentStatus;
-import com.ibm.cloud.platform_services.iam_identity.v1.model.ReportReference;
-import com.ibm.cloud.platform_services.iam_identity.v1.model.ServiceId;
-import com.ibm.cloud.platform_services.iam_identity.v1.model.ServiceIdList;
-import com.ibm.cloud.platform_services.iam_identity.v1.model.SetProfileIdentitiesOptions;
-import com.ibm.cloud.platform_services.iam_identity.v1.model.SetProfileIdentityOptions;
-import com.ibm.cloud.platform_services.iam_identity.v1.model.TrustedProfile;
-import com.ibm.cloud.platform_services.iam_identity.v1.model.TrustedProfilesList;
-import com.ibm.cloud.platform_services.iam_identity.v1.model.UnlockApiKeyOptions;
-import com.ibm.cloud.platform_services.iam_identity.v1.model.UnlockServiceIdOptions;
-import com.ibm.cloud.platform_services.iam_identity.v1.model.UpdateAccountSettingsOptions;
-import com.ibm.cloud.platform_services.iam_identity.v1.model.UpdateApiKeyOptions;
-import com.ibm.cloud.platform_services.iam_identity.v1.model.UpdateClaimRuleOptions;
-import com.ibm.cloud.platform_services.iam_identity.v1.model.UpdateProfileOptions;
-import com.ibm.cloud.platform_services.iam_identity.v1.model.UpdateServiceIdOptions;
-import com.ibm.cloud.platform_services.iam_identity.v1.model.UserMfaEnrollments;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.*;
 import com.ibm.cloud.platform_services.test.SdkIntegrationTestBase;
 import com.ibm.cloud.sdk.core.http.Response;
 import com.ibm.cloud.sdk.core.service.exception.NotFoundException;
@@ -110,12 +50,18 @@ public class IamIdentityIT extends SdkIntegrationTestBase {
     private static String PROFILE_NAME_1 = "Java-SDK-IT-TrustedProfile1";
     private static String PROFILE_NAME_2 = "Java-SDK-IT-TrustedProfile2";
     private static String CLAIMRULE_TYPE = "Profile-SAML";
-    private static String REALM_NAME = "https://w3id.sso.ibm.com/auth/sps/samlidp2/saml20";
+    private static String REALM_NAME = "https://sdk.test.realm/1234";
+    private static String PROFILE_TEMPLATE_NAME = "Java-SDK-IT-TrustedProfileTemplate";
+    private static String PROFILE_TEMPLATE_PROFILE_NAME = "Java-SDK-IT-TrustedProfile-FromTemplate";
+    private static String ASSIGNMENT_TARGET_TYPE_ACCOUNT = "Account";
+    private static String ACCOUNT_SETTINGS_TEMPLATE_NAME = "Java-SDK-IT-AccountSettingsTemplate";
 
     private static String ACCOUNT_ID;
     private static String IAM_ID;
     private static String IAM_ID_MEMBER;
     private static String IAM_APIKEY;
+    private static String ENTERPRISE_ACCOUNT_ID;
+    private static String ENTERPRISE_SUBACCOUNT_ID;
 
     private static String IAM_ID_INVALID = "IAM-InvalidId";
     private static String ACCOUNT_ID_INVALID = "Account-InvalidId";
@@ -143,7 +89,19 @@ public class IamIdentityIT extends SdkIntegrationTestBase {
 
     private String reportReference;
     private String reportReferenceMfa;
+    
+    private String profileTemplateId;
+    private long profileTemplateVersion;
+    private String profileTemplateEtag;
+    private String profileTemplateAssignmentId;
+    private String profileTemplateAssignmentEtag;
 
+    private String accountSettingsTemplateId;
+    private long accountSettingsTemplateVersion;
+    private String accountSettingsTemplateEtag;
+    private String accountSettingsTemplateAssignmentId;
+    private String accountSettingsTemplateAssignmentEtag;
+    
     @Override
     public String getConfigFilename() {
         return "../../iam_identity.env";
@@ -169,6 +127,8 @@ public class IamIdentityIT extends SdkIntegrationTestBase {
         IAM_ID = config.get("IAM_ID");
         IAM_ID_MEMBER = config.get("IAM_ID_MEMBER");
         IAM_APIKEY = config.get("APIKEY");
+        ENTERPRISE_ACCOUNT_ID = config.get("ENTERPRISE_ACCOUNT_ID"); 
+        ENTERPRISE_SUBACCOUNT_ID = config.get("ENTERPRISE_SUBACCOUNT_ID"); 
 
         profileId1 = config.get("profileId1");
 
@@ -1752,13 +1712,13 @@ public class IamIdentityIT extends SdkIntegrationTestBase {
         	accounts.add(ACCOUNT_ID);
         	String type="user";
         	String description="Identity description";
-        	ProfileIdentity profileIdentity= new ProfileIdentity.Builder()
+        	ProfileIdentityRequest profileIdentity= new ProfileIdentityRequest.Builder()
         			.identifier(IAM_ID)
         			.accounts(accounts)
         			.type(type)
         			.description(description)
         			.build();
-        	List<ProfileIdentity> listProfileIdentity= new ArrayList<ProfileIdentity>();
+        	List<ProfileIdentityRequest> listProfileIdentity= new ArrayList<ProfileIdentityRequest>();
         	listProfileIdentity.add(profileIdentity);
 
         	SetProfileIdentitiesOptions setProfileIdentitiesOptions = new SetProfileIdentitiesOptions.Builder()
@@ -1816,15 +1776,15 @@ public class IamIdentityIT extends SdkIntegrationTestBase {
         			.accounts(accounts)
         			.description(description)
                     .build();
-            Response<ProfileIdentity> response = service.setProfileIdentity(setProfileIdentityOptions).execute();
+            Response<ProfileIdentityResponse> response = service.setProfileIdentity(setProfileIdentityOptions).execute();
             // Validate response
             assertNotNull(response);
             assertEquals(response.getStatusCode(), 200);
 
-            ProfileIdentity profileIdentityResponseResult = response.getResult();
+            ProfileIdentityResponse profileIdentityResponseResult = response.getResult();
             assertNotNull(profileIdentityResponseResult);
-            assertNotNull(profileIdentityResponseResult.identifier());
-            assertEquals(profileIdentityResponseResult.identifier(), IAM_ID_MEMBER);
+            assertNotNull(profileIdentityResponseResult.getIdentifier());
+            assertEquals(profileIdentityResponseResult.getIdentifier(), IAM_ID_MEMBER);
         } catch (ServiceResponseException e) {
             fail(String.format("Service returned status code %d: %s\nError details: %s",
                     e.getStatusCode(), e.getMessage(), e.getDebuggingInfo()));
@@ -1839,14 +1799,14 @@ public class IamIdentityIT extends SdkIntegrationTestBase {
                     .identityType("user")
                     .identifierId(IAM_ID_MEMBER)
                     .build();
-            Response<ProfileIdentity> response = service.getProfileIdentity(getProfileIdentityOptions).execute();
+            Response<ProfileIdentityResponse> response = service.getProfileIdentity(getProfileIdentityOptions).execute();
             // Validate response
             assertNotNull(response);
             assertEquals(response.getStatusCode(), 200);
 
-            ProfileIdentity profileIdentityResponseResult = response.getResult();
+            ProfileIdentityResponse profileIdentityResponseResult = response.getResult();
             assertNotNull(profileIdentityResponseResult);
-            assertNotNull(profileIdentityResponseResult.identifier());
+            assertNotNull(profileIdentityResponseResult.getIdentifier());
         } catch (ServiceResponseException e) {
             fail(String.format("Service returned status code %d: %s\nError details: %s",
                     e.getStatusCode(), e.getMessage(), e.getDebuggingInfo()));
@@ -1871,7 +1831,686 @@ public class IamIdentityIT extends SdkIntegrationTestBase {
                     e.getStatusCode(), e.getMessage(), e.getDebuggingInfo()));
         }
     }
+    
+    @Test
+    public void testCreateProfileTemplate() throws Exception {
+        try {
+            ProfileClaimRuleConditions condition = new ProfileClaimRuleConditions.Builder()
+                    .claim("blueGroups")
+                    .operator("EQUALS")
+                    .value("\"cloud-docs-dev\"")
+                    .build();
+            List<ProfileClaimRuleConditions> conditions = new ArrayList<>();
+            conditions.add(condition);
+            
+        	TrustedProfileTemplateClaimRule claimRule = new TrustedProfileTemplateClaimRule.Builder()
+        			.name("My Rule")
+        			.realmName(REALM_NAME)
+        			.type(CLAIMRULE_TYPE)
+        			.expiration(43200)
+        			.conditions(conditions)
+        			.build();
+        	
+        	TemplateProfileComponentRequest profile = new TemplateProfileComponentRequest.Builder()
+        			.addRules(claimRule)
+        			.name(PROFILE_TEMPLATE_PROFILE_NAME)
+        			.description("JavaSDK test Profile cretaed from Profile Template #1")
+        			.build();
+        	
+        	CreateProfileTemplateOptions createProfileTemplateOptions = new CreateProfileTemplateOptions.Builder()
+        			.name(PROFILE_TEMPLATE_NAME)
+                    .description("JavaSDK test Profile Template #1")
+                    .accountId(ENTERPRISE_ACCOUNT_ID)
+                    .profile(profile)
+        			.build();
+        			
+            Response<TrustedProfileTemplateResponse> response = service.createProfileTemplate(createProfileTemplateOptions).execute();
+            assertNotNull(response);
+            assertEquals(response.getStatusCode(), 201);
 
+            TrustedProfileTemplateResponse trustedProfileTemplateResult = response.getResult();
+            assertNotNull(trustedProfileTemplateResult);
+
+            // Save the id for use by other test methods.
+            assertNotNull(trustedProfileTemplateResult.getId());
+            profileTemplateId = trustedProfileTemplateResult.getId();
+            assertNotNull(trustedProfileTemplateResult.getVersion());
+            profileTemplateVersion = trustedProfileTemplateResult.getVersion().longValue();
+        } catch (ServiceResponseException e) {
+            fail(String.format("Service returned status code %d: %s\nError details: %s",
+                    e.getStatusCode(), e.getMessage(), e.getDebuggingInfo()));
+        }
+    }
+    
+    
+    @Test(dependsOnMethods = { "testCreateProfileTemplate" })
+    public void testGetProfileTemplate() throws Exception {
+        try {
+            GetProfileTemplateVersionOptions getProfileTemplateOptions = new GetProfileTemplateVersionOptions.Builder()
+            		.templateId(profileTemplateId)
+            		.version(Long.toString(profileTemplateVersion))
+                    .build();
+
+            Response<TrustedProfileTemplateResponse> response = service.getProfileTemplateVersion(getProfileTemplateOptions).execute();
+            assertNotNull(response);
+            assertEquals(response.getStatusCode(), 200);
+
+            TrustedProfileTemplateResponse profileTemplateResult = response.getResult();
+            assertNotNull(profileTemplateResult);
+
+            assertEquals(profileTemplateResult.getId(), profileTemplateId);
+
+            // Grab the Etag value from the response for use in the update operation.
+            assertNotNull(response.getHeaders().values("Etag"));
+            assertEquals(response.getHeaders().values("Etag").size(), 1);
+            profileTemplateEtag = response.getHeaders().values("Etag").get(0);
+            assertNotNull(profileTemplateEtag);
+        } catch (ServiceResponseException e) {
+            fail(String.format("Service returned status code %d: %s\nError details: %s",
+                    e.getStatusCode(), e.getMessage(), e.getDebuggingInfo()));
+        }
+    }
+
+    @Test(dependsOnMethods = { "testCreateProfileTemplate" })
+    public void testListProfileTemplates() throws Exception {
+        try {
+        	ListProfileTemplatesOptions listOptions = new ListProfileTemplatesOptions.Builder()
+        			.accountId(ENTERPRISE_ACCOUNT_ID)
+        			.build();
+        	
+        	Response<TrustedProfileTemplateList> response = service.listProfileTemplates(listOptions).execute();
+            assertNotNull(response);
+            assertEquals(response.getStatusCode(), 200);
+            assertNotNull(response.getResult());
+
+        } catch (ServiceResponseException e) {
+            fail(String.format("Service returned status code %d: %s\nError details: %s",
+                    e.getStatusCode(), e.getMessage(), e.getDebuggingInfo()));
+        }
+    }
+    
+    @Test(dependsOnMethods = { "testGetProfileTemplate" })
+    public void testUpdateProfileTemplate() throws Exception {
+        try {
+        	UpdateProfileTemplateVersionOptions updateOptions = new UpdateProfileTemplateVersionOptions.Builder()
+        			.accountId(ENTERPRISE_ACCOUNT_ID)
+        			.templateId(profileTemplateId)
+        			.version(Long.toString(profileTemplateVersion))
+        			.ifMatch(profileTemplateEtag)
+        			.name(PROFILE_TEMPLATE_NAME)
+        			.description("JavaSDK test Profile Template #1 - updated")
+        			.build();
+        	
+        	Response<TrustedProfileTemplateResponse> updateResponse = service.updateProfileTemplateVersion(updateOptions).execute();
+            assertNotNull(updateResponse);
+            assertEquals(updateResponse.getStatusCode(), 200);
+            assertNotNull(updateResponse.getResult());
+        	
+            // Grab the Etag value from the response for use in the update operation.
+            assertNotNull(updateResponse.getHeaders().values("Etag"));
+            assertEquals(updateResponse.getHeaders().values("Etag").size(), 1);
+            profileTemplateEtag = updateResponse.getHeaders().values("Etag").get(0);
+            assertNotNull(profileTemplateEtag);
+        } catch (ServiceResponseException e) {
+            fail(String.format("Service returned status code %d: %s\nError details: %s",
+                    e.getStatusCode(), e.getMessage(), e.getDebuggingInfo()));
+        }
+    }
+    
+    @Test(dependsOnMethods = { "testUpdateProfileTemplate" })
+    public void testAssignProfileTemplate() throws Exception {
+        try {
+        	CommitProfileTemplateOptions commitOptions = new CommitProfileTemplateOptions.Builder()
+        			.templateId(profileTemplateId)
+        			.version(Long.toString(profileTemplateVersion))
+        			.build();
+        	
+        	Response<Void> commitResponse = service.commitProfileTemplate(commitOptions).execute();
+            assertNotNull(commitResponse);
+            assertEquals(commitResponse.getStatusCode(), 204);
+            
+            CreateTrustedProfileAssignmentOptions assignOptions = new CreateTrustedProfileAssignmentOptions.Builder()
+            		.templateId(profileTemplateId)
+            		.templateVersion(profileTemplateVersion)
+            		.targetType(ASSIGNMENT_TARGET_TYPE_ACCOUNT)
+            		.target(ENTERPRISE_SUBACCOUNT_ID)
+            		.build();
+            
+            Response<TemplateAssignmentResponse> assignResponse = service.createTrustedProfileAssignment(assignOptions).execute();
+            assertNotNull(commitResponse);
+            assertEquals(commitResponse.getStatusCode(), 204);
+            
+            TemplateAssignmentResponse assignmentResponseResult = assignResponse.getResult();
+            assertNotNull(assignmentResponseResult);
+
+            // Save the id for use by other test methods.
+            assertNotNull(assignmentResponseResult.getId());
+            profileTemplateAssignmentId = assignmentResponseResult.getId();
+            // Grab the Etag value from the response for use in the update operation.
+            assertNotNull(assignResponse.getHeaders().values("Etag"));
+            assertEquals(assignResponse.getHeaders().values("Etag").size(), 1);
+            profileTemplateAssignmentEtag = assignResponse.getHeaders().values("Etag").get(0);
+            assertNotNull(profileTemplateAssignmentEtag);
+            
+        } catch (ServiceResponseException e) {
+            fail(String.format("Service returned status code %d: %s\nError details: %s",
+                    e.getStatusCode(), e.getMessage(), e.getDebuggingInfo()));
+        }
+    }
+    
+    @Test(dependsOnMethods = { "testAssignProfileTemplate" })
+    public void testListProfileTemplateAssignments() throws Exception {
+        try {
+        	ListTrustedProfileAssignmentsOptions listOptions = new ListTrustedProfileAssignmentsOptions.Builder()
+        			.accountId(ENTERPRISE_ACCOUNT_ID)
+        			.templateId(profileTemplateId)
+        			.build();
+        	
+        	Response<TemplateAssignmentListResponse> listResponse = service.listTrustedProfileAssignments(listOptions).execute();
+            assertNotNull(listResponse);
+            assertEquals(listResponse.getStatusCode(), 200);
+            assertNotNull(listResponse.getResult());
+            
+            TemplateAssignmentListResponse listResult = listResponse.getResult();
+            assertNotNull(listResult.getAssignments());
+            assertEquals(listResult.getAssignments().size(), 1);
+        	
+        } catch (ServiceResponseException e) {
+            fail(String.format("Service returned status code %d: %s\nError details: %s",
+                    e.getStatusCode(), e.getMessage(), e.getDebuggingInfo()));
+        }
+    }
+    
+    @Test(dependsOnMethods = { "testAssignProfileTemplate" })
+    public void testCreateNewProfileTemplateVersion() throws Exception {
+        try {
+            ProfileClaimRuleConditions condition = new ProfileClaimRuleConditions.Builder()
+                    .claim("blueGroups")
+                    .operator("EQUALS")
+                    .value("\"cloud-docs-dev\"")
+                    .build();
+            List<ProfileClaimRuleConditions> conditions = new ArrayList<>();
+            conditions.add(condition);
+            
+        	TrustedProfileTemplateClaimRule claimRule = new TrustedProfileTemplateClaimRule.Builder()
+        			.name("My Rule")
+        			.realmName(REALM_NAME)
+        			.type(CLAIMRULE_TYPE)
+        			.expiration(43200)
+        			.conditions(conditions)
+        			.build();
+        	
+        	List<String> accounts= new ArrayList<String>();
+        	accounts.add(ENTERPRISE_ACCOUNT_ID);
+        	ProfileIdentityRequest profileIdentity= new ProfileIdentityRequest.Builder()
+        			.identifier(IAM_ID)
+        			.accounts(accounts)
+        			.type("user")
+        			.description("Identity description")
+        			.build();
+        	List<ProfileIdentityRequest> identities= new ArrayList<ProfileIdentityRequest>();
+        	identities.add(profileIdentity);
+        	
+        	TemplateProfileComponentRequest profile = new TemplateProfileComponentRequest.Builder()
+        			.addRules(claimRule)
+        			.name(PROFILE_TEMPLATE_PROFILE_NAME)
+        			.description("JavaSDK test Profile cretaed from Profile Template #1 - new version")
+        			.identities(identities)
+        			.build();
+        	
+        	CreateProfileTemplateVersionOptions createOptions = new CreateProfileTemplateVersionOptions.Builder()
+        			.accountId(ENTERPRISE_ACCOUNT_ID)
+        			.templateId(profileTemplateId)
+        			.name(PROFILE_TEMPLATE_NAME)
+        			.description("JavaSDK test Profile Template #1 - new version")
+        			.profile(profile)
+        			.build();
+        	
+        	Response<TrustedProfileTemplateResponse> createResponse = service.createProfileTemplateVersion(createOptions).execute();
+            assertNotNull(createResponse);
+            assertEquals(createResponse.getStatusCode(), 201);
+            assertNotNull(createResponse.getResult());
+            
+            TrustedProfileTemplateResponse createResult = createResponse.getResult();
+            assertNotNull(createResult);
+
+            // Save the version for use by other test methods.
+            assertNotNull(createResult.getVersion());
+            profileTemplateVersion = createResult.getVersion().longValue();
+        } catch (ServiceResponseException e) {
+            fail(String.format("Service returned status code %d: %s\nError details: %s",
+                    e.getStatusCode(), e.getMessage(), e.getDebuggingInfo()));
+        }
+    }
+    
+    @Test(dependsOnMethods = { "testCreateNewProfileTemplateVersion" })
+    public void testGetLatestProfileTemplateVersion() throws Exception {
+    	GetLatestProfileTemplateVersionOptions getOptions = new GetLatestProfileTemplateVersionOptions.Builder()
+    			.templateId(profileTemplateId)
+    			.build();
+    	
+    	Response<TrustedProfileTemplateResponse> getResponse = service.getLatestProfileTemplateVersion(getOptions).execute();
+        assertNotNull(getResponse);
+        assertEquals(getResponse.getStatusCode(), 200);
+        assertNotNull(getResponse.getResult());
+    }
+    
+    @Test(dependsOnMethods = { "testCreateNewProfileTemplateVersion" })
+    public void testListProfileTemplateVersions() throws Exception {
+    	
+    	ListVersionsOfProfileTemplateOptions listOptions = new ListVersionsOfProfileTemplateOptions.Builder()
+    			.templateId(profileTemplateId)
+    			.build();
+    	
+    	Response<TrustedProfileTemplateList> listResponse = service.listVersionsOfProfileTemplate(listOptions).execute();
+        assertNotNull(listResponse);
+        assertEquals(listResponse.getStatusCode(), 200);
+        assertNotNull(listResponse.getResult());
+        TrustedProfileTemplateList listResult = listResponse.getResult();
+        assertNotNull(listResult.getProfileTemplates());
+        assertTrue(listResult.getProfileTemplates().size() > 0);
+    }
+    
+    @Test(dependsOnMethods = { "testAssignProfileTemplate", "testCreateNewProfileTemplateVersion" })
+    public void testUpdateProfileTemplateAssignment() throws Exception {
+        try {
+        	CommitProfileTemplateOptions commitOptions = new CommitProfileTemplateOptions.Builder()
+        			.templateId(profileTemplateId)
+        			.version(Long.toString(profileTemplateVersion))
+        			.build();
+        	
+        	Response<Void> commitResponse = service.commitProfileTemplate(commitOptions).execute();
+            assertNotNull(commitResponse);
+            assertEquals(commitResponse.getStatusCode(), 204);
+
+        	waitUntilTrustedProfileAssignmentFinished(profileTemplateAssignmentId);
+        	
+        	UpdateTrustedProfileAssignmentOptions updateOptions = new UpdateTrustedProfileAssignmentOptions.Builder()
+        			.assignmentId(profileTemplateAssignmentId)
+        			.templateVersion(profileTemplateVersion)
+        			.ifMatch(profileTemplateAssignmentEtag)
+        			.build();
+        	
+        	Response<TemplateAssignmentResponse> updateResponse = service.updateTrustedProfileAssignment(updateOptions).execute();
+            assertNotNull(updateResponse);
+            assertEquals(updateResponse.getStatusCode(), 202);
+            assertNotNull(updateResponse.getResult());
+            
+            // Grab the Etag value from the response for use in the update operation.
+            assertNotNull(updateResponse.getHeaders().values("Etag"));
+            assertEquals(updateResponse.getHeaders().values("Etag").size(), 1);
+            profileTemplateAssignmentEtag = updateResponse.getHeaders().values("Etag").get(0);
+            assertNotNull(profileTemplateAssignmentEtag);
+            
+        } catch (ServiceResponseException e) {
+            fail(String.format("Service returned status code %d: %s\nError details: %s",
+                    e.getStatusCode(), e.getMessage(), e.getDebuggingInfo()));
+        }
+    }
+    
+    @Test(dependsOnMethods = { "testUpdateProfileTemplateAssignment" })
+    public void testDeleteProfileTemplateAssignment() throws Exception {
+        try {
+        	waitUntilTrustedProfileAssignmentFinished(profileTemplateAssignmentId);
+        	
+        	DeleteTrustedProfileAssignmentOptions deleteOptions = new DeleteTrustedProfileAssignmentOptions.Builder()
+        			.assignmentId(profileTemplateAssignmentId)
+        			.build();
+        	
+        	Response<ExceptionResponse> deleteResponse = service.deleteTrustedProfileAssignment(deleteOptions).execute();
+            assertNotNull(deleteResponse);
+            assertEquals(deleteResponse.getStatusCode(), 202);
+        	
+        } catch (ServiceResponseException e) {
+            fail(String.format("Service returned status code %d: %s\nError details: %s",
+                    e.getStatusCode(), e.getMessage(), e.getDebuggingInfo()));
+        }
+    }
+    
+    @Test(dependsOnMethods = { "testDeleteProfileTemplateAssignment" })
+    public void testDeleteProfileTemplateVersion() throws Exception {
+        try {
+        	DeleteProfileTemplateVersionOptions deleteOptions = new DeleteProfileTemplateVersionOptions.Builder()
+        			.templateId(profileTemplateId)
+        			.version("1")
+        			.build();
+        	
+        	Response<Void> deleteResponse = service.deleteProfileTemplateVersion(deleteOptions).execute();
+            assertNotNull(deleteResponse);
+            assertEquals(deleteResponse.getStatusCode(), 204);
+        } catch (ServiceResponseException e) {
+            fail(String.format("Service returned status code %d: %s\nError details: %s",
+                    e.getStatusCode(), e.getMessage(), e.getDebuggingInfo()));
+        }
+    }
+    
+    @Test(dependsOnMethods = { "testDeleteProfileTemplateVersion" })
+    public void testDeleteProfileTemplate() throws Exception {
+        try {
+        	waitUntilTrustedProfileAssignmentFinished(profileTemplateAssignmentId);
+        	
+            DeleteAllVersionsOfProfileTemplateOptions deleteTeplateOptions = new DeleteAllVersionsOfProfileTemplateOptions.Builder()
+            		.templateId(profileTemplateId)
+                    .build();
+
+            // Invoke operation
+            Response<Void> deleteResponse = service.deleteAllVersionsOfProfileTemplate(deleteTeplateOptions).execute();
+            assertNotNull(deleteResponse);
+            assertEquals(deleteResponse.getStatusCode(), 204);
+        } catch (ServiceResponseException e) {
+            fail(String.format("Service returned status code %d: %s\nError details: %s",
+                    e.getStatusCode(), e.getMessage(), e.getDebuggingInfo()));
+        }
+    }
+    
+    @Test
+    public void testCreateAccountSettingsTemplate() throws Exception {
+        try {
+        	
+        	AccountSettingsComponent accountSettings = new AccountSettingsComponent.Builder()
+        			.mfa("LEVEL1")
+        			.systemAccessTokenExpirationInSeconds("3000")
+        			.build();
+        	CreateAccountSettingsTemplateOptions createOptions = new CreateAccountSettingsTemplateOptions.Builder()
+        			.accountId(ENTERPRISE_ACCOUNT_ID)
+        			.name(ACCOUNT_SETTINGS_TEMPLATE_NAME)
+        			.description("JavaSDK test Account Settings Template #1")
+        			.accountSettings(accountSettings)
+        			.build();
+        	Response<AccountSettingsTemplateResponse> createResponse = service.createAccountSettingsTemplate(createOptions).execute();
+            assertNotNull(createResponse);
+            assertEquals(createResponse.getStatusCode(), 201);
+
+            AccountSettingsTemplateResponse createResult = createResponse.getResult();
+            assertNotNull(createResult);
+
+            // Save the id for use by other test methods.
+            assertNotNull(createResult.getId());
+            accountSettingsTemplateId = createResult.getId();
+            assertNotNull(createResult.getVersion());
+            accountSettingsTemplateVersion = createResult.getVersion().longValue();
+        	
+        } catch (ServiceResponseException e) {
+            fail(String.format("Service returned status code %d: %s\nError details: %s",
+                    e.getStatusCode(), e.getMessage(), e.getDebuggingInfo()));
+        }
+    }
+    
+    @Test(dependsOnMethods = { "testCreateAccountSettingsTemplate" })
+    public void testGetAccountSettingsTemplate() throws Exception {
+        try {
+            GetAccountSettingsTemplateVersionOptions getOptions = new GetAccountSettingsTemplateVersionOptions.Builder()
+            		.templateId(accountSettingsTemplateId)
+            		.version(Long.toString(accountSettingsTemplateVersion))
+                    .build();
+
+            Response<AccountSettingsTemplateResponse> response = service.getAccountSettingsTemplateVersion(getOptions).execute();
+            assertNotNull(response);
+            assertEquals(response.getStatusCode(), 200);
+
+            AccountSettingsTemplateResponse getResult = response.getResult();
+            assertNotNull(getResult);
+
+            assertEquals(getResult.getId(), accountSettingsTemplateId);
+
+            // Grab the Etag value from the response for use in the update operation.
+            assertNotNull(response.getHeaders().values("Etag"));
+            assertEquals(response.getHeaders().values("Etag").size(), 1);
+            accountSettingsTemplateEtag = response.getHeaders().values("Etag").get(0);
+            assertNotNull(accountSettingsTemplateEtag);
+        } catch (ServiceResponseException e) {
+            fail(String.format("Service returned status code %d: %s\nError details: %s",
+                    e.getStatusCode(), e.getMessage(), e.getDebuggingInfo()));
+        }
+    }
+
+    @Test(dependsOnMethods = { "testCreateAccountSettingsTemplate" })
+    public void testListAccountSettingsTemplates() throws Exception {
+        try {
+        	ListAccountSettingsTemplatesOptions listOptions = new ListAccountSettingsTemplatesOptions.Builder()
+        			.accountId(ENTERPRISE_ACCOUNT_ID)
+        			.build();
+        	
+        	Response<AccountSettingsTemplateList> response = service.listAccountSettingsTemplates(listOptions).execute();
+            assertNotNull(response);
+            assertEquals(response.getStatusCode(), 200);
+            assertNotNull(response.getResult());
+
+        } catch (ServiceResponseException e) {
+            fail(String.format("Service returned status code %d: %s\nError details: %s",
+                    e.getStatusCode(), e.getMessage(), e.getDebuggingInfo()));
+        }
+    }
+    
+    @Test(dependsOnMethods = { "testCreateAccountSettingsTemplate" })
+    public void testUpdateAccountSettingsTemplate() throws Exception {
+        try {
+        	AccountSettingsComponent accountSettings = new AccountSettingsComponent.Builder()
+        			.mfa("LEVEL1")
+        			.systemAccessTokenExpirationInSeconds("3000")
+        			.build();
+        	UpdateAccountSettingsTemplateVersionOptions updateOptions = new UpdateAccountSettingsTemplateVersionOptions.Builder()
+        			.accountId(ENTERPRISE_ACCOUNT_ID)
+        			.templateId(accountSettingsTemplateId)
+        			.version(Long.toString(accountSettingsTemplateVersion))
+        			.ifMatch(accountSettingsTemplateEtag)
+        			.name(ACCOUNT_SETTINGS_TEMPLATE_NAME)
+        			.description("JavaSDK test Account Settings Template #1 - updated")
+        			.accountSettings(accountSettings)
+        			.build();
+        	
+        	Response<AccountSettingsTemplateResponse> updateResponse = service.updateAccountSettingsTemplateVersion(updateOptions).execute();
+            assertNotNull(updateResponse);
+            assertEquals(updateResponse.getStatusCode(), 200);
+            assertNotNull(updateResponse.getResult());
+        	
+            // Grab the Etag value from the response for use in the update operation.
+            assertNotNull(updateResponse.getHeaders().values("Etag"));
+            assertEquals(updateResponse.getHeaders().values("Etag").size(), 1);
+            accountSettingsTemplateEtag = updateResponse.getHeaders().values("Etag").get(0);
+            assertNotNull(accountSettingsTemplateEtag);
+        } catch (ServiceResponseException e) {
+            fail(String.format("Service returned status code %d: %s\nError details: %s",
+                    e.getStatusCode(), e.getMessage(), e.getDebuggingInfo()));
+        }
+    }
+    
+    @Test(dependsOnMethods = { "testUpdateAccountSettingsTemplate" })
+    public void testAssignAccountSettingsTemplate() throws Exception {
+        try {
+        	CommitAccountSettingsTemplateOptions commitOptions = new CommitAccountSettingsTemplateOptions.Builder()
+        			.templateId(accountSettingsTemplateId)
+        			.version(Long.toString(accountSettingsTemplateVersion))
+        			.build();
+        	
+        	Response<Void> commitResponse = service.commitAccountSettingsTemplate(commitOptions).execute();
+            assertNotNull(commitResponse);
+            assertEquals(commitResponse.getStatusCode(), 204);
+            
+            CreateAccountSettingsAssignmentOptions assignOptions = new CreateAccountSettingsAssignmentOptions.Builder()
+            		.templateId(accountSettingsTemplateId)
+            		.templateVersion(accountSettingsTemplateVersion)
+            		.targetType(ASSIGNMENT_TARGET_TYPE_ACCOUNT)
+            		.target(ENTERPRISE_SUBACCOUNT_ID)
+            		.build();
+            
+            Response<TemplateAssignmentResponse> assignResponse = service.createAccountSettingsAssignment(assignOptions).execute();
+            assertNotNull(commitResponse);
+            assertEquals(commitResponse.getStatusCode(), 204);
+            
+            TemplateAssignmentResponse assignmentResponseResult = assignResponse.getResult();
+            assertNotNull(assignmentResponseResult);
+
+            // Save the id for use by other test methods.
+            assertNotNull(assignmentResponseResult.getId());
+            accountSettingsTemplateAssignmentId = assignmentResponseResult.getId();
+            // Grab the Etag value from the response for use in the update operation.
+            assertNotNull(assignResponse.getHeaders().values("Etag"));
+            assertEquals(assignResponse.getHeaders().values("Etag").size(), 1);
+            accountSettingsTemplateAssignmentEtag = assignResponse.getHeaders().values("Etag").get(0);
+            assertNotNull(accountSettingsTemplateAssignmentEtag);
+            
+        } catch (ServiceResponseException e) {
+            fail(String.format("Service returned status code %d: %s\nError details: %s",
+                    e.getStatusCode(), e.getMessage(), e.getDebuggingInfo()));
+        }
+    }
+    
+    @Test(dependsOnMethods = { "testAssignAccountSettingsTemplate" })
+    public void testCreateNewAccountSettingsTemplateVersion() throws Exception {
+        try {
+        	AccountSettingsComponent accountSettings = new AccountSettingsComponent.Builder()
+        			.mfa("LEVEL1")
+        			.systemAccessTokenExpirationInSeconds("2600")
+        			.restrictCreatePlatformApikey("RESTRICTED")
+        			.restrictCreateServiceId("RESTRICTED")
+        			.build();
+        	CreateAccountSettingsTemplateVersionOptions createOptions = new CreateAccountSettingsTemplateVersionOptions.Builder()
+        			.accountId(ENTERPRISE_ACCOUNT_ID)
+        			.templateId(accountSettingsTemplateId)
+        			.name(ACCOUNT_SETTINGS_TEMPLATE_NAME)
+        			.description("JavaSDK test AccountSettings Template #1 - new version")
+        			.accountSettings(accountSettings)
+        			.build();
+        	
+        	Response<AccountSettingsTemplateResponse> createResponse = service.createAccountSettingsTemplateVersion(createOptions).execute();
+            assertNotNull(createResponse);
+            assertEquals(createResponse.getStatusCode(), 201);
+            assertNotNull(createResponse.getResult());
+            
+            AccountSettingsTemplateResponse createResult = createResponse.getResult();
+            assertNotNull(createResult);
+
+            // Save the version for use by other test methods.
+            assertNotNull(createResult.getVersion());
+            accountSettingsTemplateVersion = createResult.getVersion().longValue();
+            
+        } catch (ServiceResponseException e) {
+            fail(String.format("Service returned status code %d: %s\nError details: %s",
+                    e.getStatusCode(), e.getMessage(), e.getDebuggingInfo()));
+        }
+    }
+    
+    @Test(dependsOnMethods = { "testCreateNewAccountSettingsTemplateVersion" })
+    public void testGetLatestAccountSettingsTemplateVersion() throws Exception {
+        GetLatestAccountSettingsTemplateVersionOptions getOptions = new GetLatestAccountSettingsTemplateVersionOptions.Builder()
+                .templateId(accountSettingsTemplateId)
+                .build();
+        
+        Response<AccountSettingsTemplateResponse> getResponse = service.getLatestAccountSettingsTemplateVersion(getOptions).execute();
+        assertNotNull(getResponse);
+        assertEquals(getResponse.getStatusCode(), 200);
+        assertNotNull(getResponse.getResult());
+    }
+    
+    @Test(dependsOnMethods = { "testCreateNewAccountSettingsTemplateVersion" })
+    public void testListAccountSettingsTemplateVersions() throws Exception {
+        
+        ListVersionsOfAccountSettingsTemplateOptions listOptions = new ListVersionsOfAccountSettingsTemplateOptions.Builder()
+                .templateId(accountSettingsTemplateId)
+                .build();
+        
+        Response<AccountSettingsTemplateList> listResponse = service.listVersionsOfAccountSettingsTemplate(listOptions).execute();
+        assertNotNull(listResponse);
+        assertEquals(listResponse.getStatusCode(), 200);
+        assertNotNull(listResponse.getResult());
+        AccountSettingsTemplateList listResult = listResponse.getResult();
+        assertNotNull(listResult.getAccountSettingsTemplates());
+        assertTrue(listResult.getAccountSettingsTemplates().size() > 0);
+    }
+    
+    @Test(dependsOnMethods = { "testAssignAccountSettingsTemplate", "testCreateNewAccountSettingsTemplateVersion" })
+    public void testUpdateAccountSettingsTemplateAssignment() throws Exception {
+        try {
+        	CommitAccountSettingsTemplateOptions commitOptions = new CommitAccountSettingsTemplateOptions.Builder()
+        			.templateId(accountSettingsTemplateId)
+        			.version(Long.toString(accountSettingsTemplateVersion))
+        			.build();
+        	
+        	Response<Void> commitResponse = service.commitAccountSettingsTemplate(commitOptions).execute();
+            assertNotNull(commitResponse);
+            assertEquals(commitResponse.getStatusCode(), 204);
+
+        	waitUntilAccountSettingsAssignmentFinished(accountSettingsTemplateAssignmentId);
+        	
+        	UpdateAccountSettingsAssignmentOptions updateOptions = new UpdateAccountSettingsAssignmentOptions.Builder()
+        			.assignmentId(accountSettingsTemplateAssignmentId)
+        			.templateVersion(accountSettingsTemplateVersion)
+        			.ifMatch(accountSettingsTemplateAssignmentEtag)
+        			.build();
+        	
+        	Response<TemplateAssignmentResponse> updateResponse = service.updateAccountSettingsAssignment(updateOptions).execute();
+            assertNotNull(updateResponse);
+            assertEquals(updateResponse.getStatusCode(), 202);
+            assertNotNull(updateResponse.getResult());
+            
+            // Grab the Etag value from the response for use in the update operation.
+            assertNotNull(updateResponse.getHeaders().values("Etag"));
+            assertEquals(updateResponse.getHeaders().values("Etag").size(), 1);
+            accountSettingsTemplateAssignmentEtag = updateResponse.getHeaders().values("Etag").get(0);
+            assertNotNull(accountSettingsTemplateAssignmentEtag);
+            
+        } catch (ServiceResponseException e) {
+            fail(String.format("Service returned status code %d: %s\nError details: %s",
+                    e.getStatusCode(), e.getMessage(), e.getDebuggingInfo()));
+        }
+    }
+    
+    @Test(dependsOnMethods = { "testUpdateAccountSettingsTemplateAssignment" })
+    public void testDeleteAccountSettingsTemplateAssignment() throws Exception {
+        try {
+        	waitUntilAccountSettingsAssignmentFinished(accountSettingsTemplateAssignmentId);
+        	
+        	DeleteAccountSettingsAssignmentOptions deleteOptions = new DeleteAccountSettingsAssignmentOptions.Builder()
+        			.assignmentId(accountSettingsTemplateAssignmentId)
+        			.build();
+        	
+        	Response<ExceptionResponse> deleteResponse = service.deleteAccountSettingsAssignment(deleteOptions).execute();
+            assertNotNull(deleteResponse);
+            assertEquals(deleteResponse.getStatusCode(), 202);
+        	
+        } catch (ServiceResponseException e) {
+            fail(String.format("Service returned status code %d: %s\nError details: %s",
+                    e.getStatusCode(), e.getMessage(), e.getDebuggingInfo()));
+        }
+    }
+    
+    @Test(dependsOnMethods = { "testUpdateAccountSettingsTemplateAssignment" })
+    public void testDeleteAccountSettingsTemplateVersion() throws Exception {
+        try {
+        	DeleteAccountSettingsTemplateVersionOptions deleteOptions = new DeleteAccountSettingsTemplateVersionOptions.Builder()
+        			.templateId(accountSettingsTemplateId)
+        			.version("1")
+        			.build();
+        	
+        	Response<Void> deleteResponse = service.deleteAccountSettingsTemplateVersion(deleteOptions).execute();
+            assertNotNull(deleteResponse);
+            assertEquals(deleteResponse.getStatusCode(), 204);
+        } catch (ServiceResponseException e) {
+            fail(String.format("Service returned status code %d: %s\nError details: %s",
+                    e.getStatusCode(), e.getMessage(), e.getDebuggingInfo()));
+        }
+    }
+    
+    @Test(dependsOnMethods = { "testDeleteAccountSettingsTemplateVersion" })
+    public void testDeleteAccountSettingsTemplate() throws Exception {
+        try {
+        	waitUntilAccountSettingsAssignmentFinished(accountSettingsTemplateAssignmentId);
+        	
+            DeleteAllVersionsOfAccountSettingsTemplateOptions deleteTeplateOptions = new DeleteAllVersionsOfAccountSettingsTemplateOptions.Builder()
+            		.templateId(accountSettingsTemplateId)
+                    .build();
+
+            // Invoke operation
+            Response<Void> deleteResponse = service.deleteAllVersionsOfAccountSettingsTemplate(deleteTeplateOptions).execute();
+            assertNotNull(deleteResponse);
+            assertEquals(deleteResponse.getStatusCode(), 204);
+        } catch (ServiceResponseException e) {
+            fail(String.format("Service returned status code %d: %s\nError details: %s",
+                    e.getStatusCode(), e.getMessage(), e.getDebuggingInfo()));
+        }
+    }
+    
     @AfterClass
     public void tearDown() {
         // Add any clean up logic here.
@@ -1879,12 +2518,73 @@ public class IamIdentityIT extends SdkIntegrationTestBase {
         cleanupResources();
     }
 
+    private boolean isFinished(String status) {
+    	return ("succeeded".equalsIgnoreCase(status) || "failed".equalsIgnoreCase(status));
+    }
+    
+    private void waitUntilTrustedProfileAssignmentFinished(String assignmentId) {
+    	GetTrustedProfileAssignmentOptions getOptions = new GetTrustedProfileAssignmentOptions.Builder()
+    			.assignmentId(assignmentId)
+    			.build();
+
+    	boolean finished = false;
+    	for (int i = 0; i < 20; i++) {
+            Response<TemplateAssignmentResponse> getResponse = null;
+    		try {
+    		    getResponse = service.getTrustedProfileAssignment(getOptions).execute();
+                TemplateAssignmentResponse result = getResponse.getResult();
+                finished = isFinished(result.getStatus());
+                if (finished) {
+                	// Grab the Etag value from the response for use in the update operation.
+                	assertNotNull(getResponse.getHeaders().values("Etag"));
+                	assertEquals(getResponse.getHeaders().values("Etag").size(), 1);
+                	profileTemplateAssignmentEtag = getResponse.getHeaders().values("Etag").get(0);
+                    break;
+                }
+    	    } catch (NotFoundException e) {
+    	    	// assignment removed
+    	    	finished = true;
+                break;
+    	    }
+            sleep(10);
+        }
+        assertEquals(finished, true);
+    }
+    
+    private void waitUntilAccountSettingsAssignmentFinished(String assignmentId) {
+    	GetAccountSettingsAssignmentOptions getOptions = new GetAccountSettingsAssignmentOptions.Builder()
+    			.assignmentId(assignmentId)
+    			.build();
+
+    	boolean finished = false;
+    	for (int i = 0; i < 20; i++) {
+            Response<TemplateAssignmentResponse> getResponse = null;
+    		try {
+    		    getResponse = service.getAccountSettingsAssignment(getOptions).execute();
+                TemplateAssignmentResponse result = getResponse.getResult();
+                finished = isFinished(result.getStatus());
+                if (finished) {
+                	// Grab the Etag value from the response for use in the update operation.
+                	assertNotNull(getResponse.getHeaders().values("Etag"));
+                	assertEquals(getResponse.getHeaders().values("Etag").size(), 1);
+                	accountSettingsTemplateAssignmentEtag = getResponse.getHeaders().values("Etag").get(0);
+                    break;
+                }
+    	    } catch (NotFoundException e) {
+    	    	// assignment removed
+    	    	finished = true;
+                break;
+    	    }
+            sleep(10);
+        }
+        assertEquals(finished, true);
+    }
+    
     private void sleep(int numSecs) {
         try {
             Thread.sleep(numSecs * 1000);
         } catch (Throwable t) {
         }
-
     }
 
     private void cleanupResources() {
@@ -1947,7 +2647,7 @@ public class IamIdentityIT extends SdkIntegrationTestBase {
                 .build();
 
         Response<TrustedProfilesList> profileResponse = service.listProfiles(listProfilesOptions).execute();
-        assertNotNull(response);
+        assertNotNull(profileResponse);
         assertEquals(profileResponse.getStatusCode(), 200);
 
         TrustedProfilesList profilesListResult = profileResponse.getResult();
@@ -1962,6 +2662,112 @@ public class IamIdentityIT extends SdkIntegrationTestBase {
 
                     // Invoke operation
                     Response<Void> deleteResponse = service.deleteProfile(deleteProfileOptions).execute();
+                    assertNotNull(deleteResponse);
+                }
+            }
+        }
+        
+        ListProfileTemplatesOptions listProfileTemplateOptions = new ListProfileTemplatesOptions.Builder()
+        		.accountId(ENTERPRISE_ACCOUNT_ID)
+        		.build(); 
+        Response<TrustedProfileTemplateList> profileTemplatesResponse = service.listProfileTemplates(listProfileTemplateOptions).execute();
+        assertNotNull(profileTemplatesResponse);
+        assertEquals(profileTemplatesResponse.getStatusCode(), 200);
+        
+        TrustedProfileTemplateList profileTemplateList = profileTemplatesResponse.getResult();
+        long numProfileTemplates = profileTemplateList.getProfileTemplates().size();
+
+        if (numProfileTemplates > 0) {
+            for (TrustedProfileTemplateResponse template : profileTemplateList.getProfileTemplates()) {
+                if (PROFILE_TEMPLATE_NAME.equals(template.getName())) {
+                	
+                	ListTrustedProfileAssignmentsOptions assignmentsListOptions = new ListTrustedProfileAssignmentsOptions.Builder()
+                			.accountId(ENTERPRISE_ACCOUNT_ID)
+                			.templateId(template.getId())
+                			.build();
+                	
+                	Response<TemplateAssignmentListResponse> assignmentsListResponse = service.listTrustedProfileAssignments(assignmentsListOptions).execute();
+                    assertNotNull(assignmentsListResponse);
+                    assertEquals(assignmentsListResponse.getStatusCode(), 200);
+                    assertNotNull(assignmentsListResponse.getResult());
+                    
+                    TemplateAssignmentListResponse assignmentsListResult = assignmentsListResponse.getResult();
+                    assertNotNull(assignmentsListResult.getAssignments());
+                    long numAssignments = assignmentsListResult.getAssignments().size();
+                    if (numAssignments > 0) {
+                    	for (TemplateAssignmentResponse assignment : assignmentsListResult.getAssignments()) {
+                    		if (!isFinished(assignment.getStatus())) {
+                    			waitUntilTrustedProfileAssignmentFinished(assignment.getId());
+                    		}
+                    		DeleteTrustedProfileAssignmentOptions deleteAssignmentOptions = new DeleteTrustedProfileAssignmentOptions.Builder()
+                    				.assignmentId(assignment.getId())
+                    				.build();
+                            Response<ExceptionResponse> deleteAssignmentResponse = service.deleteTrustedProfileAssignment(deleteAssignmentOptions).execute();
+                            assertNotNull(deleteAssignmentResponse);
+                            assertEquals(deleteAssignmentResponse.getStatusCode(), 202);
+                			waitUntilTrustedProfileAssignmentFinished(assignment.getId());
+                    	}
+                    }
+                	
+                    DeleteAllVersionsOfProfileTemplateOptions deleteTeplateOptions = new DeleteAllVersionsOfProfileTemplateOptions.Builder()
+                    		.templateId(template.getId())
+                            .build();
+
+                    // Invoke operation
+                    Response<Void> deleteResponse = service.deleteAllVersionsOfProfileTemplate(deleteTeplateOptions).execute();
+                    assertNotNull(deleteResponse);
+                }
+            }
+        }
+        
+        ListAccountSettingsTemplatesOptions listAccountSettingsTemplateOptions = new ListAccountSettingsTemplatesOptions.Builder()
+        		.accountId(ENTERPRISE_ACCOUNT_ID)
+        		.build(); 
+        Response<AccountSettingsTemplateList> accountSettingsTemplatesResponse = service.listAccountSettingsTemplates(listAccountSettingsTemplateOptions).execute();
+        assertNotNull(accountSettingsTemplatesResponse);
+        assertEquals(accountSettingsTemplatesResponse.getStatusCode(), 200);
+        
+        AccountSettingsTemplateList accountSettingsTemplateList = accountSettingsTemplatesResponse.getResult();
+        long numAccountSettingsTemplates = accountSettingsTemplateList.getAccountSettingsTemplates().size();
+
+        if (numAccountSettingsTemplates > 0) {
+            for (AccountSettingsTemplateResponse template : accountSettingsTemplateList.getAccountSettingsTemplates()) {
+                if (ACCOUNT_SETTINGS_TEMPLATE_NAME.equals(template.getName())) {
+                	
+                	ListAccountSettingsAssignmentsOptions assignmentsListOptions = new ListAccountSettingsAssignmentsOptions.Builder()
+                			.accountId(ENTERPRISE_ACCOUNT_ID)
+                			.templateId(template.getId())
+                			.build();
+                	
+                	Response<TemplateAssignmentListResponse> assignmentsListResponse = service.listAccountSettingsAssignments(assignmentsListOptions).execute();
+                    assertNotNull(assignmentsListResponse);
+                    assertEquals(assignmentsListResponse.getStatusCode(), 200);
+                    assertNotNull(assignmentsListResponse.getResult());
+                    
+                    TemplateAssignmentListResponse assignmentsListResult = assignmentsListResponse.getResult();
+                    assertNotNull(assignmentsListResult.getAssignments());
+                    long numAssignments = assignmentsListResult.getAssignments().size();
+                    if (numAssignments > 0) {
+                    	for (TemplateAssignmentResponse assignment : assignmentsListResult.getAssignments()) {
+                    		if (!isFinished(assignment.getStatus())) {
+                    			waitUntilAccountSettingsAssignmentFinished(assignment.getId());
+                    		}
+                    		DeleteAccountSettingsAssignmentOptions deleteAssignmentOptions = new DeleteAccountSettingsAssignmentOptions.Builder()
+                    				.assignmentId(assignment.getId())
+                    				.build();
+                            Response<ExceptionResponse> deleteAssignmentResponse = service.deleteAccountSettingsAssignment(deleteAssignmentOptions).execute();
+                            assertNotNull(deleteAssignmentResponse);
+                            assertEquals(deleteAssignmentResponse.getStatusCode(), 202);
+                			waitUntilAccountSettingsAssignmentFinished(assignment.getId());
+                    	}
+                    }
+                	
+                    DeleteAllVersionsOfAccountSettingsTemplateOptions deleteTeplateOptions = new DeleteAllVersionsOfAccountSettingsTemplateOptions.Builder()
+                    		.templateId(template.getId())
+                            .build();
+
+                    // Invoke operation
+                    Response<Void> deleteResponse = service.deleteAllVersionsOfAccountSettingsTemplate(deleteTeplateOptions).execute();
                     assertNotNull(deleteResponse);
                 }
             }

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/IamIdentityTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/IamIdentityTest.java
@@ -14,7 +14,10 @@ package com.ibm.cloud.platform_services.iam_identity.v1;
 
 import com.ibm.cloud.platform_services.iam_identity.v1.IamIdentity;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.AccountBasedMfaEnrollment;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.AccountSettingsComponent;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.AccountSettingsResponse;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.AccountSettingsTemplateList;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.AccountSettingsTemplateResponse;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.AccountSettingsUserMFA;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.Activity;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.ApiKey;
@@ -23,49 +26,79 @@ import com.ibm.cloud.platform_services.iam_identity.v1.model.ApiKeyList;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.ApikeyActivity;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.ApikeyActivityServiceid;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.ApikeyActivityUser;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.CommitAccountSettingsTemplateOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.CommitProfileTemplateOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.CreateAccountSettingsAssignmentOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.CreateAccountSettingsTemplateOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.CreateAccountSettingsTemplateVersionOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.CreateApiKeyOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.CreateClaimRuleOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.CreateLinkOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.CreateMfaReportOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.CreateProfileLinkRequestLink;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.CreateProfileOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.CreateProfileTemplateOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.CreateProfileTemplateVersionOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.CreateReportOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.CreateServiceIdOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.CreateTrustedProfileAssignmentOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.DeleteAccountSettingsAssignmentOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.DeleteAccountSettingsTemplateVersionOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.DeleteAllVersionsOfAccountSettingsTemplateOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.DeleteAllVersionsOfProfileTemplateOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.DeleteApiKeyOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.DeleteClaimRuleOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.DeleteLinkOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.DeleteProfileIdentityOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.DeleteProfileOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.DeleteProfileTemplateVersionOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.DeleteServiceIdOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.DeleteTrustedProfileAssignmentOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.EnityHistoryRecord;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.EntityActivity;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.Error;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.ExceptionResponse;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.GetAccountSettingsAssignmentOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.GetAccountSettingsOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.GetAccountSettingsTemplateVersionOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.GetApiKeyOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.GetApiKeysDetailsOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.GetClaimRuleOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.GetLatestAccountSettingsTemplateVersionOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.GetLatestProfileTemplateVersionOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.GetLinkOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.GetMfaReportOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.GetMfaStatusOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.GetProfileIdentitiesOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.GetProfileIdentityOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.GetProfileOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.GetProfileTemplateVersionOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.GetReportOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.GetServiceIdOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.GetTrustedProfileAssignmentOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.IdBasedMfaEnrollment;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.ListAccountSettingsAssignmentsOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.ListAccountSettingsTemplatesOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.ListApiKeysOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.ListClaimRulesOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.ListLinksOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.ListProfileTemplatesOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.ListProfilesOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.ListServiceIdsOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.ListTrustedProfileAssignmentsOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.ListVersionsOfAccountSettingsTemplateOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.ListVersionsOfProfileTemplateOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.LockApiKeyOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.LockServiceIdOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.MfaEnrollmentTypeStatus;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.MfaEnrollments;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.PolicyTemplateReference;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.ProfileClaimRule;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.ProfileClaimRuleConditions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.ProfileClaimRuleList;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.ProfileIdentitiesResponse;
-import com.ibm.cloud.platform_services.iam_identity.v1.model.ProfileIdentity;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.ProfileIdentityRequest;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.ProfileIdentityResponse;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.ProfileLink;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.ProfileLinkLink;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.ProfileLinkList;
@@ -77,15 +110,30 @@ import com.ibm.cloud.platform_services.iam_identity.v1.model.ServiceId;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.ServiceIdList;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.SetProfileIdentitiesOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.SetProfileIdentityOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.TemplateAssignmentListResponse;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.TemplateAssignmentResource;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.TemplateAssignmentResourceError;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.TemplateAssignmentResponse;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.TemplateAssignmentResponseResource;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.TemplateAssignmentResponseResourceDetail;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.TemplateProfileComponentRequest;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.TemplateProfileComponentResponse;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.TrustedProfile;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.TrustedProfileTemplateClaimRule;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.TrustedProfileTemplateList;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.TrustedProfileTemplateResponse;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.TrustedProfilesList;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.UnlockApiKeyOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.UnlockServiceIdOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.UpdateAccountSettingsAssignmentOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.UpdateAccountSettingsOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.UpdateAccountSettingsTemplateVersionOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.UpdateApiKeyOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.UpdateClaimRuleOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.UpdateProfileOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.UpdateProfileTemplateVersionOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.UpdateServiceIdOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.UpdateTrustedProfileAssignmentOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.UserActivity;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.UserMfaEnrollments;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.UserReportMfaEnrollmentStatus;
@@ -938,7 +986,7 @@ public class IamIdentityTest {
   @Test
   public void testCreateProfileWOptions() throws Throwable {
     // Register a mock response
-    String mockResponseBody = "{\"context\": {\"transaction_id\": \"transactionId\", \"operation\": \"operation\", \"user_agent\": \"userAgent\", \"url\": \"url\", \"instance_id\": \"instanceId\", \"thread_id\": \"threadId\", \"host\": \"host\", \"start_time\": \"startTime\", \"end_time\": \"endTime\", \"elapsed_time\": \"elapsedTime\", \"cluster_name\": \"clusterName\"}, \"id\": \"id\", \"entity_tag\": \"entityTag\", \"crn\": \"crn\", \"name\": \"name\", \"description\": \"description\", \"created_at\": \"2019-01-01T12:00:00.000Z\", \"modified_at\": \"2019-01-01T12:00:00.000Z\", \"iam_id\": \"iamId\", \"account_id\": \"accountId\", \"ims_account_id\": 12, \"ims_user_id\": 9, \"history\": [{\"timestamp\": \"timestamp\", \"iam_id\": \"iamId\", \"iam_id_account\": \"iamIdAccount\", \"action\": \"action\", \"params\": [\"params\"], \"message\": \"message\"}], \"activity\": {\"last_authn\": \"lastAuthn\", \"authn_count\": 10}}";
+    String mockResponseBody = "{\"context\": {\"transaction_id\": \"transactionId\", \"operation\": \"operation\", \"user_agent\": \"userAgent\", \"url\": \"url\", \"instance_id\": \"instanceId\", \"thread_id\": \"threadId\", \"host\": \"host\", \"start_time\": \"startTime\", \"end_time\": \"endTime\", \"elapsed_time\": \"elapsedTime\", \"cluster_name\": \"clusterName\"}, \"id\": \"id\", \"entity_tag\": \"entityTag\", \"crn\": \"crn\", \"name\": \"name\", \"description\": \"description\", \"created_at\": \"2019-01-01T12:00:00.000Z\", \"modified_at\": \"2019-01-01T12:00:00.000Z\", \"iam_id\": \"iamId\", \"account_id\": \"accountId\", \"template_id\": \"templateId\", \"assignment_id\": \"assignmentId\", \"ims_account_id\": 12, \"ims_user_id\": 9, \"history\": [{\"timestamp\": \"timestamp\", \"iam_id\": \"iamId\", \"iam_id_account\": \"iamIdAccount\", \"action\": \"action\", \"params\": [\"params\"], \"message\": \"message\"}], \"activity\": {\"last_authn\": \"lastAuthn\", \"authn_count\": 10}}";
     String createProfilePath = "/v1/profiles";
     server.enqueue(new MockResponse()
       .setHeader("Content-type", "application/json")
@@ -991,7 +1039,7 @@ public class IamIdentityTest {
   @Test
   public void testListProfilesWOptions() throws Throwable {
     // Register a mock response
-    String mockResponseBody = "{\"context\": {\"transaction_id\": \"transactionId\", \"operation\": \"operation\", \"user_agent\": \"userAgent\", \"url\": \"url\", \"instance_id\": \"instanceId\", \"thread_id\": \"threadId\", \"host\": \"host\", \"start_time\": \"startTime\", \"end_time\": \"endTime\", \"elapsed_time\": \"elapsedTime\", \"cluster_name\": \"clusterName\"}, \"offset\": 6, \"limit\": 5, \"first\": \"first\", \"previous\": \"previous\", \"next\": \"next\", \"profiles\": [{\"context\": {\"transaction_id\": \"transactionId\", \"operation\": \"operation\", \"user_agent\": \"userAgent\", \"url\": \"url\", \"instance_id\": \"instanceId\", \"thread_id\": \"threadId\", \"host\": \"host\", \"start_time\": \"startTime\", \"end_time\": \"endTime\", \"elapsed_time\": \"elapsedTime\", \"cluster_name\": \"clusterName\"}, \"id\": \"id\", \"entity_tag\": \"entityTag\", \"crn\": \"crn\", \"name\": \"name\", \"description\": \"description\", \"created_at\": \"2019-01-01T12:00:00.000Z\", \"modified_at\": \"2019-01-01T12:00:00.000Z\", \"iam_id\": \"iamId\", \"account_id\": \"accountId\", \"ims_account_id\": 12, \"ims_user_id\": 9, \"history\": [{\"timestamp\": \"timestamp\", \"iam_id\": \"iamId\", \"iam_id_account\": \"iamIdAccount\", \"action\": \"action\", \"params\": [\"params\"], \"message\": \"message\"}], \"activity\": {\"last_authn\": \"lastAuthn\", \"authn_count\": 10}}]}";
+    String mockResponseBody = "{\"context\": {\"transaction_id\": \"transactionId\", \"operation\": \"operation\", \"user_agent\": \"userAgent\", \"url\": \"url\", \"instance_id\": \"instanceId\", \"thread_id\": \"threadId\", \"host\": \"host\", \"start_time\": \"startTime\", \"end_time\": \"endTime\", \"elapsed_time\": \"elapsedTime\", \"cluster_name\": \"clusterName\"}, \"offset\": 6, \"limit\": 5, \"first\": \"first\", \"previous\": \"previous\", \"next\": \"next\", \"profiles\": [{\"context\": {\"transaction_id\": \"transactionId\", \"operation\": \"operation\", \"user_agent\": \"userAgent\", \"url\": \"url\", \"instance_id\": \"instanceId\", \"thread_id\": \"threadId\", \"host\": \"host\", \"start_time\": \"startTime\", \"end_time\": \"endTime\", \"elapsed_time\": \"elapsedTime\", \"cluster_name\": \"clusterName\"}, \"id\": \"id\", \"entity_tag\": \"entityTag\", \"crn\": \"crn\", \"name\": \"name\", \"description\": \"description\", \"created_at\": \"2019-01-01T12:00:00.000Z\", \"modified_at\": \"2019-01-01T12:00:00.000Z\", \"iam_id\": \"iamId\", \"account_id\": \"accountId\", \"template_id\": \"templateId\", \"assignment_id\": \"assignmentId\", \"ims_account_id\": 12, \"ims_user_id\": 9, \"history\": [{\"timestamp\": \"timestamp\", \"iam_id\": \"iamId\", \"iam_id_account\": \"iamIdAccount\", \"action\": \"action\", \"params\": [\"params\"], \"message\": \"message\"}], \"activity\": {\"last_authn\": \"lastAuthn\", \"authn_count\": 10}}]}";
     String listProfilesPath = "/v1/profiles";
     server.enqueue(new MockResponse()
       .setHeader("Content-type", "application/json")
@@ -1055,7 +1103,7 @@ public class IamIdentityTest {
   @Test
   public void testGetProfileWOptions() throws Throwable {
     // Register a mock response
-    String mockResponseBody = "{\"context\": {\"transaction_id\": \"transactionId\", \"operation\": \"operation\", \"user_agent\": \"userAgent\", \"url\": \"url\", \"instance_id\": \"instanceId\", \"thread_id\": \"threadId\", \"host\": \"host\", \"start_time\": \"startTime\", \"end_time\": \"endTime\", \"elapsed_time\": \"elapsedTime\", \"cluster_name\": \"clusterName\"}, \"id\": \"id\", \"entity_tag\": \"entityTag\", \"crn\": \"crn\", \"name\": \"name\", \"description\": \"description\", \"created_at\": \"2019-01-01T12:00:00.000Z\", \"modified_at\": \"2019-01-01T12:00:00.000Z\", \"iam_id\": \"iamId\", \"account_id\": \"accountId\", \"ims_account_id\": 12, \"ims_user_id\": 9, \"history\": [{\"timestamp\": \"timestamp\", \"iam_id\": \"iamId\", \"iam_id_account\": \"iamIdAccount\", \"action\": \"action\", \"params\": [\"params\"], \"message\": \"message\"}], \"activity\": {\"last_authn\": \"lastAuthn\", \"authn_count\": 10}}";
+    String mockResponseBody = "{\"context\": {\"transaction_id\": \"transactionId\", \"operation\": \"operation\", \"user_agent\": \"userAgent\", \"url\": \"url\", \"instance_id\": \"instanceId\", \"thread_id\": \"threadId\", \"host\": \"host\", \"start_time\": \"startTime\", \"end_time\": \"endTime\", \"elapsed_time\": \"elapsedTime\", \"cluster_name\": \"clusterName\"}, \"id\": \"id\", \"entity_tag\": \"entityTag\", \"crn\": \"crn\", \"name\": \"name\", \"description\": \"description\", \"created_at\": \"2019-01-01T12:00:00.000Z\", \"modified_at\": \"2019-01-01T12:00:00.000Z\", \"iam_id\": \"iamId\", \"account_id\": \"accountId\", \"template_id\": \"templateId\", \"assignment_id\": \"assignmentId\", \"ims_account_id\": 12, \"ims_user_id\": 9, \"history\": [{\"timestamp\": \"timestamp\", \"iam_id\": \"iamId\", \"iam_id_account\": \"iamIdAccount\", \"action\": \"action\", \"params\": [\"params\"], \"message\": \"message\"}], \"activity\": {\"last_authn\": \"lastAuthn\", \"authn_count\": 10}}";
     String getProfilePath = "/v1/profiles/testString";
     server.enqueue(new MockResponse()
       .setHeader("Content-type", "application/json")
@@ -1108,7 +1156,7 @@ public class IamIdentityTest {
   @Test
   public void testUpdateProfileWOptions() throws Throwable {
     // Register a mock response
-    String mockResponseBody = "{\"context\": {\"transaction_id\": \"transactionId\", \"operation\": \"operation\", \"user_agent\": \"userAgent\", \"url\": \"url\", \"instance_id\": \"instanceId\", \"thread_id\": \"threadId\", \"host\": \"host\", \"start_time\": \"startTime\", \"end_time\": \"endTime\", \"elapsed_time\": \"elapsedTime\", \"cluster_name\": \"clusterName\"}, \"id\": \"id\", \"entity_tag\": \"entityTag\", \"crn\": \"crn\", \"name\": \"name\", \"description\": \"description\", \"created_at\": \"2019-01-01T12:00:00.000Z\", \"modified_at\": \"2019-01-01T12:00:00.000Z\", \"iam_id\": \"iamId\", \"account_id\": \"accountId\", \"ims_account_id\": 12, \"ims_user_id\": 9, \"history\": [{\"timestamp\": \"timestamp\", \"iam_id\": \"iamId\", \"iam_id_account\": \"iamIdAccount\", \"action\": \"action\", \"params\": [\"params\"], \"message\": \"message\"}], \"activity\": {\"last_authn\": \"lastAuthn\", \"authn_count\": 10}}";
+    String mockResponseBody = "{\"context\": {\"transaction_id\": \"transactionId\", \"operation\": \"operation\", \"user_agent\": \"userAgent\", \"url\": \"url\", \"instance_id\": \"instanceId\", \"thread_id\": \"threadId\", \"host\": \"host\", \"start_time\": \"startTime\", \"end_time\": \"endTime\", \"elapsed_time\": \"elapsedTime\", \"cluster_name\": \"clusterName\"}, \"id\": \"id\", \"entity_tag\": \"entityTag\", \"crn\": \"crn\", \"name\": \"name\", \"description\": \"description\", \"created_at\": \"2019-01-01T12:00:00.000Z\", \"modified_at\": \"2019-01-01T12:00:00.000Z\", \"iam_id\": \"iamId\", \"account_id\": \"accountId\", \"template_id\": \"templateId\", \"assignment_id\": \"assignmentId\", \"ims_account_id\": 12, \"ims_user_id\": 9, \"history\": [{\"timestamp\": \"timestamp\", \"iam_id\": \"iamId\", \"iam_id_account\": \"iamIdAccount\", \"action\": \"action\", \"params\": [\"params\"], \"message\": \"message\"}], \"activity\": {\"last_authn\": \"lastAuthn\", \"authn_count\": 10}}";
     String updateProfilePath = "/v1/profiles/testString";
     server.enqueue(new MockResponse()
       .setHeader("Content-type", "application/json")
@@ -1805,9 +1853,8 @@ public class IamIdentityTest {
       .setResponseCode(200)
       .setBody(mockResponseBody));
 
-    // Construct an instance of the ProfileIdentity model
-    ProfileIdentity profileIdentityModel = new ProfileIdentity.Builder()
-      .iamId("testString")
+    // Construct an instance of the ProfileIdentityRequest model
+    ProfileIdentityRequest profileIdentityRequestModel = new ProfileIdentityRequest.Builder()
       .identifier("testString")
       .type("user")
       .accounts(java.util.Arrays.asList("testString"))
@@ -1818,7 +1865,7 @@ public class IamIdentityTest {
     SetProfileIdentitiesOptions setProfileIdentitiesOptionsModel = new SetProfileIdentitiesOptions.Builder()
       .profileId("testString")
       .ifMatch("testString")
-      .identities(java.util.Arrays.asList(profileIdentityModel))
+      .identities(java.util.Arrays.asList(profileIdentityRequestModel))
       .build();
 
     // Invoke setProfileIdentities() with a valid options model and verify the result
@@ -1875,15 +1922,14 @@ public class IamIdentityTest {
       .identityType("user")
       .identifier("testString")
       .type("user")
-      .iamId("testString")
       .accounts(java.util.Arrays.asList("testString"))
       .description("testString")
       .build();
 
     // Invoke setProfileIdentity() with a valid options model and verify the result
-    Response<ProfileIdentity> response = iamIdentityService.setProfileIdentity(setProfileIdentityOptionsModel).execute();
+    Response<ProfileIdentityResponse> response = iamIdentityService.setProfileIdentity(setProfileIdentityOptionsModel).execute();
     assertNotNull(response);
-    ProfileIdentity responseObj = response.getResult();
+    ProfileIdentityResponse responseObj = response.getResult();
     assertNotNull(responseObj);
 
     // Verify the contents of the request sent to the mock server
@@ -1934,9 +1980,9 @@ public class IamIdentityTest {
       .build();
 
     // Invoke getProfileIdentity() with a valid options model and verify the result
-    Response<ProfileIdentity> response = iamIdentityService.getProfileIdentity(getProfileIdentityOptionsModel).execute();
+    Response<ProfileIdentityResponse> response = iamIdentityService.getProfileIdentity(getProfileIdentityOptionsModel).execute();
     assertNotNull(response);
-    ProfileIdentity responseObj = response.getResult();
+    ProfileIdentityResponse responseObj = response.getResult();
     assertNotNull(responseObj);
 
     // Verify the contents of the request sent to the mock server
@@ -2301,6 +2347,878 @@ public class IamIdentityTest {
     iamIdentityService.getMfaReport(null).execute();
   }
 
+  // Test the listAccountSettingsAssignments operation with a valid options model parameter
+  @Test
+  public void testListAccountSettingsAssignmentsWOptions() throws Throwable {
+    // Register a mock response
+    String mockResponseBody = "{\"context\": {\"transaction_id\": \"transactionId\", \"operation\": \"operation\", \"user_agent\": \"userAgent\", \"url\": \"url\", \"instance_id\": \"instanceId\", \"thread_id\": \"threadId\", \"host\": \"host\", \"start_time\": \"startTime\", \"end_time\": \"endTime\", \"elapsed_time\": \"elapsedTime\", \"cluster_name\": \"clusterName\"}, \"offset\": 6, \"limit\": 5, \"first\": \"first\", \"previous\": \"previous\", \"next\": \"next\", \"assignments\": [{\"context\": {\"transaction_id\": \"transactionId\", \"operation\": \"operation\", \"user_agent\": \"userAgent\", \"url\": \"url\", \"instance_id\": \"instanceId\", \"thread_id\": \"threadId\", \"host\": \"host\", \"start_time\": \"startTime\", \"end_time\": \"endTime\", \"elapsed_time\": \"elapsedTime\", \"cluster_name\": \"clusterName\"}, \"id\": \"id\", \"account_id\": \"accountId\", \"template_id\": \"templateId\", \"template_version\": 15, \"target_type\": \"targetType\", \"target\": \"target\", \"status\": \"status\", \"resources\": [{\"target\": \"target\", \"profile\": {\"id\": \"id\", \"version\": \"version\", \"resource_created\": {\"id\": \"id\"}, \"error_message\": {\"name\": \"name\", \"errorCode\": \"errorCode\", \"message\": \"message\", \"statusCode\": \"statusCode\"}, \"status\": \"status\"}, \"account_settings\": {\"id\": \"id\", \"version\": \"version\", \"resource_created\": {\"id\": \"id\"}, \"error_message\": {\"name\": \"name\", \"errorCode\": \"errorCode\", \"message\": \"message\", \"statusCode\": \"statusCode\"}, \"status\": \"status\"}, \"policy_template_refs\": [{\"id\": \"id\", \"version\": \"version\", \"resource_created\": {\"id\": \"id\"}, \"error_message\": {\"name\": \"name\", \"errorCode\": \"errorCode\", \"message\": \"message\", \"statusCode\": \"statusCode\"}, \"status\": \"status\"}]}], \"history\": [{\"timestamp\": \"timestamp\", \"iam_id\": \"iamId\", \"iam_id_account\": \"iamIdAccount\", \"action\": \"action\", \"params\": [\"params\"], \"message\": \"message\"}], \"href\": \"href\", \"created_at\": \"createdAt\", \"created_by_id\": \"createdById\", \"last_modified_at\": \"lastModifiedAt\", \"last_modified_by_id\": \"lastModifiedById\", \"entity_tag\": \"entityTag\"}]}";
+    String listAccountSettingsAssignmentsPath = "/v1/account_settings_assignments/";
+    server.enqueue(new MockResponse()
+      .setHeader("Content-type", "application/json")
+      .setResponseCode(200)
+      .setBody(mockResponseBody));
+
+    // Construct an instance of the ListAccountSettingsAssignmentsOptions model
+    ListAccountSettingsAssignmentsOptions listAccountSettingsAssignmentsOptionsModel = new ListAccountSettingsAssignmentsOptions.Builder()
+      .accountId("testString")
+      .templateId("testString")
+      .templateVersion("testString")
+      .target("testString")
+      .targetType("Account")
+      .limit(Long.valueOf("20"))
+      .pagetoken("testString")
+      .sort("created_at")
+      .order("asc")
+      .includeHistory(false)
+      .build();
+
+    // Invoke listAccountSettingsAssignments() with a valid options model and verify the result
+    Response<TemplateAssignmentListResponse> response = iamIdentityService.listAccountSettingsAssignments(listAccountSettingsAssignmentsOptionsModel).execute();
+    assertNotNull(response);
+    TemplateAssignmentListResponse responseObj = response.getResult();
+    assertNotNull(responseObj);
+
+    // Verify the contents of the request sent to the mock server
+    RecordedRequest request = server.takeRequest();
+    assertNotNull(request);
+    assertEquals(request.getMethod(), "GET");
+    // Verify request path
+    String parsedPath = TestUtilities.parseReqPath(request);
+    assertEquals(parsedPath, listAccountSettingsAssignmentsPath);
+    // Verify query params
+    Map<String, String> query = TestUtilities.parseQueryString(request);
+    assertNotNull(query);
+    assertEquals(query.get("account_id"), "testString");
+    assertEquals(query.get("template_id"), "testString");
+    assertEquals(query.get("template_version"), "testString");
+    assertEquals(query.get("target"), "testString");
+    assertEquals(query.get("target_type"), "Account");
+    assertEquals(Long.valueOf(query.get("limit")), Long.valueOf("20"));
+    assertEquals(query.get("pagetoken"), "testString");
+    assertEquals(query.get("sort"), "created_at");
+    assertEquals(query.get("order"), "asc");
+    assertEquals(Boolean.valueOf(query.get("include_history")), Boolean.valueOf(false));
+  }
+
+  // Test the listAccountSettingsAssignments operation with and without retries enabled
+  @Test
+  public void testListAccountSettingsAssignmentsWRetries() throws Throwable {
+    iamIdentityService.enableRetries(4, 30);
+    testListAccountSettingsAssignmentsWOptions();
+
+    iamIdentityService.disableRetries();
+    testListAccountSettingsAssignmentsWOptions();
+  }
+
+  // Test the createAccountSettingsAssignment operation with a valid options model parameter
+  @Test
+  public void testCreateAccountSettingsAssignmentWOptions() throws Throwable {
+    // Register a mock response
+    String mockResponseBody = "{\"context\": {\"transaction_id\": \"transactionId\", \"operation\": \"operation\", \"user_agent\": \"userAgent\", \"url\": \"url\", \"instance_id\": \"instanceId\", \"thread_id\": \"threadId\", \"host\": \"host\", \"start_time\": \"startTime\", \"end_time\": \"endTime\", \"elapsed_time\": \"elapsedTime\", \"cluster_name\": \"clusterName\"}, \"id\": \"id\", \"account_id\": \"accountId\", \"template_id\": \"templateId\", \"template_version\": 15, \"target_type\": \"targetType\", \"target\": \"target\", \"status\": \"status\", \"resources\": [{\"target\": \"target\", \"profile\": {\"id\": \"id\", \"version\": \"version\", \"resource_created\": {\"id\": \"id\"}, \"error_message\": {\"name\": \"name\", \"errorCode\": \"errorCode\", \"message\": \"message\", \"statusCode\": \"statusCode\"}, \"status\": \"status\"}, \"account_settings\": {\"id\": \"id\", \"version\": \"version\", \"resource_created\": {\"id\": \"id\"}, \"error_message\": {\"name\": \"name\", \"errorCode\": \"errorCode\", \"message\": \"message\", \"statusCode\": \"statusCode\"}, \"status\": \"status\"}, \"policy_template_refs\": [{\"id\": \"id\", \"version\": \"version\", \"resource_created\": {\"id\": \"id\"}, \"error_message\": {\"name\": \"name\", \"errorCode\": \"errorCode\", \"message\": \"message\", \"statusCode\": \"statusCode\"}, \"status\": \"status\"}]}], \"history\": [{\"timestamp\": \"timestamp\", \"iam_id\": \"iamId\", \"iam_id_account\": \"iamIdAccount\", \"action\": \"action\", \"params\": [\"params\"], \"message\": \"message\"}], \"href\": \"href\", \"created_at\": \"createdAt\", \"created_by_id\": \"createdById\", \"last_modified_at\": \"lastModifiedAt\", \"last_modified_by_id\": \"lastModifiedById\", \"entity_tag\": \"entityTag\"}";
+    String createAccountSettingsAssignmentPath = "/v1/account_settings_assignments/";
+    server.enqueue(new MockResponse()
+      .setHeader("Content-type", "application/json")
+      .setResponseCode(202)
+      .setBody(mockResponseBody));
+
+    // Construct an instance of the CreateAccountSettingsAssignmentOptions model
+    CreateAccountSettingsAssignmentOptions createAccountSettingsAssignmentOptionsModel = new CreateAccountSettingsAssignmentOptions.Builder()
+      .templateId("testString")
+      .templateVersion(Long.valueOf("1"))
+      .targetType("Account")
+      .target("testString")
+      .build();
+
+    // Invoke createAccountSettingsAssignment() with a valid options model and verify the result
+    Response<TemplateAssignmentResponse> response = iamIdentityService.createAccountSettingsAssignment(createAccountSettingsAssignmentOptionsModel).execute();
+    assertNotNull(response);
+    TemplateAssignmentResponse responseObj = response.getResult();
+    assertNotNull(responseObj);
+
+    // Verify the contents of the request sent to the mock server
+    RecordedRequest request = server.takeRequest();
+    assertNotNull(request);
+    assertEquals(request.getMethod(), "POST");
+    // Verify request path
+    String parsedPath = TestUtilities.parseReqPath(request);
+    assertEquals(parsedPath, createAccountSettingsAssignmentPath);
+    // Verify that there is no query string
+    Map<String, String> query = TestUtilities.parseQueryString(request);
+    assertNull(query);
+  }
+
+  // Test the createAccountSettingsAssignment operation with and without retries enabled
+  @Test
+  public void testCreateAccountSettingsAssignmentWRetries() throws Throwable {
+    iamIdentityService.enableRetries(4, 30);
+    testCreateAccountSettingsAssignmentWOptions();
+
+    iamIdentityService.disableRetries();
+    testCreateAccountSettingsAssignmentWOptions();
+  }
+
+  // Test the createAccountSettingsAssignment operation with a null options model (negative test)
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testCreateAccountSettingsAssignmentNoOptions() throws Throwable {
+    server.enqueue(new MockResponse());
+    iamIdentityService.createAccountSettingsAssignment(null).execute();
+  }
+
+  // Test the getAccountSettingsAssignment operation with a valid options model parameter
+  @Test
+  public void testGetAccountSettingsAssignmentWOptions() throws Throwable {
+    // Register a mock response
+    String mockResponseBody = "{\"context\": {\"transaction_id\": \"transactionId\", \"operation\": \"operation\", \"user_agent\": \"userAgent\", \"url\": \"url\", \"instance_id\": \"instanceId\", \"thread_id\": \"threadId\", \"host\": \"host\", \"start_time\": \"startTime\", \"end_time\": \"endTime\", \"elapsed_time\": \"elapsedTime\", \"cluster_name\": \"clusterName\"}, \"id\": \"id\", \"account_id\": \"accountId\", \"template_id\": \"templateId\", \"template_version\": 15, \"target_type\": \"targetType\", \"target\": \"target\", \"status\": \"status\", \"resources\": [{\"target\": \"target\", \"profile\": {\"id\": \"id\", \"version\": \"version\", \"resource_created\": {\"id\": \"id\"}, \"error_message\": {\"name\": \"name\", \"errorCode\": \"errorCode\", \"message\": \"message\", \"statusCode\": \"statusCode\"}, \"status\": \"status\"}, \"account_settings\": {\"id\": \"id\", \"version\": \"version\", \"resource_created\": {\"id\": \"id\"}, \"error_message\": {\"name\": \"name\", \"errorCode\": \"errorCode\", \"message\": \"message\", \"statusCode\": \"statusCode\"}, \"status\": \"status\"}, \"policy_template_refs\": [{\"id\": \"id\", \"version\": \"version\", \"resource_created\": {\"id\": \"id\"}, \"error_message\": {\"name\": \"name\", \"errorCode\": \"errorCode\", \"message\": \"message\", \"statusCode\": \"statusCode\"}, \"status\": \"status\"}]}], \"history\": [{\"timestamp\": \"timestamp\", \"iam_id\": \"iamId\", \"iam_id_account\": \"iamIdAccount\", \"action\": \"action\", \"params\": [\"params\"], \"message\": \"message\"}], \"href\": \"href\", \"created_at\": \"createdAt\", \"created_by_id\": \"createdById\", \"last_modified_at\": \"lastModifiedAt\", \"last_modified_by_id\": \"lastModifiedById\", \"entity_tag\": \"entityTag\"}";
+    String getAccountSettingsAssignmentPath = "/v1/account_settings_assignments/testString";
+    server.enqueue(new MockResponse()
+      .setHeader("Content-type", "application/json")
+      .setResponseCode(200)
+      .setBody(mockResponseBody));
+
+    // Construct an instance of the GetAccountSettingsAssignmentOptions model
+    GetAccountSettingsAssignmentOptions getAccountSettingsAssignmentOptionsModel = new GetAccountSettingsAssignmentOptions.Builder()
+      .assignmentId("testString")
+      .includeHistory(false)
+      .build();
+
+    // Invoke getAccountSettingsAssignment() with a valid options model and verify the result
+    Response<TemplateAssignmentResponse> response = iamIdentityService.getAccountSettingsAssignment(getAccountSettingsAssignmentOptionsModel).execute();
+    assertNotNull(response);
+    TemplateAssignmentResponse responseObj = response.getResult();
+    assertNotNull(responseObj);
+
+    // Verify the contents of the request sent to the mock server
+    RecordedRequest request = server.takeRequest();
+    assertNotNull(request);
+    assertEquals(request.getMethod(), "GET");
+    // Verify request path
+    String parsedPath = TestUtilities.parseReqPath(request);
+    assertEquals(parsedPath, getAccountSettingsAssignmentPath);
+    // Verify query params
+    Map<String, String> query = TestUtilities.parseQueryString(request);
+    assertNotNull(query);
+    assertEquals(Boolean.valueOf(query.get("include_history")), Boolean.valueOf(false));
+  }
+
+  // Test the getAccountSettingsAssignment operation with and without retries enabled
+  @Test
+  public void testGetAccountSettingsAssignmentWRetries() throws Throwable {
+    iamIdentityService.enableRetries(4, 30);
+    testGetAccountSettingsAssignmentWOptions();
+
+    iamIdentityService.disableRetries();
+    testGetAccountSettingsAssignmentWOptions();
+  }
+
+  // Test the getAccountSettingsAssignment operation with a null options model (negative test)
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testGetAccountSettingsAssignmentNoOptions() throws Throwable {
+    server.enqueue(new MockResponse());
+    iamIdentityService.getAccountSettingsAssignment(null).execute();
+  }
+
+  // Test the deleteAccountSettingsAssignment operation with a valid options model parameter
+  @Test
+  public void testDeleteAccountSettingsAssignmentWOptions() throws Throwable {
+    // Register a mock response
+    String mockResponseBody = "{\"context\": {\"transaction_id\": \"transactionId\", \"operation\": \"operation\", \"user_agent\": \"userAgent\", \"url\": \"url\", \"instance_id\": \"instanceId\", \"thread_id\": \"threadId\", \"host\": \"host\", \"start_time\": \"startTime\", \"end_time\": \"endTime\", \"elapsed_time\": \"elapsedTime\", \"cluster_name\": \"clusterName\"}, \"status_code\": \"statusCode\", \"errors\": [{\"code\": \"code\", \"message_code\": \"messageCode\", \"message\": \"message\", \"details\": \"details\"}], \"trace\": \"trace\"}";
+    String deleteAccountSettingsAssignmentPath = "/v1/account_settings_assignments/testString";
+    server.enqueue(new MockResponse()
+      .setHeader("Content-type", "application/json")
+      .setResponseCode(202)
+      .setBody(mockResponseBody));
+
+    // Construct an instance of the DeleteAccountSettingsAssignmentOptions model
+    DeleteAccountSettingsAssignmentOptions deleteAccountSettingsAssignmentOptionsModel = new DeleteAccountSettingsAssignmentOptions.Builder()
+      .assignmentId("testString")
+      .build();
+
+    // Invoke deleteAccountSettingsAssignment() with a valid options model and verify the result
+    Response<ExceptionResponse> response = iamIdentityService.deleteAccountSettingsAssignment(deleteAccountSettingsAssignmentOptionsModel).execute();
+    assertNotNull(response);
+    ExceptionResponse responseObj = response.getResult();
+    assertNotNull(responseObj);
+
+    // Verify the contents of the request sent to the mock server
+    RecordedRequest request = server.takeRequest();
+    assertNotNull(request);
+    assertEquals(request.getMethod(), "DELETE");
+    // Verify request path
+    String parsedPath = TestUtilities.parseReqPath(request);
+    assertEquals(parsedPath, deleteAccountSettingsAssignmentPath);
+    // Verify that there is no query string
+    Map<String, String> query = TestUtilities.parseQueryString(request);
+    assertNull(query);
+  }
+
+  // Test the deleteAccountSettingsAssignment operation with and without retries enabled
+  @Test
+  public void testDeleteAccountSettingsAssignmentWRetries() throws Throwable {
+    iamIdentityService.enableRetries(4, 30);
+    testDeleteAccountSettingsAssignmentWOptions();
+
+    iamIdentityService.disableRetries();
+    testDeleteAccountSettingsAssignmentWOptions();
+  }
+
+  // Test the deleteAccountSettingsAssignment operation with a null options model (negative test)
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testDeleteAccountSettingsAssignmentNoOptions() throws Throwable {
+    server.enqueue(new MockResponse());
+    iamIdentityService.deleteAccountSettingsAssignment(null).execute();
+  }
+
+  // Test the updateAccountSettingsAssignment operation with a valid options model parameter
+  @Test
+  public void testUpdateAccountSettingsAssignmentWOptions() throws Throwable {
+    // Register a mock response
+    String mockResponseBody = "{\"context\": {\"transaction_id\": \"transactionId\", \"operation\": \"operation\", \"user_agent\": \"userAgent\", \"url\": \"url\", \"instance_id\": \"instanceId\", \"thread_id\": \"threadId\", \"host\": \"host\", \"start_time\": \"startTime\", \"end_time\": \"endTime\", \"elapsed_time\": \"elapsedTime\", \"cluster_name\": \"clusterName\"}, \"id\": \"id\", \"account_id\": \"accountId\", \"template_id\": \"templateId\", \"template_version\": 15, \"target_type\": \"targetType\", \"target\": \"target\", \"status\": \"status\", \"resources\": [{\"target\": \"target\", \"profile\": {\"id\": \"id\", \"version\": \"version\", \"resource_created\": {\"id\": \"id\"}, \"error_message\": {\"name\": \"name\", \"errorCode\": \"errorCode\", \"message\": \"message\", \"statusCode\": \"statusCode\"}, \"status\": \"status\"}, \"account_settings\": {\"id\": \"id\", \"version\": \"version\", \"resource_created\": {\"id\": \"id\"}, \"error_message\": {\"name\": \"name\", \"errorCode\": \"errorCode\", \"message\": \"message\", \"statusCode\": \"statusCode\"}, \"status\": \"status\"}, \"policy_template_refs\": [{\"id\": \"id\", \"version\": \"version\", \"resource_created\": {\"id\": \"id\"}, \"error_message\": {\"name\": \"name\", \"errorCode\": \"errorCode\", \"message\": \"message\", \"statusCode\": \"statusCode\"}, \"status\": \"status\"}]}], \"history\": [{\"timestamp\": \"timestamp\", \"iam_id\": \"iamId\", \"iam_id_account\": \"iamIdAccount\", \"action\": \"action\", \"params\": [\"params\"], \"message\": \"message\"}], \"href\": \"href\", \"created_at\": \"createdAt\", \"created_by_id\": \"createdById\", \"last_modified_at\": \"lastModifiedAt\", \"last_modified_by_id\": \"lastModifiedById\", \"entity_tag\": \"entityTag\"}";
+    String updateAccountSettingsAssignmentPath = "/v1/account_settings_assignments/testString";
+    server.enqueue(new MockResponse()
+      .setHeader("Content-type", "application/json")
+      .setResponseCode(200)
+      .setBody(mockResponseBody));
+
+    // Construct an instance of the UpdateAccountSettingsAssignmentOptions model
+    UpdateAccountSettingsAssignmentOptions updateAccountSettingsAssignmentOptionsModel = new UpdateAccountSettingsAssignmentOptions.Builder()
+      .assignmentId("testString")
+      .ifMatch("testString")
+      .templateVersion(Long.valueOf("1"))
+      .build();
+
+    // Invoke updateAccountSettingsAssignment() with a valid options model and verify the result
+    Response<TemplateAssignmentResponse> response = iamIdentityService.updateAccountSettingsAssignment(updateAccountSettingsAssignmentOptionsModel).execute();
+    assertNotNull(response);
+    TemplateAssignmentResponse responseObj = response.getResult();
+    assertNotNull(responseObj);
+
+    // Verify the contents of the request sent to the mock server
+    RecordedRequest request = server.takeRequest();
+    assertNotNull(request);
+    assertEquals(request.getMethod(), "PATCH");
+    // Verify request path
+    String parsedPath = TestUtilities.parseReqPath(request);
+    assertEquals(parsedPath, updateAccountSettingsAssignmentPath);
+    // Verify header parameters
+    assertEquals(request.getHeader("If-Match"), "testString");
+    // Verify that there is no query string
+    Map<String, String> query = TestUtilities.parseQueryString(request);
+    assertNull(query);
+  }
+
+  // Test the updateAccountSettingsAssignment operation with and without retries enabled
+  @Test
+  public void testUpdateAccountSettingsAssignmentWRetries() throws Throwable {
+    iamIdentityService.enableRetries(4, 30);
+    testUpdateAccountSettingsAssignmentWOptions();
+
+    iamIdentityService.disableRetries();
+    testUpdateAccountSettingsAssignmentWOptions();
+  }
+
+  // Test the updateAccountSettingsAssignment operation with a null options model (negative test)
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testUpdateAccountSettingsAssignmentNoOptions() throws Throwable {
+    server.enqueue(new MockResponse());
+    iamIdentityService.updateAccountSettingsAssignment(null).execute();
+  }
+
+  // Test the listAccountSettingsTemplates operation with a valid options model parameter
+  @Test
+  public void testListAccountSettingsTemplatesWOptions() throws Throwable {
+    // Register a mock response
+    String mockResponseBody = "{\"context\": {\"transaction_id\": \"transactionId\", \"operation\": \"operation\", \"user_agent\": \"userAgent\", \"url\": \"url\", \"instance_id\": \"instanceId\", \"thread_id\": \"threadId\", \"host\": \"host\", \"start_time\": \"startTime\", \"end_time\": \"endTime\", \"elapsed_time\": \"elapsedTime\", \"cluster_name\": \"clusterName\"}, \"offset\": 6, \"limit\": 20, \"first\": \"first\", \"previous\": \"previous\", \"next\": \"next\", \"account_settings_templates\": [{\"id\": \"id\", \"version\": 7, \"account_id\": \"accountId\", \"name\": \"name\", \"description\": \"description\", \"committed\": false, \"account_settings\": {\"restrict_create_service_id\": \"NOT_SET\", \"restrict_create_platform_apikey\": \"NOT_SET\", \"allowed_ip_addresses\": \"allowedIpAddresses\", \"mfa\": \"NONE\", \"user_mfa\": [{\"iam_id\": \"iamId\", \"mfa\": \"NONE\"}], \"session_expiration_in_seconds\": \"86400\", \"session_invalidation_in_seconds\": \"7200\", \"max_sessions_per_identity\": \"maxSessionsPerIdentity\", \"system_access_token_expiration_in_seconds\": \"3600\", \"system_refresh_token_expiration_in_seconds\": \"259200\"}, \"history\": [{\"timestamp\": \"timestamp\", \"iam_id\": \"iamId\", \"iam_id_account\": \"iamIdAccount\", \"action\": \"action\", \"params\": [\"params\"], \"message\": \"message\"}], \"entity_tag\": \"entityTag\", \"crn\": \"crn\", \"created_at\": \"createdAt\", \"created_by_id\": \"createdById\", \"last_modified_at\": \"lastModifiedAt\", \"last_modified_by_id\": \"lastModifiedById\"}]}";
+    String listAccountSettingsTemplatesPath = "/v1/account_settings_templates";
+    server.enqueue(new MockResponse()
+      .setHeader("Content-type", "application/json")
+      .setResponseCode(200)
+      .setBody(mockResponseBody));
+
+    // Construct an instance of the ListAccountSettingsTemplatesOptions model
+    ListAccountSettingsTemplatesOptions listAccountSettingsTemplatesOptionsModel = new ListAccountSettingsTemplatesOptions.Builder()
+      .accountId("testString")
+      .limit("20")
+      .pagetoken("testString")
+      .sort("created_at")
+      .order("asc")
+      .includeHistory("false")
+      .build();
+
+    // Invoke listAccountSettingsTemplates() with a valid options model and verify the result
+    Response<AccountSettingsTemplateList> response = iamIdentityService.listAccountSettingsTemplates(listAccountSettingsTemplatesOptionsModel).execute();
+    assertNotNull(response);
+    AccountSettingsTemplateList responseObj = response.getResult();
+    assertNotNull(responseObj);
+
+    // Verify the contents of the request sent to the mock server
+    RecordedRequest request = server.takeRequest();
+    assertNotNull(request);
+    assertEquals(request.getMethod(), "GET");
+    // Verify request path
+    String parsedPath = TestUtilities.parseReqPath(request);
+    assertEquals(parsedPath, listAccountSettingsTemplatesPath);
+    // Verify query params
+    Map<String, String> query = TestUtilities.parseQueryString(request);
+    assertNotNull(query);
+    assertEquals(query.get("account_id"), "testString");
+    assertEquals(query.get("limit"), "20");
+    assertEquals(query.get("pagetoken"), "testString");
+    assertEquals(query.get("sort"), "created_at");
+    assertEquals(query.get("order"), "asc");
+    assertEquals(query.get("include_history"), "false");
+  }
+
+  // Test the listAccountSettingsTemplates operation with and without retries enabled
+  @Test
+  public void testListAccountSettingsTemplatesWRetries() throws Throwable {
+    iamIdentityService.enableRetries(4, 30);
+    testListAccountSettingsTemplatesWOptions();
+
+    iamIdentityService.disableRetries();
+    testListAccountSettingsTemplatesWOptions();
+  }
+
+  // Test the createAccountSettingsTemplate operation with a valid options model parameter
+  @Test
+  public void testCreateAccountSettingsTemplateWOptions() throws Throwable {
+    // Register a mock response
+    String mockResponseBody = "{\"id\": \"id\", \"version\": 7, \"account_id\": \"accountId\", \"name\": \"name\", \"description\": \"description\", \"committed\": false, \"account_settings\": {\"restrict_create_service_id\": \"NOT_SET\", \"restrict_create_platform_apikey\": \"NOT_SET\", \"allowed_ip_addresses\": \"allowedIpAddresses\", \"mfa\": \"NONE\", \"user_mfa\": [{\"iam_id\": \"iamId\", \"mfa\": \"NONE\"}], \"session_expiration_in_seconds\": \"86400\", \"session_invalidation_in_seconds\": \"7200\", \"max_sessions_per_identity\": \"maxSessionsPerIdentity\", \"system_access_token_expiration_in_seconds\": \"3600\", \"system_refresh_token_expiration_in_seconds\": \"259200\"}, \"history\": [{\"timestamp\": \"timestamp\", \"iam_id\": \"iamId\", \"iam_id_account\": \"iamIdAccount\", \"action\": \"action\", \"params\": [\"params\"], \"message\": \"message\"}], \"entity_tag\": \"entityTag\", \"crn\": \"crn\", \"created_at\": \"createdAt\", \"created_by_id\": \"createdById\", \"last_modified_at\": \"lastModifiedAt\", \"last_modified_by_id\": \"lastModifiedById\"}";
+    String createAccountSettingsTemplatePath = "/v1/account_settings_templates";
+    server.enqueue(new MockResponse()
+      .setHeader("Content-type", "application/json")
+      .setResponseCode(201)
+      .setBody(mockResponseBody));
+
+    // Construct an instance of the AccountSettingsUserMFA model
+    AccountSettingsUserMFA accountSettingsUserMfaModel = new AccountSettingsUserMFA.Builder()
+      .iamId("testString")
+      .mfa("NONE")
+      .build();
+
+    // Construct an instance of the AccountSettingsComponent model
+    AccountSettingsComponent accountSettingsComponentModel = new AccountSettingsComponent.Builder()
+      .restrictCreateServiceId("NOT_SET")
+      .restrictCreatePlatformApikey("NOT_SET")
+      .allowedIpAddresses("testString")
+      .mfa("NONE")
+      .userMfa(java.util.Arrays.asList(accountSettingsUserMfaModel))
+      .sessionExpirationInSeconds("86400")
+      .sessionInvalidationInSeconds("7200")
+      .maxSessionsPerIdentity("testString")
+      .systemAccessTokenExpirationInSeconds("3600")
+      .systemRefreshTokenExpirationInSeconds("259200")
+      .build();
+
+    // Construct an instance of the CreateAccountSettingsTemplateOptions model
+    CreateAccountSettingsTemplateOptions createAccountSettingsTemplateOptionsModel = new CreateAccountSettingsTemplateOptions.Builder()
+      .accountId("testString")
+      .name("testString")
+      .description("testString")
+      .accountSettings(accountSettingsComponentModel)
+      .build();
+
+    // Invoke createAccountSettingsTemplate() with a valid options model and verify the result
+    Response<AccountSettingsTemplateResponse> response = iamIdentityService.createAccountSettingsTemplate(createAccountSettingsTemplateOptionsModel).execute();
+    assertNotNull(response);
+    AccountSettingsTemplateResponse responseObj = response.getResult();
+    assertNotNull(responseObj);
+
+    // Verify the contents of the request sent to the mock server
+    RecordedRequest request = server.takeRequest();
+    assertNotNull(request);
+    assertEquals(request.getMethod(), "POST");
+    // Verify request path
+    String parsedPath = TestUtilities.parseReqPath(request);
+    assertEquals(parsedPath, createAccountSettingsTemplatePath);
+    // Verify that there is no query string
+    Map<String, String> query = TestUtilities.parseQueryString(request);
+    assertNull(query);
+  }
+
+  // Test the createAccountSettingsTemplate operation with and without retries enabled
+  @Test
+  public void testCreateAccountSettingsTemplateWRetries() throws Throwable {
+    iamIdentityService.enableRetries(4, 30);
+    testCreateAccountSettingsTemplateWOptions();
+
+    iamIdentityService.disableRetries();
+    testCreateAccountSettingsTemplateWOptions();
+  }
+
+  // Test the getLatestAccountSettingsTemplateVersion operation with a valid options model parameter
+  @Test
+  public void testGetLatestAccountSettingsTemplateVersionWOptions() throws Throwable {
+    // Register a mock response
+    String mockResponseBody = "{\"id\": \"id\", \"version\": 7, \"account_id\": \"accountId\", \"name\": \"name\", \"description\": \"description\", \"committed\": false, \"account_settings\": {\"restrict_create_service_id\": \"NOT_SET\", \"restrict_create_platform_apikey\": \"NOT_SET\", \"allowed_ip_addresses\": \"allowedIpAddresses\", \"mfa\": \"NONE\", \"user_mfa\": [{\"iam_id\": \"iamId\", \"mfa\": \"NONE\"}], \"session_expiration_in_seconds\": \"86400\", \"session_invalidation_in_seconds\": \"7200\", \"max_sessions_per_identity\": \"maxSessionsPerIdentity\", \"system_access_token_expiration_in_seconds\": \"3600\", \"system_refresh_token_expiration_in_seconds\": \"259200\"}, \"history\": [{\"timestamp\": \"timestamp\", \"iam_id\": \"iamId\", \"iam_id_account\": \"iamIdAccount\", \"action\": \"action\", \"params\": [\"params\"], \"message\": \"message\"}], \"entity_tag\": \"entityTag\", \"crn\": \"crn\", \"created_at\": \"createdAt\", \"created_by_id\": \"createdById\", \"last_modified_at\": \"lastModifiedAt\", \"last_modified_by_id\": \"lastModifiedById\"}";
+    String getLatestAccountSettingsTemplateVersionPath = "/v1/account_settings_templates/testString";
+    server.enqueue(new MockResponse()
+      .setHeader("Content-type", "application/json")
+      .setResponseCode(200)
+      .setBody(mockResponseBody));
+
+    // Construct an instance of the GetLatestAccountSettingsTemplateVersionOptions model
+    GetLatestAccountSettingsTemplateVersionOptions getLatestAccountSettingsTemplateVersionOptionsModel = new GetLatestAccountSettingsTemplateVersionOptions.Builder()
+      .templateId("testString")
+      .includeHistory(false)
+      .build();
+
+    // Invoke getLatestAccountSettingsTemplateVersion() with a valid options model and verify the result
+    Response<AccountSettingsTemplateResponse> response = iamIdentityService.getLatestAccountSettingsTemplateVersion(getLatestAccountSettingsTemplateVersionOptionsModel).execute();
+    assertNotNull(response);
+    AccountSettingsTemplateResponse responseObj = response.getResult();
+    assertNotNull(responseObj);
+
+    // Verify the contents of the request sent to the mock server
+    RecordedRequest request = server.takeRequest();
+    assertNotNull(request);
+    assertEquals(request.getMethod(), "GET");
+    // Verify request path
+    String parsedPath = TestUtilities.parseReqPath(request);
+    assertEquals(parsedPath, getLatestAccountSettingsTemplateVersionPath);
+    // Verify query params
+    Map<String, String> query = TestUtilities.parseQueryString(request);
+    assertNotNull(query);
+    assertEquals(Boolean.valueOf(query.get("include_history")), Boolean.valueOf(false));
+  }
+
+  // Test the getLatestAccountSettingsTemplateVersion operation with and without retries enabled
+  @Test
+  public void testGetLatestAccountSettingsTemplateVersionWRetries() throws Throwable {
+    iamIdentityService.enableRetries(4, 30);
+    testGetLatestAccountSettingsTemplateVersionWOptions();
+
+    iamIdentityService.disableRetries();
+    testGetLatestAccountSettingsTemplateVersionWOptions();
+  }
+
+  // Test the getLatestAccountSettingsTemplateVersion operation with a null options model (negative test)
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testGetLatestAccountSettingsTemplateVersionNoOptions() throws Throwable {
+    server.enqueue(new MockResponse());
+    iamIdentityService.getLatestAccountSettingsTemplateVersion(null).execute();
+  }
+
+  // Test the deleteAllVersionsOfAccountSettingsTemplate operation with a valid options model parameter
+  @Test
+  public void testDeleteAllVersionsOfAccountSettingsTemplateWOptions() throws Throwable {
+    // Register a mock response
+    String mockResponseBody = "";
+    String deleteAllVersionsOfAccountSettingsTemplatePath = "/v1/account_settings_templates/testString";
+    server.enqueue(new MockResponse()
+      .setResponseCode(204)
+      .setBody(mockResponseBody));
+
+    // Construct an instance of the DeleteAllVersionsOfAccountSettingsTemplateOptions model
+    DeleteAllVersionsOfAccountSettingsTemplateOptions deleteAllVersionsOfAccountSettingsTemplateOptionsModel = new DeleteAllVersionsOfAccountSettingsTemplateOptions.Builder()
+      .templateId("testString")
+      .build();
+
+    // Invoke deleteAllVersionsOfAccountSettingsTemplate() with a valid options model and verify the result
+    Response<Void> response = iamIdentityService.deleteAllVersionsOfAccountSettingsTemplate(deleteAllVersionsOfAccountSettingsTemplateOptionsModel).execute();
+    assertNotNull(response);
+    Void responseObj = response.getResult();
+    assertNull(responseObj);
+
+    // Verify the contents of the request sent to the mock server
+    RecordedRequest request = server.takeRequest();
+    assertNotNull(request);
+    assertEquals(request.getMethod(), "DELETE");
+    // Verify request path
+    String parsedPath = TestUtilities.parseReqPath(request);
+    assertEquals(parsedPath, deleteAllVersionsOfAccountSettingsTemplatePath);
+    // Verify that there is no query string
+    Map<String, String> query = TestUtilities.parseQueryString(request);
+    assertNull(query);
+  }
+
+  // Test the deleteAllVersionsOfAccountSettingsTemplate operation with and without retries enabled
+  @Test
+  public void testDeleteAllVersionsOfAccountSettingsTemplateWRetries() throws Throwable {
+    iamIdentityService.enableRetries(4, 30);
+    testDeleteAllVersionsOfAccountSettingsTemplateWOptions();
+
+    iamIdentityService.disableRetries();
+    testDeleteAllVersionsOfAccountSettingsTemplateWOptions();
+  }
+
+  // Test the deleteAllVersionsOfAccountSettingsTemplate operation with a null options model (negative test)
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testDeleteAllVersionsOfAccountSettingsTemplateNoOptions() throws Throwable {
+    server.enqueue(new MockResponse());
+    iamIdentityService.deleteAllVersionsOfAccountSettingsTemplate(null).execute();
+  }
+
+  // Test the listVersionsOfAccountSettingsTemplate operation with a valid options model parameter
+  @Test
+  public void testListVersionsOfAccountSettingsTemplateWOptions() throws Throwable {
+    // Register a mock response
+    String mockResponseBody = "{\"context\": {\"transaction_id\": \"transactionId\", \"operation\": \"operation\", \"user_agent\": \"userAgent\", \"url\": \"url\", \"instance_id\": \"instanceId\", \"thread_id\": \"threadId\", \"host\": \"host\", \"start_time\": \"startTime\", \"end_time\": \"endTime\", \"elapsed_time\": \"elapsedTime\", \"cluster_name\": \"clusterName\"}, \"offset\": 6, \"limit\": 20, \"first\": \"first\", \"previous\": \"previous\", \"next\": \"next\", \"account_settings_templates\": [{\"id\": \"id\", \"version\": 7, \"account_id\": \"accountId\", \"name\": \"name\", \"description\": \"description\", \"committed\": false, \"account_settings\": {\"restrict_create_service_id\": \"NOT_SET\", \"restrict_create_platform_apikey\": \"NOT_SET\", \"allowed_ip_addresses\": \"allowedIpAddresses\", \"mfa\": \"NONE\", \"user_mfa\": [{\"iam_id\": \"iamId\", \"mfa\": \"NONE\"}], \"session_expiration_in_seconds\": \"86400\", \"session_invalidation_in_seconds\": \"7200\", \"max_sessions_per_identity\": \"maxSessionsPerIdentity\", \"system_access_token_expiration_in_seconds\": \"3600\", \"system_refresh_token_expiration_in_seconds\": \"259200\"}, \"history\": [{\"timestamp\": \"timestamp\", \"iam_id\": \"iamId\", \"iam_id_account\": \"iamIdAccount\", \"action\": \"action\", \"params\": [\"params\"], \"message\": \"message\"}], \"entity_tag\": \"entityTag\", \"crn\": \"crn\", \"created_at\": \"createdAt\", \"created_by_id\": \"createdById\", \"last_modified_at\": \"lastModifiedAt\", \"last_modified_by_id\": \"lastModifiedById\"}]}";
+    String listVersionsOfAccountSettingsTemplatePath = "/v1/account_settings_templates/testString/versions";
+    server.enqueue(new MockResponse()
+      .setHeader("Content-type", "application/json")
+      .setResponseCode(200)
+      .setBody(mockResponseBody));
+
+    // Construct an instance of the ListVersionsOfAccountSettingsTemplateOptions model
+    ListVersionsOfAccountSettingsTemplateOptions listVersionsOfAccountSettingsTemplateOptionsModel = new ListVersionsOfAccountSettingsTemplateOptions.Builder()
+      .templateId("testString")
+      .limit("20")
+      .pagetoken("testString")
+      .sort("created_at")
+      .order("asc")
+      .includeHistory("false")
+      .build();
+
+    // Invoke listVersionsOfAccountSettingsTemplate() with a valid options model and verify the result
+    Response<AccountSettingsTemplateList> response = iamIdentityService.listVersionsOfAccountSettingsTemplate(listVersionsOfAccountSettingsTemplateOptionsModel).execute();
+    assertNotNull(response);
+    AccountSettingsTemplateList responseObj = response.getResult();
+    assertNotNull(responseObj);
+
+    // Verify the contents of the request sent to the mock server
+    RecordedRequest request = server.takeRequest();
+    assertNotNull(request);
+    assertEquals(request.getMethod(), "GET");
+    // Verify request path
+    String parsedPath = TestUtilities.parseReqPath(request);
+    assertEquals(parsedPath, listVersionsOfAccountSettingsTemplatePath);
+    // Verify query params
+    Map<String, String> query = TestUtilities.parseQueryString(request);
+    assertNotNull(query);
+    assertEquals(query.get("limit"), "20");
+    assertEquals(query.get("pagetoken"), "testString");
+    assertEquals(query.get("sort"), "created_at");
+    assertEquals(query.get("order"), "asc");
+    assertEquals(query.get("include_history"), "false");
+  }
+
+  // Test the listVersionsOfAccountSettingsTemplate operation with and without retries enabled
+  @Test
+  public void testListVersionsOfAccountSettingsTemplateWRetries() throws Throwable {
+    iamIdentityService.enableRetries(4, 30);
+    testListVersionsOfAccountSettingsTemplateWOptions();
+
+    iamIdentityService.disableRetries();
+    testListVersionsOfAccountSettingsTemplateWOptions();
+  }
+
+  // Test the listVersionsOfAccountSettingsTemplate operation with a null options model (negative test)
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testListVersionsOfAccountSettingsTemplateNoOptions() throws Throwable {
+    server.enqueue(new MockResponse());
+    iamIdentityService.listVersionsOfAccountSettingsTemplate(null).execute();
+  }
+
+  // Test the createAccountSettingsTemplateVersion operation with a valid options model parameter
+  @Test
+  public void testCreateAccountSettingsTemplateVersionWOptions() throws Throwable {
+    // Register a mock response
+    String mockResponseBody = "{\"id\": \"id\", \"version\": 7, \"account_id\": \"accountId\", \"name\": \"name\", \"description\": \"description\", \"committed\": false, \"account_settings\": {\"restrict_create_service_id\": \"NOT_SET\", \"restrict_create_platform_apikey\": \"NOT_SET\", \"allowed_ip_addresses\": \"allowedIpAddresses\", \"mfa\": \"NONE\", \"user_mfa\": [{\"iam_id\": \"iamId\", \"mfa\": \"NONE\"}], \"session_expiration_in_seconds\": \"86400\", \"session_invalidation_in_seconds\": \"7200\", \"max_sessions_per_identity\": \"maxSessionsPerIdentity\", \"system_access_token_expiration_in_seconds\": \"3600\", \"system_refresh_token_expiration_in_seconds\": \"259200\"}, \"history\": [{\"timestamp\": \"timestamp\", \"iam_id\": \"iamId\", \"iam_id_account\": \"iamIdAccount\", \"action\": \"action\", \"params\": [\"params\"], \"message\": \"message\"}], \"entity_tag\": \"entityTag\", \"crn\": \"crn\", \"created_at\": \"createdAt\", \"created_by_id\": \"createdById\", \"last_modified_at\": \"lastModifiedAt\", \"last_modified_by_id\": \"lastModifiedById\"}";
+    String createAccountSettingsTemplateVersionPath = "/v1/account_settings_templates/testString/versions";
+    server.enqueue(new MockResponse()
+      .setHeader("Content-type", "application/json")
+      .setResponseCode(201)
+      .setBody(mockResponseBody));
+
+    // Construct an instance of the AccountSettingsUserMFA model
+    AccountSettingsUserMFA accountSettingsUserMfaModel = new AccountSettingsUserMFA.Builder()
+      .iamId("testString")
+      .mfa("NONE")
+      .build();
+
+    // Construct an instance of the AccountSettingsComponent model
+    AccountSettingsComponent accountSettingsComponentModel = new AccountSettingsComponent.Builder()
+      .restrictCreateServiceId("NOT_SET")
+      .restrictCreatePlatformApikey("NOT_SET")
+      .allowedIpAddresses("testString")
+      .mfa("NONE")
+      .userMfa(java.util.Arrays.asList(accountSettingsUserMfaModel))
+      .sessionExpirationInSeconds("86400")
+      .sessionInvalidationInSeconds("7200")
+      .maxSessionsPerIdentity("testString")
+      .systemAccessTokenExpirationInSeconds("3600")
+      .systemRefreshTokenExpirationInSeconds("259200")
+      .build();
+
+    // Construct an instance of the CreateAccountSettingsTemplateVersionOptions model
+    CreateAccountSettingsTemplateVersionOptions createAccountSettingsTemplateVersionOptionsModel = new CreateAccountSettingsTemplateVersionOptions.Builder()
+      .templateId("testString")
+      .accountId("testString")
+      .name("testString")
+      .description("testString")
+      .accountSettings(accountSettingsComponentModel)
+      .build();
+
+    // Invoke createAccountSettingsTemplateVersion() with a valid options model and verify the result
+    Response<AccountSettingsTemplateResponse> response = iamIdentityService.createAccountSettingsTemplateVersion(createAccountSettingsTemplateVersionOptionsModel).execute();
+    assertNotNull(response);
+    AccountSettingsTemplateResponse responseObj = response.getResult();
+    assertNotNull(responseObj);
+
+    // Verify the contents of the request sent to the mock server
+    RecordedRequest request = server.takeRequest();
+    assertNotNull(request);
+    assertEquals(request.getMethod(), "POST");
+    // Verify request path
+    String parsedPath = TestUtilities.parseReqPath(request);
+    assertEquals(parsedPath, createAccountSettingsTemplateVersionPath);
+    // Verify that there is no query string
+    Map<String, String> query = TestUtilities.parseQueryString(request);
+    assertNull(query);
+  }
+
+  // Test the createAccountSettingsTemplateVersion operation with and without retries enabled
+  @Test
+  public void testCreateAccountSettingsTemplateVersionWRetries() throws Throwable {
+    iamIdentityService.enableRetries(4, 30);
+    testCreateAccountSettingsTemplateVersionWOptions();
+
+    iamIdentityService.disableRetries();
+    testCreateAccountSettingsTemplateVersionWOptions();
+  }
+
+  // Test the createAccountSettingsTemplateVersion operation with a null options model (negative test)
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testCreateAccountSettingsTemplateVersionNoOptions() throws Throwable {
+    server.enqueue(new MockResponse());
+    iamIdentityService.createAccountSettingsTemplateVersion(null).execute();
+  }
+
+  // Test the getAccountSettingsTemplateVersion operation with a valid options model parameter
+  @Test
+  public void testGetAccountSettingsTemplateVersionWOptions() throws Throwable {
+    // Register a mock response
+    String mockResponseBody = "{\"id\": \"id\", \"version\": 7, \"account_id\": \"accountId\", \"name\": \"name\", \"description\": \"description\", \"committed\": false, \"account_settings\": {\"restrict_create_service_id\": \"NOT_SET\", \"restrict_create_platform_apikey\": \"NOT_SET\", \"allowed_ip_addresses\": \"allowedIpAddresses\", \"mfa\": \"NONE\", \"user_mfa\": [{\"iam_id\": \"iamId\", \"mfa\": \"NONE\"}], \"session_expiration_in_seconds\": \"86400\", \"session_invalidation_in_seconds\": \"7200\", \"max_sessions_per_identity\": \"maxSessionsPerIdentity\", \"system_access_token_expiration_in_seconds\": \"3600\", \"system_refresh_token_expiration_in_seconds\": \"259200\"}, \"history\": [{\"timestamp\": \"timestamp\", \"iam_id\": \"iamId\", \"iam_id_account\": \"iamIdAccount\", \"action\": \"action\", \"params\": [\"params\"], \"message\": \"message\"}], \"entity_tag\": \"entityTag\", \"crn\": \"crn\", \"created_at\": \"createdAt\", \"created_by_id\": \"createdById\", \"last_modified_at\": \"lastModifiedAt\", \"last_modified_by_id\": \"lastModifiedById\"}";
+    String getAccountSettingsTemplateVersionPath = "/v1/account_settings_templates/testString/versions/testString";
+    server.enqueue(new MockResponse()
+      .setHeader("Content-type", "application/json")
+      .setResponseCode(200)
+      .setBody(mockResponseBody));
+
+    // Construct an instance of the GetAccountSettingsTemplateVersionOptions model
+    GetAccountSettingsTemplateVersionOptions getAccountSettingsTemplateVersionOptionsModel = new GetAccountSettingsTemplateVersionOptions.Builder()
+      .templateId("testString")
+      .version("testString")
+      .includeHistory(false)
+      .build();
+
+    // Invoke getAccountSettingsTemplateVersion() with a valid options model and verify the result
+    Response<AccountSettingsTemplateResponse> response = iamIdentityService.getAccountSettingsTemplateVersion(getAccountSettingsTemplateVersionOptionsModel).execute();
+    assertNotNull(response);
+    AccountSettingsTemplateResponse responseObj = response.getResult();
+    assertNotNull(responseObj);
+
+    // Verify the contents of the request sent to the mock server
+    RecordedRequest request = server.takeRequest();
+    assertNotNull(request);
+    assertEquals(request.getMethod(), "GET");
+    // Verify request path
+    String parsedPath = TestUtilities.parseReqPath(request);
+    assertEquals(parsedPath, getAccountSettingsTemplateVersionPath);
+    // Verify query params
+    Map<String, String> query = TestUtilities.parseQueryString(request);
+    assertNotNull(query);
+    assertEquals(Boolean.valueOf(query.get("include_history")), Boolean.valueOf(false));
+  }
+
+  // Test the getAccountSettingsTemplateVersion operation with and without retries enabled
+  @Test
+  public void testGetAccountSettingsTemplateVersionWRetries() throws Throwable {
+    iamIdentityService.enableRetries(4, 30);
+    testGetAccountSettingsTemplateVersionWOptions();
+
+    iamIdentityService.disableRetries();
+    testGetAccountSettingsTemplateVersionWOptions();
+  }
+
+  // Test the getAccountSettingsTemplateVersion operation with a null options model (negative test)
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testGetAccountSettingsTemplateVersionNoOptions() throws Throwable {
+    server.enqueue(new MockResponse());
+    iamIdentityService.getAccountSettingsTemplateVersion(null).execute();
+  }
+
+  // Test the updateAccountSettingsTemplateVersion operation with a valid options model parameter
+  @Test
+  public void testUpdateAccountSettingsTemplateVersionWOptions() throws Throwable {
+    // Register a mock response
+    String mockResponseBody = "{\"id\": \"id\", \"version\": 7, \"account_id\": \"accountId\", \"name\": \"name\", \"description\": \"description\", \"committed\": false, \"account_settings\": {\"restrict_create_service_id\": \"NOT_SET\", \"restrict_create_platform_apikey\": \"NOT_SET\", \"allowed_ip_addresses\": \"allowedIpAddresses\", \"mfa\": \"NONE\", \"user_mfa\": [{\"iam_id\": \"iamId\", \"mfa\": \"NONE\"}], \"session_expiration_in_seconds\": \"86400\", \"session_invalidation_in_seconds\": \"7200\", \"max_sessions_per_identity\": \"maxSessionsPerIdentity\", \"system_access_token_expiration_in_seconds\": \"3600\", \"system_refresh_token_expiration_in_seconds\": \"259200\"}, \"history\": [{\"timestamp\": \"timestamp\", \"iam_id\": \"iamId\", \"iam_id_account\": \"iamIdAccount\", \"action\": \"action\", \"params\": [\"params\"], \"message\": \"message\"}], \"entity_tag\": \"entityTag\", \"crn\": \"crn\", \"created_at\": \"createdAt\", \"created_by_id\": \"createdById\", \"last_modified_at\": \"lastModifiedAt\", \"last_modified_by_id\": \"lastModifiedById\"}";
+    String updateAccountSettingsTemplateVersionPath = "/v1/account_settings_templates/testString/versions/testString";
+    server.enqueue(new MockResponse()
+      .setHeader("Content-type", "application/json")
+      .setResponseCode(200)
+      .setBody(mockResponseBody));
+
+    // Construct an instance of the AccountSettingsUserMFA model
+    AccountSettingsUserMFA accountSettingsUserMfaModel = new AccountSettingsUserMFA.Builder()
+      .iamId("testString")
+      .mfa("NONE")
+      .build();
+
+    // Construct an instance of the AccountSettingsComponent model
+    AccountSettingsComponent accountSettingsComponentModel = new AccountSettingsComponent.Builder()
+      .restrictCreateServiceId("NOT_SET")
+      .restrictCreatePlatformApikey("NOT_SET")
+      .allowedIpAddresses("testString")
+      .mfa("NONE")
+      .userMfa(java.util.Arrays.asList(accountSettingsUserMfaModel))
+      .sessionExpirationInSeconds("86400")
+      .sessionInvalidationInSeconds("7200")
+      .maxSessionsPerIdentity("testString")
+      .systemAccessTokenExpirationInSeconds("3600")
+      .systemRefreshTokenExpirationInSeconds("259200")
+      .build();
+
+    // Construct an instance of the UpdateAccountSettingsTemplateVersionOptions model
+    UpdateAccountSettingsTemplateVersionOptions updateAccountSettingsTemplateVersionOptionsModel = new UpdateAccountSettingsTemplateVersionOptions.Builder()
+      .ifMatch("testString")
+      .templateId("testString")
+      .version("testString")
+      .accountId("testString")
+      .name("testString")
+      .description("testString")
+      .accountSettings(accountSettingsComponentModel)
+      .build();
+
+    // Invoke updateAccountSettingsTemplateVersion() with a valid options model and verify the result
+    Response<AccountSettingsTemplateResponse> response = iamIdentityService.updateAccountSettingsTemplateVersion(updateAccountSettingsTemplateVersionOptionsModel).execute();
+    assertNotNull(response);
+    AccountSettingsTemplateResponse responseObj = response.getResult();
+    assertNotNull(responseObj);
+
+    // Verify the contents of the request sent to the mock server
+    RecordedRequest request = server.takeRequest();
+    assertNotNull(request);
+    assertEquals(request.getMethod(), "PUT");
+    // Verify request path
+    String parsedPath = TestUtilities.parseReqPath(request);
+    assertEquals(parsedPath, updateAccountSettingsTemplateVersionPath);
+    // Verify header parameters
+    assertEquals(request.getHeader("If-Match"), "testString");
+    // Verify that there is no query string
+    Map<String, String> query = TestUtilities.parseQueryString(request);
+    assertNull(query);
+  }
+
+  // Test the updateAccountSettingsTemplateVersion operation with and without retries enabled
+  @Test
+  public void testUpdateAccountSettingsTemplateVersionWRetries() throws Throwable {
+    iamIdentityService.enableRetries(4, 30);
+    testUpdateAccountSettingsTemplateVersionWOptions();
+
+    iamIdentityService.disableRetries();
+    testUpdateAccountSettingsTemplateVersionWOptions();
+  }
+
+  // Test the updateAccountSettingsTemplateVersion operation with a null options model (negative test)
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testUpdateAccountSettingsTemplateVersionNoOptions() throws Throwable {
+    server.enqueue(new MockResponse());
+    iamIdentityService.updateAccountSettingsTemplateVersion(null).execute();
+  }
+
+  // Test the deleteAccountSettingsTemplateVersion operation with a valid options model parameter
+  @Test
+  public void testDeleteAccountSettingsTemplateVersionWOptions() throws Throwable {
+    // Register a mock response
+    String mockResponseBody = "";
+    String deleteAccountSettingsTemplateVersionPath = "/v1/account_settings_templates/testString/versions/testString";
+    server.enqueue(new MockResponse()
+      .setResponseCode(204)
+      .setBody(mockResponseBody));
+
+    // Construct an instance of the DeleteAccountSettingsTemplateVersionOptions model
+    DeleteAccountSettingsTemplateVersionOptions deleteAccountSettingsTemplateVersionOptionsModel = new DeleteAccountSettingsTemplateVersionOptions.Builder()
+      .templateId("testString")
+      .version("testString")
+      .build();
+
+    // Invoke deleteAccountSettingsTemplateVersion() with a valid options model and verify the result
+    Response<Void> response = iamIdentityService.deleteAccountSettingsTemplateVersion(deleteAccountSettingsTemplateVersionOptionsModel).execute();
+    assertNotNull(response);
+    Void responseObj = response.getResult();
+    assertNull(responseObj);
+
+    // Verify the contents of the request sent to the mock server
+    RecordedRequest request = server.takeRequest();
+    assertNotNull(request);
+    assertEquals(request.getMethod(), "DELETE");
+    // Verify request path
+    String parsedPath = TestUtilities.parseReqPath(request);
+    assertEquals(parsedPath, deleteAccountSettingsTemplateVersionPath);
+    // Verify that there is no query string
+    Map<String, String> query = TestUtilities.parseQueryString(request);
+    assertNull(query);
+  }
+
+  // Test the deleteAccountSettingsTemplateVersion operation with and without retries enabled
+  @Test
+  public void testDeleteAccountSettingsTemplateVersionWRetries() throws Throwable {
+    iamIdentityService.enableRetries(4, 30);
+    testDeleteAccountSettingsTemplateVersionWOptions();
+
+    iamIdentityService.disableRetries();
+    testDeleteAccountSettingsTemplateVersionWOptions();
+  }
+
+  // Test the deleteAccountSettingsTemplateVersion operation with a null options model (negative test)
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testDeleteAccountSettingsTemplateVersionNoOptions() throws Throwable {
+    server.enqueue(new MockResponse());
+    iamIdentityService.deleteAccountSettingsTemplateVersion(null).execute();
+  }
+
+  // Test the commitAccountSettingsTemplate operation with a valid options model parameter
+  @Test
+  public void testCommitAccountSettingsTemplateWOptions() throws Throwable {
+    // Register a mock response
+    String mockResponseBody = "";
+    String commitAccountSettingsTemplatePath = "/v1/account_settings_templates/testString/versions/testString/commit";
+    server.enqueue(new MockResponse()
+      .setResponseCode(204)
+      .setBody(mockResponseBody));
+
+    // Construct an instance of the CommitAccountSettingsTemplateOptions model
+    CommitAccountSettingsTemplateOptions commitAccountSettingsTemplateOptionsModel = new CommitAccountSettingsTemplateOptions.Builder()
+      .templateId("testString")
+      .version("testString")
+      .build();
+
+    // Invoke commitAccountSettingsTemplate() with a valid options model and verify the result
+    Response<Void> response = iamIdentityService.commitAccountSettingsTemplate(commitAccountSettingsTemplateOptionsModel).execute();
+    assertNotNull(response);
+    Void responseObj = response.getResult();
+    assertNull(responseObj);
+
+    // Verify the contents of the request sent to the mock server
+    RecordedRequest request = server.takeRequest();
+    assertNotNull(request);
+    assertEquals(request.getMethod(), "POST");
+    // Verify request path
+    String parsedPath = TestUtilities.parseReqPath(request);
+    assertEquals(parsedPath, commitAccountSettingsTemplatePath);
+    // Verify that there is no query string
+    Map<String, String> query = TestUtilities.parseQueryString(request);
+    assertNull(query);
+  }
+
+  // Test the commitAccountSettingsTemplate operation with and without retries enabled
+  @Test
+  public void testCommitAccountSettingsTemplateWRetries() throws Throwable {
+    iamIdentityService.enableRetries(4, 30);
+    testCommitAccountSettingsTemplateWOptions();
+
+    iamIdentityService.disableRetries();
+    testCommitAccountSettingsTemplateWOptions();
+  }
+
+  // Test the commitAccountSettingsTemplate operation with a null options model (negative test)
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testCommitAccountSettingsTemplateNoOptions() throws Throwable {
+    server.enqueue(new MockResponse());
+    iamIdentityService.commitAccountSettingsTemplate(null).execute();
+  }
+
   // Test the createReport operation with a valid options model parameter
   @Test
   public void testCreateReportWOptions() throws Throwable {
@@ -2406,6 +3324,935 @@ public class IamIdentityTest {
   public void testGetReportNoOptions() throws Throwable {
     server.enqueue(new MockResponse());
     iamIdentityService.getReport(null).execute();
+  }
+
+  // Test the listTrustedProfileAssignments operation with a valid options model parameter
+  @Test
+  public void testListTrustedProfileAssignmentsWOptions() throws Throwable {
+    // Register a mock response
+    String mockResponseBody = "{\"context\": {\"transaction_id\": \"transactionId\", \"operation\": \"operation\", \"user_agent\": \"userAgent\", \"url\": \"url\", \"instance_id\": \"instanceId\", \"thread_id\": \"threadId\", \"host\": \"host\", \"start_time\": \"startTime\", \"end_time\": \"endTime\", \"elapsed_time\": \"elapsedTime\", \"cluster_name\": \"clusterName\"}, \"offset\": 6, \"limit\": 5, \"first\": \"first\", \"previous\": \"previous\", \"next\": \"next\", \"assignments\": [{\"context\": {\"transaction_id\": \"transactionId\", \"operation\": \"operation\", \"user_agent\": \"userAgent\", \"url\": \"url\", \"instance_id\": \"instanceId\", \"thread_id\": \"threadId\", \"host\": \"host\", \"start_time\": \"startTime\", \"end_time\": \"endTime\", \"elapsed_time\": \"elapsedTime\", \"cluster_name\": \"clusterName\"}, \"id\": \"id\", \"account_id\": \"accountId\", \"template_id\": \"templateId\", \"template_version\": 15, \"target_type\": \"targetType\", \"target\": \"target\", \"status\": \"status\", \"resources\": [{\"target\": \"target\", \"profile\": {\"id\": \"id\", \"version\": \"version\", \"resource_created\": {\"id\": \"id\"}, \"error_message\": {\"name\": \"name\", \"errorCode\": \"errorCode\", \"message\": \"message\", \"statusCode\": \"statusCode\"}, \"status\": \"status\"}, \"account_settings\": {\"id\": \"id\", \"version\": \"version\", \"resource_created\": {\"id\": \"id\"}, \"error_message\": {\"name\": \"name\", \"errorCode\": \"errorCode\", \"message\": \"message\", \"statusCode\": \"statusCode\"}, \"status\": \"status\"}, \"policy_template_refs\": [{\"id\": \"id\", \"version\": \"version\", \"resource_created\": {\"id\": \"id\"}, \"error_message\": {\"name\": \"name\", \"errorCode\": \"errorCode\", \"message\": \"message\", \"statusCode\": \"statusCode\"}, \"status\": \"status\"}]}], \"history\": [{\"timestamp\": \"timestamp\", \"iam_id\": \"iamId\", \"iam_id_account\": \"iamIdAccount\", \"action\": \"action\", \"params\": [\"params\"], \"message\": \"message\"}], \"href\": \"href\", \"created_at\": \"createdAt\", \"created_by_id\": \"createdById\", \"last_modified_at\": \"lastModifiedAt\", \"last_modified_by_id\": \"lastModifiedById\", \"entity_tag\": \"entityTag\"}]}";
+    String listTrustedProfileAssignmentsPath = "/v1/profile_assignments/";
+    server.enqueue(new MockResponse()
+      .setHeader("Content-type", "application/json")
+      .setResponseCode(200)
+      .setBody(mockResponseBody));
+
+    // Construct an instance of the ListTrustedProfileAssignmentsOptions model
+    ListTrustedProfileAssignmentsOptions listTrustedProfileAssignmentsOptionsModel = new ListTrustedProfileAssignmentsOptions.Builder()
+      .accountId("testString")
+      .templateId("testString")
+      .templateVersion("testString")
+      .target("testString")
+      .targetType("Account")
+      .limit(Long.valueOf("20"))
+      .pagetoken("testString")
+      .sort("created_at")
+      .order("asc")
+      .includeHistory(false)
+      .build();
+
+    // Invoke listTrustedProfileAssignments() with a valid options model and verify the result
+    Response<TemplateAssignmentListResponse> response = iamIdentityService.listTrustedProfileAssignments(listTrustedProfileAssignmentsOptionsModel).execute();
+    assertNotNull(response);
+    TemplateAssignmentListResponse responseObj = response.getResult();
+    assertNotNull(responseObj);
+
+    // Verify the contents of the request sent to the mock server
+    RecordedRequest request = server.takeRequest();
+    assertNotNull(request);
+    assertEquals(request.getMethod(), "GET");
+    // Verify request path
+    String parsedPath = TestUtilities.parseReqPath(request);
+    assertEquals(parsedPath, listTrustedProfileAssignmentsPath);
+    // Verify query params
+    Map<String, String> query = TestUtilities.parseQueryString(request);
+    assertNotNull(query);
+    assertEquals(query.get("account_id"), "testString");
+    assertEquals(query.get("template_id"), "testString");
+    assertEquals(query.get("template_version"), "testString");
+    assertEquals(query.get("target"), "testString");
+    assertEquals(query.get("target_type"), "Account");
+    assertEquals(Long.valueOf(query.get("limit")), Long.valueOf("20"));
+    assertEquals(query.get("pagetoken"), "testString");
+    assertEquals(query.get("sort"), "created_at");
+    assertEquals(query.get("order"), "asc");
+    assertEquals(Boolean.valueOf(query.get("include_history")), Boolean.valueOf(false));
+  }
+
+  // Test the listTrustedProfileAssignments operation with and without retries enabled
+  @Test
+  public void testListTrustedProfileAssignmentsWRetries() throws Throwable {
+    iamIdentityService.enableRetries(4, 30);
+    testListTrustedProfileAssignmentsWOptions();
+
+    iamIdentityService.disableRetries();
+    testListTrustedProfileAssignmentsWOptions();
+  }
+
+  // Test the createTrustedProfileAssignment operation with a valid options model parameter
+  @Test
+  public void testCreateTrustedProfileAssignmentWOptions() throws Throwable {
+    // Register a mock response
+    String mockResponseBody = "{\"context\": {\"transaction_id\": \"transactionId\", \"operation\": \"operation\", \"user_agent\": \"userAgent\", \"url\": \"url\", \"instance_id\": \"instanceId\", \"thread_id\": \"threadId\", \"host\": \"host\", \"start_time\": \"startTime\", \"end_time\": \"endTime\", \"elapsed_time\": \"elapsedTime\", \"cluster_name\": \"clusterName\"}, \"id\": \"id\", \"account_id\": \"accountId\", \"template_id\": \"templateId\", \"template_version\": 15, \"target_type\": \"targetType\", \"target\": \"target\", \"status\": \"status\", \"resources\": [{\"target\": \"target\", \"profile\": {\"id\": \"id\", \"version\": \"version\", \"resource_created\": {\"id\": \"id\"}, \"error_message\": {\"name\": \"name\", \"errorCode\": \"errorCode\", \"message\": \"message\", \"statusCode\": \"statusCode\"}, \"status\": \"status\"}, \"account_settings\": {\"id\": \"id\", \"version\": \"version\", \"resource_created\": {\"id\": \"id\"}, \"error_message\": {\"name\": \"name\", \"errorCode\": \"errorCode\", \"message\": \"message\", \"statusCode\": \"statusCode\"}, \"status\": \"status\"}, \"policy_template_refs\": [{\"id\": \"id\", \"version\": \"version\", \"resource_created\": {\"id\": \"id\"}, \"error_message\": {\"name\": \"name\", \"errorCode\": \"errorCode\", \"message\": \"message\", \"statusCode\": \"statusCode\"}, \"status\": \"status\"}]}], \"history\": [{\"timestamp\": \"timestamp\", \"iam_id\": \"iamId\", \"iam_id_account\": \"iamIdAccount\", \"action\": \"action\", \"params\": [\"params\"], \"message\": \"message\"}], \"href\": \"href\", \"created_at\": \"createdAt\", \"created_by_id\": \"createdById\", \"last_modified_at\": \"lastModifiedAt\", \"last_modified_by_id\": \"lastModifiedById\", \"entity_tag\": \"entityTag\"}";
+    String createTrustedProfileAssignmentPath = "/v1/profile_assignments/";
+    server.enqueue(new MockResponse()
+      .setHeader("Content-type", "application/json")
+      .setResponseCode(202)
+      .setBody(mockResponseBody));
+
+    // Construct an instance of the CreateTrustedProfileAssignmentOptions model
+    CreateTrustedProfileAssignmentOptions createTrustedProfileAssignmentOptionsModel = new CreateTrustedProfileAssignmentOptions.Builder()
+      .templateId("testString")
+      .templateVersion(Long.valueOf("1"))
+      .targetType("Account")
+      .target("testString")
+      .build();
+
+    // Invoke createTrustedProfileAssignment() with a valid options model and verify the result
+    Response<TemplateAssignmentResponse> response = iamIdentityService.createTrustedProfileAssignment(createTrustedProfileAssignmentOptionsModel).execute();
+    assertNotNull(response);
+    TemplateAssignmentResponse responseObj = response.getResult();
+    assertNotNull(responseObj);
+
+    // Verify the contents of the request sent to the mock server
+    RecordedRequest request = server.takeRequest();
+    assertNotNull(request);
+    assertEquals(request.getMethod(), "POST");
+    // Verify request path
+    String parsedPath = TestUtilities.parseReqPath(request);
+    assertEquals(parsedPath, createTrustedProfileAssignmentPath);
+    // Verify that there is no query string
+    Map<String, String> query = TestUtilities.parseQueryString(request);
+    assertNull(query);
+  }
+
+  // Test the createTrustedProfileAssignment operation with and without retries enabled
+  @Test
+  public void testCreateTrustedProfileAssignmentWRetries() throws Throwable {
+    iamIdentityService.enableRetries(4, 30);
+    testCreateTrustedProfileAssignmentWOptions();
+
+    iamIdentityService.disableRetries();
+    testCreateTrustedProfileAssignmentWOptions();
+  }
+
+  // Test the createTrustedProfileAssignment operation with a null options model (negative test)
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testCreateTrustedProfileAssignmentNoOptions() throws Throwable {
+    server.enqueue(new MockResponse());
+    iamIdentityService.createTrustedProfileAssignment(null).execute();
+  }
+
+  // Test the getTrustedProfileAssignment operation with a valid options model parameter
+  @Test
+  public void testGetTrustedProfileAssignmentWOptions() throws Throwable {
+    // Register a mock response
+    String mockResponseBody = "{\"context\": {\"transaction_id\": \"transactionId\", \"operation\": \"operation\", \"user_agent\": \"userAgent\", \"url\": \"url\", \"instance_id\": \"instanceId\", \"thread_id\": \"threadId\", \"host\": \"host\", \"start_time\": \"startTime\", \"end_time\": \"endTime\", \"elapsed_time\": \"elapsedTime\", \"cluster_name\": \"clusterName\"}, \"id\": \"id\", \"account_id\": \"accountId\", \"template_id\": \"templateId\", \"template_version\": 15, \"target_type\": \"targetType\", \"target\": \"target\", \"status\": \"status\", \"resources\": [{\"target\": \"target\", \"profile\": {\"id\": \"id\", \"version\": \"version\", \"resource_created\": {\"id\": \"id\"}, \"error_message\": {\"name\": \"name\", \"errorCode\": \"errorCode\", \"message\": \"message\", \"statusCode\": \"statusCode\"}, \"status\": \"status\"}, \"account_settings\": {\"id\": \"id\", \"version\": \"version\", \"resource_created\": {\"id\": \"id\"}, \"error_message\": {\"name\": \"name\", \"errorCode\": \"errorCode\", \"message\": \"message\", \"statusCode\": \"statusCode\"}, \"status\": \"status\"}, \"policy_template_refs\": [{\"id\": \"id\", \"version\": \"version\", \"resource_created\": {\"id\": \"id\"}, \"error_message\": {\"name\": \"name\", \"errorCode\": \"errorCode\", \"message\": \"message\", \"statusCode\": \"statusCode\"}, \"status\": \"status\"}]}], \"history\": [{\"timestamp\": \"timestamp\", \"iam_id\": \"iamId\", \"iam_id_account\": \"iamIdAccount\", \"action\": \"action\", \"params\": [\"params\"], \"message\": \"message\"}], \"href\": \"href\", \"created_at\": \"createdAt\", \"created_by_id\": \"createdById\", \"last_modified_at\": \"lastModifiedAt\", \"last_modified_by_id\": \"lastModifiedById\", \"entity_tag\": \"entityTag\"}";
+    String getTrustedProfileAssignmentPath = "/v1/profile_assignments/testString";
+    server.enqueue(new MockResponse()
+      .setHeader("Content-type", "application/json")
+      .setResponseCode(200)
+      .setBody(mockResponseBody));
+
+    // Construct an instance of the GetTrustedProfileAssignmentOptions model
+    GetTrustedProfileAssignmentOptions getTrustedProfileAssignmentOptionsModel = new GetTrustedProfileAssignmentOptions.Builder()
+      .assignmentId("testString")
+      .includeHistory(false)
+      .build();
+
+    // Invoke getTrustedProfileAssignment() with a valid options model and verify the result
+    Response<TemplateAssignmentResponse> response = iamIdentityService.getTrustedProfileAssignment(getTrustedProfileAssignmentOptionsModel).execute();
+    assertNotNull(response);
+    TemplateAssignmentResponse responseObj = response.getResult();
+    assertNotNull(responseObj);
+
+    // Verify the contents of the request sent to the mock server
+    RecordedRequest request = server.takeRequest();
+    assertNotNull(request);
+    assertEquals(request.getMethod(), "GET");
+    // Verify request path
+    String parsedPath = TestUtilities.parseReqPath(request);
+    assertEquals(parsedPath, getTrustedProfileAssignmentPath);
+    // Verify query params
+    Map<String, String> query = TestUtilities.parseQueryString(request);
+    assertNotNull(query);
+    assertEquals(Boolean.valueOf(query.get("include_history")), Boolean.valueOf(false));
+  }
+
+  // Test the getTrustedProfileAssignment operation with and without retries enabled
+  @Test
+  public void testGetTrustedProfileAssignmentWRetries() throws Throwable {
+    iamIdentityService.enableRetries(4, 30);
+    testGetTrustedProfileAssignmentWOptions();
+
+    iamIdentityService.disableRetries();
+    testGetTrustedProfileAssignmentWOptions();
+  }
+
+  // Test the getTrustedProfileAssignment operation with a null options model (negative test)
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testGetTrustedProfileAssignmentNoOptions() throws Throwable {
+    server.enqueue(new MockResponse());
+    iamIdentityService.getTrustedProfileAssignment(null).execute();
+  }
+
+  // Test the deleteTrustedProfileAssignment operation with a valid options model parameter
+  @Test
+  public void testDeleteTrustedProfileAssignmentWOptions() throws Throwable {
+    // Register a mock response
+    String mockResponseBody = "{\"context\": {\"transaction_id\": \"transactionId\", \"operation\": \"operation\", \"user_agent\": \"userAgent\", \"url\": \"url\", \"instance_id\": \"instanceId\", \"thread_id\": \"threadId\", \"host\": \"host\", \"start_time\": \"startTime\", \"end_time\": \"endTime\", \"elapsed_time\": \"elapsedTime\", \"cluster_name\": \"clusterName\"}, \"status_code\": \"statusCode\", \"errors\": [{\"code\": \"code\", \"message_code\": \"messageCode\", \"message\": \"message\", \"details\": \"details\"}], \"trace\": \"trace\"}";
+    String deleteTrustedProfileAssignmentPath = "/v1/profile_assignments/testString";
+    server.enqueue(new MockResponse()
+      .setHeader("Content-type", "application/json")
+      .setResponseCode(202)
+      .setBody(mockResponseBody));
+
+    // Construct an instance of the DeleteTrustedProfileAssignmentOptions model
+    DeleteTrustedProfileAssignmentOptions deleteTrustedProfileAssignmentOptionsModel = new DeleteTrustedProfileAssignmentOptions.Builder()
+      .assignmentId("testString")
+      .build();
+
+    // Invoke deleteTrustedProfileAssignment() with a valid options model and verify the result
+    Response<ExceptionResponse> response = iamIdentityService.deleteTrustedProfileAssignment(deleteTrustedProfileAssignmentOptionsModel).execute();
+    assertNotNull(response);
+    ExceptionResponse responseObj = response.getResult();
+    assertNotNull(responseObj);
+
+    // Verify the contents of the request sent to the mock server
+    RecordedRequest request = server.takeRequest();
+    assertNotNull(request);
+    assertEquals(request.getMethod(), "DELETE");
+    // Verify request path
+    String parsedPath = TestUtilities.parseReqPath(request);
+    assertEquals(parsedPath, deleteTrustedProfileAssignmentPath);
+    // Verify that there is no query string
+    Map<String, String> query = TestUtilities.parseQueryString(request);
+    assertNull(query);
+  }
+
+  // Test the deleteTrustedProfileAssignment operation with and without retries enabled
+  @Test
+  public void testDeleteTrustedProfileAssignmentWRetries() throws Throwable {
+    iamIdentityService.enableRetries(4, 30);
+    testDeleteTrustedProfileAssignmentWOptions();
+
+    iamIdentityService.disableRetries();
+    testDeleteTrustedProfileAssignmentWOptions();
+  }
+
+  // Test the deleteTrustedProfileAssignment operation with a null options model (negative test)
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testDeleteTrustedProfileAssignmentNoOptions() throws Throwable {
+    server.enqueue(new MockResponse());
+    iamIdentityService.deleteTrustedProfileAssignment(null).execute();
+  }
+
+  // Test the updateTrustedProfileAssignment operation with a valid options model parameter
+  @Test
+  public void testUpdateTrustedProfileAssignmentWOptions() throws Throwable {
+    // Register a mock response
+    String mockResponseBody = "{\"context\": {\"transaction_id\": \"transactionId\", \"operation\": \"operation\", \"user_agent\": \"userAgent\", \"url\": \"url\", \"instance_id\": \"instanceId\", \"thread_id\": \"threadId\", \"host\": \"host\", \"start_time\": \"startTime\", \"end_time\": \"endTime\", \"elapsed_time\": \"elapsedTime\", \"cluster_name\": \"clusterName\"}, \"id\": \"id\", \"account_id\": \"accountId\", \"template_id\": \"templateId\", \"template_version\": 15, \"target_type\": \"targetType\", \"target\": \"target\", \"status\": \"status\", \"resources\": [{\"target\": \"target\", \"profile\": {\"id\": \"id\", \"version\": \"version\", \"resource_created\": {\"id\": \"id\"}, \"error_message\": {\"name\": \"name\", \"errorCode\": \"errorCode\", \"message\": \"message\", \"statusCode\": \"statusCode\"}, \"status\": \"status\"}, \"account_settings\": {\"id\": \"id\", \"version\": \"version\", \"resource_created\": {\"id\": \"id\"}, \"error_message\": {\"name\": \"name\", \"errorCode\": \"errorCode\", \"message\": \"message\", \"statusCode\": \"statusCode\"}, \"status\": \"status\"}, \"policy_template_refs\": [{\"id\": \"id\", \"version\": \"version\", \"resource_created\": {\"id\": \"id\"}, \"error_message\": {\"name\": \"name\", \"errorCode\": \"errorCode\", \"message\": \"message\", \"statusCode\": \"statusCode\"}, \"status\": \"status\"}]}], \"history\": [{\"timestamp\": \"timestamp\", \"iam_id\": \"iamId\", \"iam_id_account\": \"iamIdAccount\", \"action\": \"action\", \"params\": [\"params\"], \"message\": \"message\"}], \"href\": \"href\", \"created_at\": \"createdAt\", \"created_by_id\": \"createdById\", \"last_modified_at\": \"lastModifiedAt\", \"last_modified_by_id\": \"lastModifiedById\", \"entity_tag\": \"entityTag\"}";
+    String updateTrustedProfileAssignmentPath = "/v1/profile_assignments/testString";
+    server.enqueue(new MockResponse()
+      .setHeader("Content-type", "application/json")
+      .setResponseCode(200)
+      .setBody(mockResponseBody));
+
+    // Construct an instance of the UpdateTrustedProfileAssignmentOptions model
+    UpdateTrustedProfileAssignmentOptions updateTrustedProfileAssignmentOptionsModel = new UpdateTrustedProfileAssignmentOptions.Builder()
+      .assignmentId("testString")
+      .ifMatch("testString")
+      .templateVersion(Long.valueOf("1"))
+      .build();
+
+    // Invoke updateTrustedProfileAssignment() with a valid options model and verify the result
+    Response<TemplateAssignmentResponse> response = iamIdentityService.updateTrustedProfileAssignment(updateTrustedProfileAssignmentOptionsModel).execute();
+    assertNotNull(response);
+    TemplateAssignmentResponse responseObj = response.getResult();
+    assertNotNull(responseObj);
+
+    // Verify the contents of the request sent to the mock server
+    RecordedRequest request = server.takeRequest();
+    assertNotNull(request);
+    assertEquals(request.getMethod(), "PATCH");
+    // Verify request path
+    String parsedPath = TestUtilities.parseReqPath(request);
+    assertEquals(parsedPath, updateTrustedProfileAssignmentPath);
+    // Verify header parameters
+    assertEquals(request.getHeader("If-Match"), "testString");
+    // Verify that there is no query string
+    Map<String, String> query = TestUtilities.parseQueryString(request);
+    assertNull(query);
+  }
+
+  // Test the updateTrustedProfileAssignment operation with and without retries enabled
+  @Test
+  public void testUpdateTrustedProfileAssignmentWRetries() throws Throwable {
+    iamIdentityService.enableRetries(4, 30);
+    testUpdateTrustedProfileAssignmentWOptions();
+
+    iamIdentityService.disableRetries();
+    testUpdateTrustedProfileAssignmentWOptions();
+  }
+
+  // Test the updateTrustedProfileAssignment operation with a null options model (negative test)
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testUpdateTrustedProfileAssignmentNoOptions() throws Throwable {
+    server.enqueue(new MockResponse());
+    iamIdentityService.updateTrustedProfileAssignment(null).execute();
+  }
+
+  // Test the listProfileTemplates operation with a valid options model parameter
+  @Test
+  public void testListProfileTemplatesWOptions() throws Throwable {
+    // Register a mock response
+    String mockResponseBody = "{\"context\": {\"transaction_id\": \"transactionId\", \"operation\": \"operation\", \"user_agent\": \"userAgent\", \"url\": \"url\", \"instance_id\": \"instanceId\", \"thread_id\": \"threadId\", \"host\": \"host\", \"start_time\": \"startTime\", \"end_time\": \"endTime\", \"elapsed_time\": \"elapsedTime\", \"cluster_name\": \"clusterName\"}, \"offset\": 6, \"limit\": 20, \"first\": \"first\", \"previous\": \"previous\", \"next\": \"next\", \"profile_templates\": [{\"id\": \"id\", \"version\": 7, \"account_id\": \"accountId\", \"name\": \"name\", \"description\": \"description\", \"committed\": false, \"profile\": {\"name\": \"name\", \"description\": \"description\", \"rules\": [{\"name\": \"name\", \"type\": \"Profile-SAML\", \"realm_name\": \"realmName\", \"expiration\": 10, \"conditions\": [{\"claim\": \"claim\", \"operator\": \"operator\", \"value\": \"value\"}]}], \"identities\": [{\"iam_id\": \"iamId\", \"identifier\": \"identifier\", \"type\": \"user\", \"accounts\": [\"accounts\"], \"description\": \"description\"}]}, \"policy_template_references\": [{\"id\": \"id\", \"version\": \"version\"}], \"history\": [{\"timestamp\": \"timestamp\", \"iam_id\": \"iamId\", \"iam_id_account\": \"iamIdAccount\", \"action\": \"action\", \"params\": [\"params\"], \"message\": \"message\"}], \"entity_tag\": \"entityTag\", \"crn\": \"crn\", \"created_at\": \"createdAt\", \"created_by_id\": \"createdById\", \"last_modified_at\": \"lastModifiedAt\", \"last_modified_by_id\": \"lastModifiedById\"}]}";
+    String listProfileTemplatesPath = "/v1/profile_templates";
+    server.enqueue(new MockResponse()
+      .setHeader("Content-type", "application/json")
+      .setResponseCode(200)
+      .setBody(mockResponseBody));
+
+    // Construct an instance of the ListProfileTemplatesOptions model
+    ListProfileTemplatesOptions listProfileTemplatesOptionsModel = new ListProfileTemplatesOptions.Builder()
+      .accountId("testString")
+      .limit("20")
+      .pagetoken("testString")
+      .sort("created_at")
+      .order("asc")
+      .includeHistory("false")
+      .build();
+
+    // Invoke listProfileTemplates() with a valid options model and verify the result
+    Response<TrustedProfileTemplateList> response = iamIdentityService.listProfileTemplates(listProfileTemplatesOptionsModel).execute();
+    assertNotNull(response);
+    TrustedProfileTemplateList responseObj = response.getResult();
+    assertNotNull(responseObj);
+
+    // Verify the contents of the request sent to the mock server
+    RecordedRequest request = server.takeRequest();
+    assertNotNull(request);
+    assertEquals(request.getMethod(), "GET");
+    // Verify request path
+    String parsedPath = TestUtilities.parseReqPath(request);
+    assertEquals(parsedPath, listProfileTemplatesPath);
+    // Verify query params
+    Map<String, String> query = TestUtilities.parseQueryString(request);
+    assertNotNull(query);
+    assertEquals(query.get("account_id"), "testString");
+    assertEquals(query.get("limit"), "20");
+    assertEquals(query.get("pagetoken"), "testString");
+    assertEquals(query.get("sort"), "created_at");
+    assertEquals(query.get("order"), "asc");
+    assertEquals(query.get("include_history"), "false");
+  }
+
+  // Test the listProfileTemplates operation with and without retries enabled
+  @Test
+  public void testListProfileTemplatesWRetries() throws Throwable {
+    iamIdentityService.enableRetries(4, 30);
+    testListProfileTemplatesWOptions();
+
+    iamIdentityService.disableRetries();
+    testListProfileTemplatesWOptions();
+  }
+
+  // Test the createProfileTemplate operation with a valid options model parameter
+  @Test
+  public void testCreateProfileTemplateWOptions() throws Throwable {
+    // Register a mock response
+    String mockResponseBody = "{\"id\": \"id\", \"version\": 7, \"account_id\": \"accountId\", \"name\": \"name\", \"description\": \"description\", \"committed\": false, \"profile\": {\"name\": \"name\", \"description\": \"description\", \"rules\": [{\"name\": \"name\", \"type\": \"Profile-SAML\", \"realm_name\": \"realmName\", \"expiration\": 10, \"conditions\": [{\"claim\": \"claim\", \"operator\": \"operator\", \"value\": \"value\"}]}], \"identities\": [{\"iam_id\": \"iamId\", \"identifier\": \"identifier\", \"type\": \"user\", \"accounts\": [\"accounts\"], \"description\": \"description\"}]}, \"policy_template_references\": [{\"id\": \"id\", \"version\": \"version\"}], \"history\": [{\"timestamp\": \"timestamp\", \"iam_id\": \"iamId\", \"iam_id_account\": \"iamIdAccount\", \"action\": \"action\", \"params\": [\"params\"], \"message\": \"message\"}], \"entity_tag\": \"entityTag\", \"crn\": \"crn\", \"created_at\": \"createdAt\", \"created_by_id\": \"createdById\", \"last_modified_at\": \"lastModifiedAt\", \"last_modified_by_id\": \"lastModifiedById\"}";
+    String createProfileTemplatePath = "/v1/profile_templates";
+    server.enqueue(new MockResponse()
+      .setHeader("Content-type", "application/json")
+      .setResponseCode(201)
+      .setBody(mockResponseBody));
+
+    // Construct an instance of the ProfileClaimRuleConditions model
+    ProfileClaimRuleConditions profileClaimRuleConditionsModel = new ProfileClaimRuleConditions.Builder()
+      .claim("testString")
+      .operator("testString")
+      .value("testString")
+      .build();
+
+    // Construct an instance of the TrustedProfileTemplateClaimRule model
+    TrustedProfileTemplateClaimRule trustedProfileTemplateClaimRuleModel = new TrustedProfileTemplateClaimRule.Builder()
+      .name("testString")
+      .type("Profile-SAML")
+      .realmName("testString")
+      .expiration(Long.valueOf("26"))
+      .conditions(java.util.Arrays.asList(profileClaimRuleConditionsModel))
+      .build();
+
+    // Construct an instance of the ProfileIdentityRequest model
+    ProfileIdentityRequest profileIdentityRequestModel = new ProfileIdentityRequest.Builder()
+      .identifier("testString")
+      .type("user")
+      .accounts(java.util.Arrays.asList("testString"))
+      .description("testString")
+      .build();
+
+    // Construct an instance of the TemplateProfileComponentRequest model
+    TemplateProfileComponentRequest templateProfileComponentRequestModel = new TemplateProfileComponentRequest.Builder()
+      .name("testString")
+      .description("testString")
+      .rules(java.util.Arrays.asList(trustedProfileTemplateClaimRuleModel))
+      .identities(java.util.Arrays.asList(profileIdentityRequestModel))
+      .build();
+
+    // Construct an instance of the PolicyTemplateReference model
+    PolicyTemplateReference policyTemplateReferenceModel = new PolicyTemplateReference.Builder()
+      .id("testString")
+      .version("testString")
+      .build();
+
+    // Construct an instance of the CreateProfileTemplateOptions model
+    CreateProfileTemplateOptions createProfileTemplateOptionsModel = new CreateProfileTemplateOptions.Builder()
+      .accountId("testString")
+      .name("testString")
+      .description("testString")
+      .profile(templateProfileComponentRequestModel)
+      .policyTemplateReferences(java.util.Arrays.asList(policyTemplateReferenceModel))
+      .build();
+
+    // Invoke createProfileTemplate() with a valid options model and verify the result
+    Response<TrustedProfileTemplateResponse> response = iamIdentityService.createProfileTemplate(createProfileTemplateOptionsModel).execute();
+    assertNotNull(response);
+    TrustedProfileTemplateResponse responseObj = response.getResult();
+    assertNotNull(responseObj);
+
+    // Verify the contents of the request sent to the mock server
+    RecordedRequest request = server.takeRequest();
+    assertNotNull(request);
+    assertEquals(request.getMethod(), "POST");
+    // Verify request path
+    String parsedPath = TestUtilities.parseReqPath(request);
+    assertEquals(parsedPath, createProfileTemplatePath);
+    // Verify that there is no query string
+    Map<String, String> query = TestUtilities.parseQueryString(request);
+    assertNull(query);
+  }
+
+  // Test the createProfileTemplate operation with and without retries enabled
+  @Test
+  public void testCreateProfileTemplateWRetries() throws Throwable {
+    iamIdentityService.enableRetries(4, 30);
+    testCreateProfileTemplateWOptions();
+
+    iamIdentityService.disableRetries();
+    testCreateProfileTemplateWOptions();
+  }
+
+  // Test the getLatestProfileTemplateVersion operation with a valid options model parameter
+  @Test
+  public void testGetLatestProfileTemplateVersionWOptions() throws Throwable {
+    // Register a mock response
+    String mockResponseBody = "{\"id\": \"id\", \"version\": 7, \"account_id\": \"accountId\", \"name\": \"name\", \"description\": \"description\", \"committed\": false, \"profile\": {\"name\": \"name\", \"description\": \"description\", \"rules\": [{\"name\": \"name\", \"type\": \"Profile-SAML\", \"realm_name\": \"realmName\", \"expiration\": 10, \"conditions\": [{\"claim\": \"claim\", \"operator\": \"operator\", \"value\": \"value\"}]}], \"identities\": [{\"iam_id\": \"iamId\", \"identifier\": \"identifier\", \"type\": \"user\", \"accounts\": [\"accounts\"], \"description\": \"description\"}]}, \"policy_template_references\": [{\"id\": \"id\", \"version\": \"version\"}], \"history\": [{\"timestamp\": \"timestamp\", \"iam_id\": \"iamId\", \"iam_id_account\": \"iamIdAccount\", \"action\": \"action\", \"params\": [\"params\"], \"message\": \"message\"}], \"entity_tag\": \"entityTag\", \"crn\": \"crn\", \"created_at\": \"createdAt\", \"created_by_id\": \"createdById\", \"last_modified_at\": \"lastModifiedAt\", \"last_modified_by_id\": \"lastModifiedById\"}";
+    String getLatestProfileTemplateVersionPath = "/v1/profile_templates/testString";
+    server.enqueue(new MockResponse()
+      .setHeader("Content-type", "application/json")
+      .setResponseCode(200)
+      .setBody(mockResponseBody));
+
+    // Construct an instance of the GetLatestProfileTemplateVersionOptions model
+    GetLatestProfileTemplateVersionOptions getLatestProfileTemplateVersionOptionsModel = new GetLatestProfileTemplateVersionOptions.Builder()
+      .templateId("testString")
+      .includeHistory(false)
+      .build();
+
+    // Invoke getLatestProfileTemplateVersion() with a valid options model and verify the result
+    Response<TrustedProfileTemplateResponse> response = iamIdentityService.getLatestProfileTemplateVersion(getLatestProfileTemplateVersionOptionsModel).execute();
+    assertNotNull(response);
+    TrustedProfileTemplateResponse responseObj = response.getResult();
+    assertNotNull(responseObj);
+
+    // Verify the contents of the request sent to the mock server
+    RecordedRequest request = server.takeRequest();
+    assertNotNull(request);
+    assertEquals(request.getMethod(), "GET");
+    // Verify request path
+    String parsedPath = TestUtilities.parseReqPath(request);
+    assertEquals(parsedPath, getLatestProfileTemplateVersionPath);
+    // Verify query params
+    Map<String, String> query = TestUtilities.parseQueryString(request);
+    assertNotNull(query);
+    assertEquals(Boolean.valueOf(query.get("include_history")), Boolean.valueOf(false));
+  }
+
+  // Test the getLatestProfileTemplateVersion operation with and without retries enabled
+  @Test
+  public void testGetLatestProfileTemplateVersionWRetries() throws Throwable {
+    iamIdentityService.enableRetries(4, 30);
+    testGetLatestProfileTemplateVersionWOptions();
+
+    iamIdentityService.disableRetries();
+    testGetLatestProfileTemplateVersionWOptions();
+  }
+
+  // Test the getLatestProfileTemplateVersion operation with a null options model (negative test)
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testGetLatestProfileTemplateVersionNoOptions() throws Throwable {
+    server.enqueue(new MockResponse());
+    iamIdentityService.getLatestProfileTemplateVersion(null).execute();
+  }
+
+  // Test the deleteAllVersionsOfProfileTemplate operation with a valid options model parameter
+  @Test
+  public void testDeleteAllVersionsOfProfileTemplateWOptions() throws Throwable {
+    // Register a mock response
+    String mockResponseBody = "";
+    String deleteAllVersionsOfProfileTemplatePath = "/v1/profile_templates/testString";
+    server.enqueue(new MockResponse()
+      .setResponseCode(204)
+      .setBody(mockResponseBody));
+
+    // Construct an instance of the DeleteAllVersionsOfProfileTemplateOptions model
+    DeleteAllVersionsOfProfileTemplateOptions deleteAllVersionsOfProfileTemplateOptionsModel = new DeleteAllVersionsOfProfileTemplateOptions.Builder()
+      .templateId("testString")
+      .build();
+
+    // Invoke deleteAllVersionsOfProfileTemplate() with a valid options model and verify the result
+    Response<Void> response = iamIdentityService.deleteAllVersionsOfProfileTemplate(deleteAllVersionsOfProfileTemplateOptionsModel).execute();
+    assertNotNull(response);
+    Void responseObj = response.getResult();
+    assertNull(responseObj);
+
+    // Verify the contents of the request sent to the mock server
+    RecordedRequest request = server.takeRequest();
+    assertNotNull(request);
+    assertEquals(request.getMethod(), "DELETE");
+    // Verify request path
+    String parsedPath = TestUtilities.parseReqPath(request);
+    assertEquals(parsedPath, deleteAllVersionsOfProfileTemplatePath);
+    // Verify that there is no query string
+    Map<String, String> query = TestUtilities.parseQueryString(request);
+    assertNull(query);
+  }
+
+  // Test the deleteAllVersionsOfProfileTemplate operation with and without retries enabled
+  @Test
+  public void testDeleteAllVersionsOfProfileTemplateWRetries() throws Throwable {
+    iamIdentityService.enableRetries(4, 30);
+    testDeleteAllVersionsOfProfileTemplateWOptions();
+
+    iamIdentityService.disableRetries();
+    testDeleteAllVersionsOfProfileTemplateWOptions();
+  }
+
+  // Test the deleteAllVersionsOfProfileTemplate operation with a null options model (negative test)
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testDeleteAllVersionsOfProfileTemplateNoOptions() throws Throwable {
+    server.enqueue(new MockResponse());
+    iamIdentityService.deleteAllVersionsOfProfileTemplate(null).execute();
+  }
+
+  // Test the listVersionsOfProfileTemplate operation with a valid options model parameter
+  @Test
+  public void testListVersionsOfProfileTemplateWOptions() throws Throwable {
+    // Register a mock response
+    String mockResponseBody = "{\"context\": {\"transaction_id\": \"transactionId\", \"operation\": \"operation\", \"user_agent\": \"userAgent\", \"url\": \"url\", \"instance_id\": \"instanceId\", \"thread_id\": \"threadId\", \"host\": \"host\", \"start_time\": \"startTime\", \"end_time\": \"endTime\", \"elapsed_time\": \"elapsedTime\", \"cluster_name\": \"clusterName\"}, \"offset\": 6, \"limit\": 20, \"first\": \"first\", \"previous\": \"previous\", \"next\": \"next\", \"profile_templates\": [{\"id\": \"id\", \"version\": 7, \"account_id\": \"accountId\", \"name\": \"name\", \"description\": \"description\", \"committed\": false, \"profile\": {\"name\": \"name\", \"description\": \"description\", \"rules\": [{\"name\": \"name\", \"type\": \"Profile-SAML\", \"realm_name\": \"realmName\", \"expiration\": 10, \"conditions\": [{\"claim\": \"claim\", \"operator\": \"operator\", \"value\": \"value\"}]}], \"identities\": [{\"iam_id\": \"iamId\", \"identifier\": \"identifier\", \"type\": \"user\", \"accounts\": [\"accounts\"], \"description\": \"description\"}]}, \"policy_template_references\": [{\"id\": \"id\", \"version\": \"version\"}], \"history\": [{\"timestamp\": \"timestamp\", \"iam_id\": \"iamId\", \"iam_id_account\": \"iamIdAccount\", \"action\": \"action\", \"params\": [\"params\"], \"message\": \"message\"}], \"entity_tag\": \"entityTag\", \"crn\": \"crn\", \"created_at\": \"createdAt\", \"created_by_id\": \"createdById\", \"last_modified_at\": \"lastModifiedAt\", \"last_modified_by_id\": \"lastModifiedById\"}]}";
+    String listVersionsOfProfileTemplatePath = "/v1/profile_templates/testString/versions";
+    server.enqueue(new MockResponse()
+      .setHeader("Content-type", "application/json")
+      .setResponseCode(200)
+      .setBody(mockResponseBody));
+
+    // Construct an instance of the ListVersionsOfProfileTemplateOptions model
+    ListVersionsOfProfileTemplateOptions listVersionsOfProfileTemplateOptionsModel = new ListVersionsOfProfileTemplateOptions.Builder()
+      .templateId("testString")
+      .limit("20")
+      .pagetoken("testString")
+      .sort("created_at")
+      .order("asc")
+      .includeHistory("false")
+      .build();
+
+    // Invoke listVersionsOfProfileTemplate() with a valid options model and verify the result
+    Response<TrustedProfileTemplateList> response = iamIdentityService.listVersionsOfProfileTemplate(listVersionsOfProfileTemplateOptionsModel).execute();
+    assertNotNull(response);
+    TrustedProfileTemplateList responseObj = response.getResult();
+    assertNotNull(responseObj);
+
+    // Verify the contents of the request sent to the mock server
+    RecordedRequest request = server.takeRequest();
+    assertNotNull(request);
+    assertEquals(request.getMethod(), "GET");
+    // Verify request path
+    String parsedPath = TestUtilities.parseReqPath(request);
+    assertEquals(parsedPath, listVersionsOfProfileTemplatePath);
+    // Verify query params
+    Map<String, String> query = TestUtilities.parseQueryString(request);
+    assertNotNull(query);
+    assertEquals(query.get("limit"), "20");
+    assertEquals(query.get("pagetoken"), "testString");
+    assertEquals(query.get("sort"), "created_at");
+    assertEquals(query.get("order"), "asc");
+    assertEquals(query.get("include_history"), "false");
+  }
+
+  // Test the listVersionsOfProfileTemplate operation with and without retries enabled
+  @Test
+  public void testListVersionsOfProfileTemplateWRetries() throws Throwable {
+    iamIdentityService.enableRetries(4, 30);
+    testListVersionsOfProfileTemplateWOptions();
+
+    iamIdentityService.disableRetries();
+    testListVersionsOfProfileTemplateWOptions();
+  }
+
+  // Test the listVersionsOfProfileTemplate operation with a null options model (negative test)
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testListVersionsOfProfileTemplateNoOptions() throws Throwable {
+    server.enqueue(new MockResponse());
+    iamIdentityService.listVersionsOfProfileTemplate(null).execute();
+  }
+
+  // Test the createProfileTemplateVersion operation with a valid options model parameter
+  @Test
+  public void testCreateProfileTemplateVersionWOptions() throws Throwable {
+    // Register a mock response
+    String mockResponseBody = "{\"id\": \"id\", \"version\": 7, \"account_id\": \"accountId\", \"name\": \"name\", \"description\": \"description\", \"committed\": false, \"profile\": {\"name\": \"name\", \"description\": \"description\", \"rules\": [{\"name\": \"name\", \"type\": \"Profile-SAML\", \"realm_name\": \"realmName\", \"expiration\": 10, \"conditions\": [{\"claim\": \"claim\", \"operator\": \"operator\", \"value\": \"value\"}]}], \"identities\": [{\"iam_id\": \"iamId\", \"identifier\": \"identifier\", \"type\": \"user\", \"accounts\": [\"accounts\"], \"description\": \"description\"}]}, \"policy_template_references\": [{\"id\": \"id\", \"version\": \"version\"}], \"history\": [{\"timestamp\": \"timestamp\", \"iam_id\": \"iamId\", \"iam_id_account\": \"iamIdAccount\", \"action\": \"action\", \"params\": [\"params\"], \"message\": \"message\"}], \"entity_tag\": \"entityTag\", \"crn\": \"crn\", \"created_at\": \"createdAt\", \"created_by_id\": \"createdById\", \"last_modified_at\": \"lastModifiedAt\", \"last_modified_by_id\": \"lastModifiedById\"}";
+    String createProfileTemplateVersionPath = "/v1/profile_templates/testString/versions";
+    server.enqueue(new MockResponse()
+      .setHeader("Content-type", "application/json")
+      .setResponseCode(201)
+      .setBody(mockResponseBody));
+
+    // Construct an instance of the ProfileClaimRuleConditions model
+    ProfileClaimRuleConditions profileClaimRuleConditionsModel = new ProfileClaimRuleConditions.Builder()
+      .claim("testString")
+      .operator("testString")
+      .value("testString")
+      .build();
+
+    // Construct an instance of the TrustedProfileTemplateClaimRule model
+    TrustedProfileTemplateClaimRule trustedProfileTemplateClaimRuleModel = new TrustedProfileTemplateClaimRule.Builder()
+      .name("testString")
+      .type("Profile-SAML")
+      .realmName("testString")
+      .expiration(Long.valueOf("26"))
+      .conditions(java.util.Arrays.asList(profileClaimRuleConditionsModel))
+      .build();
+
+    // Construct an instance of the ProfileIdentityRequest model
+    ProfileIdentityRequest profileIdentityRequestModel = new ProfileIdentityRequest.Builder()
+      .identifier("testString")
+      .type("user")
+      .accounts(java.util.Arrays.asList("testString"))
+      .description("testString")
+      .build();
+
+    // Construct an instance of the TemplateProfileComponentRequest model
+    TemplateProfileComponentRequest templateProfileComponentRequestModel = new TemplateProfileComponentRequest.Builder()
+      .name("testString")
+      .description("testString")
+      .rules(java.util.Arrays.asList(trustedProfileTemplateClaimRuleModel))
+      .identities(java.util.Arrays.asList(profileIdentityRequestModel))
+      .build();
+
+    // Construct an instance of the PolicyTemplateReference model
+    PolicyTemplateReference policyTemplateReferenceModel = new PolicyTemplateReference.Builder()
+      .id("testString")
+      .version("testString")
+      .build();
+
+    // Construct an instance of the CreateProfileTemplateVersionOptions model
+    CreateProfileTemplateVersionOptions createProfileTemplateVersionOptionsModel = new CreateProfileTemplateVersionOptions.Builder()
+      .templateId("testString")
+      .accountId("testString")
+      .name("testString")
+      .description("testString")
+      .profile(templateProfileComponentRequestModel)
+      .policyTemplateReferences(java.util.Arrays.asList(policyTemplateReferenceModel))
+      .build();
+
+    // Invoke createProfileTemplateVersion() with a valid options model and verify the result
+    Response<TrustedProfileTemplateResponse> response = iamIdentityService.createProfileTemplateVersion(createProfileTemplateVersionOptionsModel).execute();
+    assertNotNull(response);
+    TrustedProfileTemplateResponse responseObj = response.getResult();
+    assertNotNull(responseObj);
+
+    // Verify the contents of the request sent to the mock server
+    RecordedRequest request = server.takeRequest();
+    assertNotNull(request);
+    assertEquals(request.getMethod(), "POST");
+    // Verify request path
+    String parsedPath = TestUtilities.parseReqPath(request);
+    assertEquals(parsedPath, createProfileTemplateVersionPath);
+    // Verify that there is no query string
+    Map<String, String> query = TestUtilities.parseQueryString(request);
+    assertNull(query);
+  }
+
+  // Test the createProfileTemplateVersion operation with and without retries enabled
+  @Test
+  public void testCreateProfileTemplateVersionWRetries() throws Throwable {
+    iamIdentityService.enableRetries(4, 30);
+    testCreateProfileTemplateVersionWOptions();
+
+    iamIdentityService.disableRetries();
+    testCreateProfileTemplateVersionWOptions();
+  }
+
+  // Test the createProfileTemplateVersion operation with a null options model (negative test)
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testCreateProfileTemplateVersionNoOptions() throws Throwable {
+    server.enqueue(new MockResponse());
+    iamIdentityService.createProfileTemplateVersion(null).execute();
+  }
+
+  // Test the getProfileTemplateVersion operation with a valid options model parameter
+  @Test
+  public void testGetProfileTemplateVersionWOptions() throws Throwable {
+    // Register a mock response
+    String mockResponseBody = "{\"id\": \"id\", \"version\": 7, \"account_id\": \"accountId\", \"name\": \"name\", \"description\": \"description\", \"committed\": false, \"profile\": {\"name\": \"name\", \"description\": \"description\", \"rules\": [{\"name\": \"name\", \"type\": \"Profile-SAML\", \"realm_name\": \"realmName\", \"expiration\": 10, \"conditions\": [{\"claim\": \"claim\", \"operator\": \"operator\", \"value\": \"value\"}]}], \"identities\": [{\"iam_id\": \"iamId\", \"identifier\": \"identifier\", \"type\": \"user\", \"accounts\": [\"accounts\"], \"description\": \"description\"}]}, \"policy_template_references\": [{\"id\": \"id\", \"version\": \"version\"}], \"history\": [{\"timestamp\": \"timestamp\", \"iam_id\": \"iamId\", \"iam_id_account\": \"iamIdAccount\", \"action\": \"action\", \"params\": [\"params\"], \"message\": \"message\"}], \"entity_tag\": \"entityTag\", \"crn\": \"crn\", \"created_at\": \"createdAt\", \"created_by_id\": \"createdById\", \"last_modified_at\": \"lastModifiedAt\", \"last_modified_by_id\": \"lastModifiedById\"}";
+    String getProfileTemplateVersionPath = "/v1/profile_templates/testString/versions/testString";
+    server.enqueue(new MockResponse()
+      .setHeader("Content-type", "application/json")
+      .setResponseCode(200)
+      .setBody(mockResponseBody));
+
+    // Construct an instance of the GetProfileTemplateVersionOptions model
+    GetProfileTemplateVersionOptions getProfileTemplateVersionOptionsModel = new GetProfileTemplateVersionOptions.Builder()
+      .templateId("testString")
+      .version("testString")
+      .includeHistory(false)
+      .build();
+
+    // Invoke getProfileTemplateVersion() with a valid options model and verify the result
+    Response<TrustedProfileTemplateResponse> response = iamIdentityService.getProfileTemplateVersion(getProfileTemplateVersionOptionsModel).execute();
+    assertNotNull(response);
+    TrustedProfileTemplateResponse responseObj = response.getResult();
+    assertNotNull(responseObj);
+
+    // Verify the contents of the request sent to the mock server
+    RecordedRequest request = server.takeRequest();
+    assertNotNull(request);
+    assertEquals(request.getMethod(), "GET");
+    // Verify request path
+    String parsedPath = TestUtilities.parseReqPath(request);
+    assertEquals(parsedPath, getProfileTemplateVersionPath);
+    // Verify query params
+    Map<String, String> query = TestUtilities.parseQueryString(request);
+    assertNotNull(query);
+    assertEquals(Boolean.valueOf(query.get("include_history")), Boolean.valueOf(false));
+  }
+
+  // Test the getProfileTemplateVersion operation with and without retries enabled
+  @Test
+  public void testGetProfileTemplateVersionWRetries() throws Throwable {
+    iamIdentityService.enableRetries(4, 30);
+    testGetProfileTemplateVersionWOptions();
+
+    iamIdentityService.disableRetries();
+    testGetProfileTemplateVersionWOptions();
+  }
+
+  // Test the getProfileTemplateVersion operation with a null options model (negative test)
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testGetProfileTemplateVersionNoOptions() throws Throwable {
+    server.enqueue(new MockResponse());
+    iamIdentityService.getProfileTemplateVersion(null).execute();
+  }
+
+  // Test the updateProfileTemplateVersion operation with a valid options model parameter
+  @Test
+  public void testUpdateProfileTemplateVersionWOptions() throws Throwable {
+    // Register a mock response
+    String mockResponseBody = "{\"id\": \"id\", \"version\": 7, \"account_id\": \"accountId\", \"name\": \"name\", \"description\": \"description\", \"committed\": false, \"profile\": {\"name\": \"name\", \"description\": \"description\", \"rules\": [{\"name\": \"name\", \"type\": \"Profile-SAML\", \"realm_name\": \"realmName\", \"expiration\": 10, \"conditions\": [{\"claim\": \"claim\", \"operator\": \"operator\", \"value\": \"value\"}]}], \"identities\": [{\"iam_id\": \"iamId\", \"identifier\": \"identifier\", \"type\": \"user\", \"accounts\": [\"accounts\"], \"description\": \"description\"}]}, \"policy_template_references\": [{\"id\": \"id\", \"version\": \"version\"}], \"history\": [{\"timestamp\": \"timestamp\", \"iam_id\": \"iamId\", \"iam_id_account\": \"iamIdAccount\", \"action\": \"action\", \"params\": [\"params\"], \"message\": \"message\"}], \"entity_tag\": \"entityTag\", \"crn\": \"crn\", \"created_at\": \"createdAt\", \"created_by_id\": \"createdById\", \"last_modified_at\": \"lastModifiedAt\", \"last_modified_by_id\": \"lastModifiedById\"}";
+    String updateProfileTemplateVersionPath = "/v1/profile_templates/testString/versions/testString";
+    server.enqueue(new MockResponse()
+      .setHeader("Content-type", "application/json")
+      .setResponseCode(200)
+      .setBody(mockResponseBody));
+
+    // Construct an instance of the ProfileClaimRuleConditions model
+    ProfileClaimRuleConditions profileClaimRuleConditionsModel = new ProfileClaimRuleConditions.Builder()
+      .claim("testString")
+      .operator("testString")
+      .value("testString")
+      .build();
+
+    // Construct an instance of the TrustedProfileTemplateClaimRule model
+    TrustedProfileTemplateClaimRule trustedProfileTemplateClaimRuleModel = new TrustedProfileTemplateClaimRule.Builder()
+      .name("testString")
+      .type("Profile-SAML")
+      .realmName("testString")
+      .expiration(Long.valueOf("26"))
+      .conditions(java.util.Arrays.asList(profileClaimRuleConditionsModel))
+      .build();
+
+    // Construct an instance of the ProfileIdentityRequest model
+    ProfileIdentityRequest profileIdentityRequestModel = new ProfileIdentityRequest.Builder()
+      .identifier("testString")
+      .type("user")
+      .accounts(java.util.Arrays.asList("testString"))
+      .description("testString")
+      .build();
+
+    // Construct an instance of the TemplateProfileComponentRequest model
+    TemplateProfileComponentRequest templateProfileComponentRequestModel = new TemplateProfileComponentRequest.Builder()
+      .name("testString")
+      .description("testString")
+      .rules(java.util.Arrays.asList(trustedProfileTemplateClaimRuleModel))
+      .identities(java.util.Arrays.asList(profileIdentityRequestModel))
+      .build();
+
+    // Construct an instance of the PolicyTemplateReference model
+    PolicyTemplateReference policyTemplateReferenceModel = new PolicyTemplateReference.Builder()
+      .id("testString")
+      .version("testString")
+      .build();
+
+    // Construct an instance of the UpdateProfileTemplateVersionOptions model
+    UpdateProfileTemplateVersionOptions updateProfileTemplateVersionOptionsModel = new UpdateProfileTemplateVersionOptions.Builder()
+      .ifMatch("testString")
+      .templateId("testString")
+      .version("testString")
+      .accountId("testString")
+      .name("testString")
+      .description("testString")
+      .profile(templateProfileComponentRequestModel)
+      .policyTemplateReferences(java.util.Arrays.asList(policyTemplateReferenceModel))
+      .build();
+
+    // Invoke updateProfileTemplateVersion() with a valid options model and verify the result
+    Response<TrustedProfileTemplateResponse> response = iamIdentityService.updateProfileTemplateVersion(updateProfileTemplateVersionOptionsModel).execute();
+    assertNotNull(response);
+    TrustedProfileTemplateResponse responseObj = response.getResult();
+    assertNotNull(responseObj);
+
+    // Verify the contents of the request sent to the mock server
+    RecordedRequest request = server.takeRequest();
+    assertNotNull(request);
+    assertEquals(request.getMethod(), "PUT");
+    // Verify request path
+    String parsedPath = TestUtilities.parseReqPath(request);
+    assertEquals(parsedPath, updateProfileTemplateVersionPath);
+    // Verify header parameters
+    assertEquals(request.getHeader("If-Match"), "testString");
+    // Verify that there is no query string
+    Map<String, String> query = TestUtilities.parseQueryString(request);
+    assertNull(query);
+  }
+
+  // Test the updateProfileTemplateVersion operation with and without retries enabled
+  @Test
+  public void testUpdateProfileTemplateVersionWRetries() throws Throwable {
+    iamIdentityService.enableRetries(4, 30);
+    testUpdateProfileTemplateVersionWOptions();
+
+    iamIdentityService.disableRetries();
+    testUpdateProfileTemplateVersionWOptions();
+  }
+
+  // Test the updateProfileTemplateVersion operation with a null options model (negative test)
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testUpdateProfileTemplateVersionNoOptions() throws Throwable {
+    server.enqueue(new MockResponse());
+    iamIdentityService.updateProfileTemplateVersion(null).execute();
+  }
+
+  // Test the deleteProfileTemplateVersion operation with a valid options model parameter
+  @Test
+  public void testDeleteProfileTemplateVersionWOptions() throws Throwable {
+    // Register a mock response
+    String mockResponseBody = "";
+    String deleteProfileTemplateVersionPath = "/v1/profile_templates/testString/versions/testString";
+    server.enqueue(new MockResponse()
+      .setResponseCode(204)
+      .setBody(mockResponseBody));
+
+    // Construct an instance of the DeleteProfileTemplateVersionOptions model
+    DeleteProfileTemplateVersionOptions deleteProfileTemplateVersionOptionsModel = new DeleteProfileTemplateVersionOptions.Builder()
+      .templateId("testString")
+      .version("testString")
+      .build();
+
+    // Invoke deleteProfileTemplateVersion() with a valid options model and verify the result
+    Response<Void> response = iamIdentityService.deleteProfileTemplateVersion(deleteProfileTemplateVersionOptionsModel).execute();
+    assertNotNull(response);
+    Void responseObj = response.getResult();
+    assertNull(responseObj);
+
+    // Verify the contents of the request sent to the mock server
+    RecordedRequest request = server.takeRequest();
+    assertNotNull(request);
+    assertEquals(request.getMethod(), "DELETE");
+    // Verify request path
+    String parsedPath = TestUtilities.parseReqPath(request);
+    assertEquals(parsedPath, deleteProfileTemplateVersionPath);
+    // Verify that there is no query string
+    Map<String, String> query = TestUtilities.parseQueryString(request);
+    assertNull(query);
+  }
+
+  // Test the deleteProfileTemplateVersion operation with and without retries enabled
+  @Test
+  public void testDeleteProfileTemplateVersionWRetries() throws Throwable {
+    iamIdentityService.enableRetries(4, 30);
+    testDeleteProfileTemplateVersionWOptions();
+
+    iamIdentityService.disableRetries();
+    testDeleteProfileTemplateVersionWOptions();
+  }
+
+  // Test the deleteProfileTemplateVersion operation with a null options model (negative test)
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testDeleteProfileTemplateVersionNoOptions() throws Throwable {
+    server.enqueue(new MockResponse());
+    iamIdentityService.deleteProfileTemplateVersion(null).execute();
+  }
+
+  // Test the commitProfileTemplate operation with a valid options model parameter
+  @Test
+  public void testCommitProfileTemplateWOptions() throws Throwable {
+    // Register a mock response
+    String mockResponseBody = "";
+    String commitProfileTemplatePath = "/v1/profile_templates/testString/versions/testString/commit";
+    server.enqueue(new MockResponse()
+      .setResponseCode(204)
+      .setBody(mockResponseBody));
+
+    // Construct an instance of the CommitProfileTemplateOptions model
+    CommitProfileTemplateOptions commitProfileTemplateOptionsModel = new CommitProfileTemplateOptions.Builder()
+      .templateId("testString")
+      .version("testString")
+      .build();
+
+    // Invoke commitProfileTemplate() with a valid options model and verify the result
+    Response<Void> response = iamIdentityService.commitProfileTemplate(commitProfileTemplateOptionsModel).execute();
+    assertNotNull(response);
+    Void responseObj = response.getResult();
+    assertNull(responseObj);
+
+    // Verify the contents of the request sent to the mock server
+    RecordedRequest request = server.takeRequest();
+    assertNotNull(request);
+    assertEquals(request.getMethod(), "POST");
+    // Verify request path
+    String parsedPath = TestUtilities.parseReqPath(request);
+    assertEquals(parsedPath, commitProfileTemplatePath);
+    // Verify that there is no query string
+    Map<String, String> query = TestUtilities.parseQueryString(request);
+    assertNull(query);
+  }
+
+  // Test the commitProfileTemplate operation with and without retries enabled
+  @Test
+  public void testCommitProfileTemplateWRetries() throws Throwable {
+    iamIdentityService.enableRetries(4, 30);
+    testCommitProfileTemplateWOptions();
+
+    iamIdentityService.disableRetries();
+    testCommitProfileTemplateWOptions();
+  }
+
+  // Test the commitProfileTemplate operation with a null options model (negative test)
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testCommitProfileTemplateNoOptions() throws Throwable {
+    server.enqueue(new MockResponse());
+    iamIdentityService.commitProfileTemplate(null).execute();
   }
 
   // Perform setup needed before each test method

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/AccountSettingsComponentTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/AccountSettingsComponentTest.java
@@ -1,0 +1,79 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import com.ibm.cloud.platform_services.iam_identity.v1.model.AccountSettingsComponent;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.AccountSettingsUserMFA;
+import com.ibm.cloud.platform_services.iam_identity.v1.utils.TestUtilities;
+import com.ibm.cloud.sdk.core.service.model.FileWithMetadata;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.List;
+import org.testng.annotations.Test;
+import static org.testng.Assert.*;
+
+/**
+ * Unit test class for the AccountSettingsComponent model.
+ */
+public class AccountSettingsComponentTest {
+  final HashMap<String, InputStream> mockStreamMap = TestUtilities.createMockStreamMap();
+  final List<FileWithMetadata> mockListFileWithMetadata = TestUtilities.creatMockListFileWithMetadata();
+
+  @Test
+  public void testAccountSettingsComponent() throws Throwable {
+    AccountSettingsUserMFA accountSettingsUserMfaModel = new AccountSettingsUserMFA.Builder()
+      .iamId("testString")
+      .mfa("NONE")
+      .build();
+    assertEquals(accountSettingsUserMfaModel.iamId(), "testString");
+    assertEquals(accountSettingsUserMfaModel.mfa(), "NONE");
+
+    AccountSettingsComponent accountSettingsComponentModel = new AccountSettingsComponent.Builder()
+      .restrictCreateServiceId("NOT_SET")
+      .restrictCreatePlatformApikey("NOT_SET")
+      .allowedIpAddresses("testString")
+      .mfa("NONE")
+      .userMfa(java.util.Arrays.asList(accountSettingsUserMfaModel))
+      .sessionExpirationInSeconds("86400")
+      .sessionInvalidationInSeconds("7200")
+      .maxSessionsPerIdentity("testString")
+      .systemAccessTokenExpirationInSeconds("3600")
+      .systemRefreshTokenExpirationInSeconds("259200")
+      .build();
+    assertEquals(accountSettingsComponentModel.restrictCreateServiceId(), "NOT_SET");
+    assertEquals(accountSettingsComponentModel.restrictCreatePlatformApikey(), "NOT_SET");
+    assertEquals(accountSettingsComponentModel.allowedIpAddresses(), "testString");
+    assertEquals(accountSettingsComponentModel.mfa(), "NONE");
+    assertEquals(accountSettingsComponentModel.userMfa(), java.util.Arrays.asList(accountSettingsUserMfaModel));
+    assertEquals(accountSettingsComponentModel.sessionExpirationInSeconds(), "86400");
+    assertEquals(accountSettingsComponentModel.sessionInvalidationInSeconds(), "7200");
+    assertEquals(accountSettingsComponentModel.maxSessionsPerIdentity(), "testString");
+    assertEquals(accountSettingsComponentModel.systemAccessTokenExpirationInSeconds(), "3600");
+    assertEquals(accountSettingsComponentModel.systemRefreshTokenExpirationInSeconds(), "259200");
+
+    String json = TestUtilities.serialize(accountSettingsComponentModel);
+
+    AccountSettingsComponent accountSettingsComponentModelNew = TestUtilities.deserialize(json, AccountSettingsComponent.class);
+    assertTrue(accountSettingsComponentModelNew instanceof AccountSettingsComponent);
+    assertEquals(accountSettingsComponentModelNew.restrictCreateServiceId(), "NOT_SET");
+    assertEquals(accountSettingsComponentModelNew.restrictCreatePlatformApikey(), "NOT_SET");
+    assertEquals(accountSettingsComponentModelNew.allowedIpAddresses(), "testString");
+    assertEquals(accountSettingsComponentModelNew.mfa(), "NONE");
+    assertEquals(accountSettingsComponentModelNew.sessionExpirationInSeconds(), "86400");
+    assertEquals(accountSettingsComponentModelNew.sessionInvalidationInSeconds(), "7200");
+    assertEquals(accountSettingsComponentModelNew.maxSessionsPerIdentity(), "testString");
+    assertEquals(accountSettingsComponentModelNew.systemAccessTokenExpirationInSeconds(), "3600");
+    assertEquals(accountSettingsComponentModelNew.systemRefreshTokenExpirationInSeconds(), "259200");
+  }
+}

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/AccountSettingsResponseTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/AccountSettingsResponseTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/AccountSettingsTemplateListTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/AccountSettingsTemplateListTest.java
@@ -1,0 +1,48 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import com.ibm.cloud.platform_services.iam_identity.v1.model.AccountSettingsComponent;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.AccountSettingsTemplateList;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.AccountSettingsTemplateResponse;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.AccountSettingsUserMFA;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.EnityHistoryRecord;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.ResponseContext;
+import com.ibm.cloud.platform_services.iam_identity.v1.utils.TestUtilities;
+import com.ibm.cloud.sdk.core.service.model.FileWithMetadata;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.List;
+import org.testng.annotations.Test;
+import static org.testng.Assert.*;
+
+/**
+ * Unit test class for the AccountSettingsTemplateList model.
+ */
+public class AccountSettingsTemplateListTest {
+  final HashMap<String, InputStream> mockStreamMap = TestUtilities.createMockStreamMap();
+  final List<FileWithMetadata> mockListFileWithMetadata = TestUtilities.creatMockListFileWithMetadata();
+
+  @Test
+  public void testAccountSettingsTemplateList() throws Throwable {
+    AccountSettingsTemplateList accountSettingsTemplateListModel = new AccountSettingsTemplateList();
+    assertNull(accountSettingsTemplateListModel.getContext());
+    assertNull(accountSettingsTemplateListModel.getOffset());
+    assertNull(accountSettingsTemplateListModel.getLimit());
+    assertNull(accountSettingsTemplateListModel.getFirst());
+    assertNull(accountSettingsTemplateListModel.getPrevious());
+    assertNull(accountSettingsTemplateListModel.getNext());
+    assertNull(accountSettingsTemplateListModel.getAccountSettingsTemplates());
+  }
+}

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/AccountSettingsTemplateResponseTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/AccountSettingsTemplateResponseTest.java
@@ -1,0 +1,53 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import com.ibm.cloud.platform_services.iam_identity.v1.model.AccountSettingsComponent;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.AccountSettingsTemplateResponse;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.AccountSettingsUserMFA;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.EnityHistoryRecord;
+import com.ibm.cloud.platform_services.iam_identity.v1.utils.TestUtilities;
+import com.ibm.cloud.sdk.core.service.model.FileWithMetadata;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.List;
+import org.testng.annotations.Test;
+import static org.testng.Assert.*;
+
+/**
+ * Unit test class for the AccountSettingsTemplateResponse model.
+ */
+public class AccountSettingsTemplateResponseTest {
+  final HashMap<String, InputStream> mockStreamMap = TestUtilities.createMockStreamMap();
+  final List<FileWithMetadata> mockListFileWithMetadata = TestUtilities.creatMockListFileWithMetadata();
+
+  @Test
+  public void testAccountSettingsTemplateResponse() throws Throwable {
+    AccountSettingsTemplateResponse accountSettingsTemplateResponseModel = new AccountSettingsTemplateResponse();
+    assertNull(accountSettingsTemplateResponseModel.getId());
+    assertNull(accountSettingsTemplateResponseModel.getVersion());
+    assertNull(accountSettingsTemplateResponseModel.getAccountId());
+    assertNull(accountSettingsTemplateResponseModel.getName());
+    assertNull(accountSettingsTemplateResponseModel.getDescription());
+    assertNull(accountSettingsTemplateResponseModel.isCommitted());
+    assertNull(accountSettingsTemplateResponseModel.getAccountSettings());
+    assertNull(accountSettingsTemplateResponseModel.getHistory());
+    assertNull(accountSettingsTemplateResponseModel.getEntityTag());
+    assertNull(accountSettingsTemplateResponseModel.getCrn());
+    assertNull(accountSettingsTemplateResponseModel.getCreatedAt());
+    assertNull(accountSettingsTemplateResponseModel.getCreatedById());
+    assertNull(accountSettingsTemplateResponseModel.getLastModifiedAt());
+    assertNull(accountSettingsTemplateResponseModel.getLastModifiedById());
+  }
+}

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/AccountSettingsUserMFATest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/AccountSettingsUserMFATest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ActivityTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ActivityTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ApiKeyInsideCreateServiceIdRequestTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ApiKeyInsideCreateServiceIdRequestTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ApiKeyListTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ApiKeyListTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ApiKeyTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ApiKeyTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ApikeyActivityServiceidTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ApikeyActivityServiceidTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ApikeyActivityTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ApikeyActivityTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ApikeyActivityUserTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ApikeyActivityUserTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/CommitAccountSettingsTemplateOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/CommitAccountSettingsTemplateOptionsTest.java
@@ -1,0 +1,47 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import com.ibm.cloud.platform_services.iam_identity.v1.model.CommitAccountSettingsTemplateOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.utils.TestUtilities;
+import com.ibm.cloud.sdk.core.service.model.FileWithMetadata;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.List;
+import org.testng.annotations.Test;
+import static org.testng.Assert.*;
+
+/**
+ * Unit test class for the CommitAccountSettingsTemplateOptions model.
+ */
+public class CommitAccountSettingsTemplateOptionsTest {
+  final HashMap<String, InputStream> mockStreamMap = TestUtilities.createMockStreamMap();
+  final List<FileWithMetadata> mockListFileWithMetadata = TestUtilities.creatMockListFileWithMetadata();
+
+  @Test
+  public void testCommitAccountSettingsTemplateOptions() throws Throwable {
+    CommitAccountSettingsTemplateOptions commitAccountSettingsTemplateOptionsModel = new CommitAccountSettingsTemplateOptions.Builder()
+      .templateId("testString")
+      .version("testString")
+      .build();
+    assertEquals(commitAccountSettingsTemplateOptionsModel.templateId(), "testString");
+    assertEquals(commitAccountSettingsTemplateOptionsModel.version(), "testString");
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testCommitAccountSettingsTemplateOptionsError() throws Throwable {
+    new CommitAccountSettingsTemplateOptions.Builder().build();
+  }
+
+}

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/CommitProfileTemplateOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/CommitProfileTemplateOptionsTest.java
@@ -1,0 +1,47 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import com.ibm.cloud.platform_services.iam_identity.v1.model.CommitProfileTemplateOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.utils.TestUtilities;
+import com.ibm.cloud.sdk.core.service.model.FileWithMetadata;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.List;
+import org.testng.annotations.Test;
+import static org.testng.Assert.*;
+
+/**
+ * Unit test class for the CommitProfileTemplateOptions model.
+ */
+public class CommitProfileTemplateOptionsTest {
+  final HashMap<String, InputStream> mockStreamMap = TestUtilities.createMockStreamMap();
+  final List<FileWithMetadata> mockListFileWithMetadata = TestUtilities.creatMockListFileWithMetadata();
+
+  @Test
+  public void testCommitProfileTemplateOptions() throws Throwable {
+    CommitProfileTemplateOptions commitProfileTemplateOptionsModel = new CommitProfileTemplateOptions.Builder()
+      .templateId("testString")
+      .version("testString")
+      .build();
+    assertEquals(commitProfileTemplateOptionsModel.templateId(), "testString");
+    assertEquals(commitProfileTemplateOptionsModel.version(), "testString");
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testCommitProfileTemplateOptionsError() throws Throwable {
+    new CommitProfileTemplateOptions.Builder().build();
+  }
+
+}

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/CreateAccountSettingsAssignmentOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/CreateAccountSettingsAssignmentOptionsTest.java
@@ -1,0 +1,51 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import com.ibm.cloud.platform_services.iam_identity.v1.model.CreateAccountSettingsAssignmentOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.utils.TestUtilities;
+import com.ibm.cloud.sdk.core.service.model.FileWithMetadata;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.List;
+import org.testng.annotations.Test;
+import static org.testng.Assert.*;
+
+/**
+ * Unit test class for the CreateAccountSettingsAssignmentOptions model.
+ */
+public class CreateAccountSettingsAssignmentOptionsTest {
+  final HashMap<String, InputStream> mockStreamMap = TestUtilities.createMockStreamMap();
+  final List<FileWithMetadata> mockListFileWithMetadata = TestUtilities.creatMockListFileWithMetadata();
+
+  @Test
+  public void testCreateAccountSettingsAssignmentOptions() throws Throwable {
+    CreateAccountSettingsAssignmentOptions createAccountSettingsAssignmentOptionsModel = new CreateAccountSettingsAssignmentOptions.Builder()
+      .templateId("testString")
+      .templateVersion(Long.valueOf("1"))
+      .targetType("Account")
+      .target("testString")
+      .build();
+    assertEquals(createAccountSettingsAssignmentOptionsModel.templateId(), "testString");
+    assertEquals(createAccountSettingsAssignmentOptionsModel.templateVersion(), Long.valueOf("1"));
+    assertEquals(createAccountSettingsAssignmentOptionsModel.targetType(), "Account");
+    assertEquals(createAccountSettingsAssignmentOptionsModel.target(), "testString");
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testCreateAccountSettingsAssignmentOptionsError() throws Throwable {
+    new CreateAccountSettingsAssignmentOptions.Builder().build();
+  }
+
+}

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/CreateAccountSettingsTemplateOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/CreateAccountSettingsTemplateOptionsTest.java
@@ -1,0 +1,77 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import com.ibm.cloud.platform_services.iam_identity.v1.model.AccountSettingsComponent;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.AccountSettingsUserMFA;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.CreateAccountSettingsTemplateOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.utils.TestUtilities;
+import com.ibm.cloud.sdk.core.service.model.FileWithMetadata;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.List;
+import org.testng.annotations.Test;
+import static org.testng.Assert.*;
+
+/**
+ * Unit test class for the CreateAccountSettingsTemplateOptions model.
+ */
+public class CreateAccountSettingsTemplateOptionsTest {
+  final HashMap<String, InputStream> mockStreamMap = TestUtilities.createMockStreamMap();
+  final List<FileWithMetadata> mockListFileWithMetadata = TestUtilities.creatMockListFileWithMetadata();
+
+  @Test
+  public void testCreateAccountSettingsTemplateOptions() throws Throwable {
+    AccountSettingsUserMFA accountSettingsUserMfaModel = new AccountSettingsUserMFA.Builder()
+      .iamId("testString")
+      .mfa("NONE")
+      .build();
+    assertEquals(accountSettingsUserMfaModel.iamId(), "testString");
+    assertEquals(accountSettingsUserMfaModel.mfa(), "NONE");
+
+    AccountSettingsComponent accountSettingsComponentModel = new AccountSettingsComponent.Builder()
+      .restrictCreateServiceId("NOT_SET")
+      .restrictCreatePlatformApikey("NOT_SET")
+      .allowedIpAddresses("testString")
+      .mfa("NONE")
+      .userMfa(java.util.Arrays.asList(accountSettingsUserMfaModel))
+      .sessionExpirationInSeconds("86400")
+      .sessionInvalidationInSeconds("7200")
+      .maxSessionsPerIdentity("testString")
+      .systemAccessTokenExpirationInSeconds("3600")
+      .systemRefreshTokenExpirationInSeconds("259200")
+      .build();
+    assertEquals(accountSettingsComponentModel.restrictCreateServiceId(), "NOT_SET");
+    assertEquals(accountSettingsComponentModel.restrictCreatePlatformApikey(), "NOT_SET");
+    assertEquals(accountSettingsComponentModel.allowedIpAddresses(), "testString");
+    assertEquals(accountSettingsComponentModel.mfa(), "NONE");
+    assertEquals(accountSettingsComponentModel.userMfa(), java.util.Arrays.asList(accountSettingsUserMfaModel));
+    assertEquals(accountSettingsComponentModel.sessionExpirationInSeconds(), "86400");
+    assertEquals(accountSettingsComponentModel.sessionInvalidationInSeconds(), "7200");
+    assertEquals(accountSettingsComponentModel.maxSessionsPerIdentity(), "testString");
+    assertEquals(accountSettingsComponentModel.systemAccessTokenExpirationInSeconds(), "3600");
+    assertEquals(accountSettingsComponentModel.systemRefreshTokenExpirationInSeconds(), "259200");
+
+    CreateAccountSettingsTemplateOptions createAccountSettingsTemplateOptionsModel = new CreateAccountSettingsTemplateOptions.Builder()
+      .accountId("testString")
+      .name("testString")
+      .description("testString")
+      .accountSettings(accountSettingsComponentModel)
+      .build();
+    assertEquals(createAccountSettingsTemplateOptionsModel.accountId(), "testString");
+    assertEquals(createAccountSettingsTemplateOptionsModel.name(), "testString");
+    assertEquals(createAccountSettingsTemplateOptionsModel.description(), "testString");
+    assertEquals(createAccountSettingsTemplateOptionsModel.accountSettings(), accountSettingsComponentModel);
+  }
+}

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/CreateAccountSettingsTemplateVersionOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/CreateAccountSettingsTemplateVersionOptionsTest.java
@@ -1,0 +1,85 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import com.ibm.cloud.platform_services.iam_identity.v1.model.AccountSettingsComponent;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.AccountSettingsUserMFA;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.CreateAccountSettingsTemplateVersionOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.utils.TestUtilities;
+import com.ibm.cloud.sdk.core.service.model.FileWithMetadata;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.List;
+import org.testng.annotations.Test;
+import static org.testng.Assert.*;
+
+/**
+ * Unit test class for the CreateAccountSettingsTemplateVersionOptions model.
+ */
+public class CreateAccountSettingsTemplateVersionOptionsTest {
+  final HashMap<String, InputStream> mockStreamMap = TestUtilities.createMockStreamMap();
+  final List<FileWithMetadata> mockListFileWithMetadata = TestUtilities.creatMockListFileWithMetadata();
+
+  @Test
+  public void testCreateAccountSettingsTemplateVersionOptions() throws Throwable {
+    AccountSettingsUserMFA accountSettingsUserMfaModel = new AccountSettingsUserMFA.Builder()
+      .iamId("testString")
+      .mfa("NONE")
+      .build();
+    assertEquals(accountSettingsUserMfaModel.iamId(), "testString");
+    assertEquals(accountSettingsUserMfaModel.mfa(), "NONE");
+
+    AccountSettingsComponent accountSettingsComponentModel = new AccountSettingsComponent.Builder()
+      .restrictCreateServiceId("NOT_SET")
+      .restrictCreatePlatformApikey("NOT_SET")
+      .allowedIpAddresses("testString")
+      .mfa("NONE")
+      .userMfa(java.util.Arrays.asList(accountSettingsUserMfaModel))
+      .sessionExpirationInSeconds("86400")
+      .sessionInvalidationInSeconds("7200")
+      .maxSessionsPerIdentity("testString")
+      .systemAccessTokenExpirationInSeconds("3600")
+      .systemRefreshTokenExpirationInSeconds("259200")
+      .build();
+    assertEquals(accountSettingsComponentModel.restrictCreateServiceId(), "NOT_SET");
+    assertEquals(accountSettingsComponentModel.restrictCreatePlatformApikey(), "NOT_SET");
+    assertEquals(accountSettingsComponentModel.allowedIpAddresses(), "testString");
+    assertEquals(accountSettingsComponentModel.mfa(), "NONE");
+    assertEquals(accountSettingsComponentModel.userMfa(), java.util.Arrays.asList(accountSettingsUserMfaModel));
+    assertEquals(accountSettingsComponentModel.sessionExpirationInSeconds(), "86400");
+    assertEquals(accountSettingsComponentModel.sessionInvalidationInSeconds(), "7200");
+    assertEquals(accountSettingsComponentModel.maxSessionsPerIdentity(), "testString");
+    assertEquals(accountSettingsComponentModel.systemAccessTokenExpirationInSeconds(), "3600");
+    assertEquals(accountSettingsComponentModel.systemRefreshTokenExpirationInSeconds(), "259200");
+
+    CreateAccountSettingsTemplateVersionOptions createAccountSettingsTemplateVersionOptionsModel = new CreateAccountSettingsTemplateVersionOptions.Builder()
+      .templateId("testString")
+      .accountId("testString")
+      .name("testString")
+      .description("testString")
+      .accountSettings(accountSettingsComponentModel)
+      .build();
+    assertEquals(createAccountSettingsTemplateVersionOptionsModel.templateId(), "testString");
+    assertEquals(createAccountSettingsTemplateVersionOptionsModel.accountId(), "testString");
+    assertEquals(createAccountSettingsTemplateVersionOptionsModel.name(), "testString");
+    assertEquals(createAccountSettingsTemplateVersionOptionsModel.description(), "testString");
+    assertEquals(createAccountSettingsTemplateVersionOptionsModel.accountSettings(), accountSettingsComponentModel);
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testCreateAccountSettingsTemplateVersionOptionsError() throws Throwable {
+    new CreateAccountSettingsTemplateVersionOptions.Builder().build();
+  }
+
+}

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/CreateApiKeyOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/CreateApiKeyOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/CreateClaimRuleOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/CreateClaimRuleOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/CreateLinkOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/CreateLinkOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/CreateProfileLinkRequestLinkTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/CreateProfileLinkRequestLinkTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/CreateProfileOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/CreateProfileOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/CreateProfileTemplateOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/CreateProfileTemplateOptionsTest.java
@@ -1,0 +1,103 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import com.ibm.cloud.platform_services.iam_identity.v1.model.CreateProfileTemplateOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.PolicyTemplateReference;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.ProfileClaimRuleConditions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.ProfileIdentityRequest;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.TemplateProfileComponentRequest;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.TrustedProfileTemplateClaimRule;
+import com.ibm.cloud.platform_services.iam_identity.v1.utils.TestUtilities;
+import com.ibm.cloud.sdk.core.service.model.FileWithMetadata;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.List;
+import org.testng.annotations.Test;
+import static org.testng.Assert.*;
+
+/**
+ * Unit test class for the CreateProfileTemplateOptions model.
+ */
+public class CreateProfileTemplateOptionsTest {
+  final HashMap<String, InputStream> mockStreamMap = TestUtilities.createMockStreamMap();
+  final List<FileWithMetadata> mockListFileWithMetadata = TestUtilities.creatMockListFileWithMetadata();
+
+  @Test
+  public void testCreateProfileTemplateOptions() throws Throwable {
+    ProfileClaimRuleConditions profileClaimRuleConditionsModel = new ProfileClaimRuleConditions.Builder()
+      .claim("testString")
+      .operator("testString")
+      .value("testString")
+      .build();
+    assertEquals(profileClaimRuleConditionsModel.claim(), "testString");
+    assertEquals(profileClaimRuleConditionsModel.operator(), "testString");
+    assertEquals(profileClaimRuleConditionsModel.value(), "testString");
+
+    TrustedProfileTemplateClaimRule trustedProfileTemplateClaimRuleModel = new TrustedProfileTemplateClaimRule.Builder()
+      .name("testString")
+      .type("Profile-SAML")
+      .realmName("testString")
+      .expiration(Long.valueOf("26"))
+      .conditions(java.util.Arrays.asList(profileClaimRuleConditionsModel))
+      .build();
+    assertEquals(trustedProfileTemplateClaimRuleModel.name(), "testString");
+    assertEquals(trustedProfileTemplateClaimRuleModel.type(), "Profile-SAML");
+    assertEquals(trustedProfileTemplateClaimRuleModel.realmName(), "testString");
+    assertEquals(trustedProfileTemplateClaimRuleModel.expiration(), Long.valueOf("26"));
+    assertEquals(trustedProfileTemplateClaimRuleModel.conditions(), java.util.Arrays.asList(profileClaimRuleConditionsModel));
+
+    ProfileIdentityRequest profileIdentityRequestModel = new ProfileIdentityRequest.Builder()
+      .identifier("testString")
+      .type("user")
+      .accounts(java.util.Arrays.asList("testString"))
+      .description("testString")
+      .build();
+    assertEquals(profileIdentityRequestModel.identifier(), "testString");
+    assertEquals(profileIdentityRequestModel.type(), "user");
+    assertEquals(profileIdentityRequestModel.accounts(), java.util.Arrays.asList("testString"));
+    assertEquals(profileIdentityRequestModel.description(), "testString");
+
+    TemplateProfileComponentRequest templateProfileComponentRequestModel = new TemplateProfileComponentRequest.Builder()
+      .name("testString")
+      .description("testString")
+      .rules(java.util.Arrays.asList(trustedProfileTemplateClaimRuleModel))
+      .identities(java.util.Arrays.asList(profileIdentityRequestModel))
+      .build();
+    assertEquals(templateProfileComponentRequestModel.name(), "testString");
+    assertEquals(templateProfileComponentRequestModel.description(), "testString");
+    assertEquals(templateProfileComponentRequestModel.rules(), java.util.Arrays.asList(trustedProfileTemplateClaimRuleModel));
+    assertEquals(templateProfileComponentRequestModel.identities(), java.util.Arrays.asList(profileIdentityRequestModel));
+
+    PolicyTemplateReference policyTemplateReferenceModel = new PolicyTemplateReference.Builder()
+      .id("testString")
+      .version("testString")
+      .build();
+    assertEquals(policyTemplateReferenceModel.id(), "testString");
+    assertEquals(policyTemplateReferenceModel.version(), "testString");
+
+    CreateProfileTemplateOptions createProfileTemplateOptionsModel = new CreateProfileTemplateOptions.Builder()
+      .accountId("testString")
+      .name("testString")
+      .description("testString")
+      .profile(templateProfileComponentRequestModel)
+      .policyTemplateReferences(java.util.Arrays.asList(policyTemplateReferenceModel))
+      .build();
+    assertEquals(createProfileTemplateOptionsModel.accountId(), "testString");
+    assertEquals(createProfileTemplateOptionsModel.name(), "testString");
+    assertEquals(createProfileTemplateOptionsModel.description(), "testString");
+    assertEquals(createProfileTemplateOptionsModel.profile(), templateProfileComponentRequestModel);
+    assertEquals(createProfileTemplateOptionsModel.policyTemplateReferences(), java.util.Arrays.asList(policyTemplateReferenceModel));
+  }
+}

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/CreateProfileTemplateVersionOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/CreateProfileTemplateVersionOptionsTest.java
@@ -1,0 +1,111 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import com.ibm.cloud.platform_services.iam_identity.v1.model.CreateProfileTemplateVersionOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.PolicyTemplateReference;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.ProfileClaimRuleConditions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.ProfileIdentityRequest;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.TemplateProfileComponentRequest;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.TrustedProfileTemplateClaimRule;
+import com.ibm.cloud.platform_services.iam_identity.v1.utils.TestUtilities;
+import com.ibm.cloud.sdk.core.service.model.FileWithMetadata;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.List;
+import org.testng.annotations.Test;
+import static org.testng.Assert.*;
+
+/**
+ * Unit test class for the CreateProfileTemplateVersionOptions model.
+ */
+public class CreateProfileTemplateVersionOptionsTest {
+  final HashMap<String, InputStream> mockStreamMap = TestUtilities.createMockStreamMap();
+  final List<FileWithMetadata> mockListFileWithMetadata = TestUtilities.creatMockListFileWithMetadata();
+
+  @Test
+  public void testCreateProfileTemplateVersionOptions() throws Throwable {
+    ProfileClaimRuleConditions profileClaimRuleConditionsModel = new ProfileClaimRuleConditions.Builder()
+      .claim("testString")
+      .operator("testString")
+      .value("testString")
+      .build();
+    assertEquals(profileClaimRuleConditionsModel.claim(), "testString");
+    assertEquals(profileClaimRuleConditionsModel.operator(), "testString");
+    assertEquals(profileClaimRuleConditionsModel.value(), "testString");
+
+    TrustedProfileTemplateClaimRule trustedProfileTemplateClaimRuleModel = new TrustedProfileTemplateClaimRule.Builder()
+      .name("testString")
+      .type("Profile-SAML")
+      .realmName("testString")
+      .expiration(Long.valueOf("26"))
+      .conditions(java.util.Arrays.asList(profileClaimRuleConditionsModel))
+      .build();
+    assertEquals(trustedProfileTemplateClaimRuleModel.name(), "testString");
+    assertEquals(trustedProfileTemplateClaimRuleModel.type(), "Profile-SAML");
+    assertEquals(trustedProfileTemplateClaimRuleModel.realmName(), "testString");
+    assertEquals(trustedProfileTemplateClaimRuleModel.expiration(), Long.valueOf("26"));
+    assertEquals(trustedProfileTemplateClaimRuleModel.conditions(), java.util.Arrays.asList(profileClaimRuleConditionsModel));
+
+    ProfileIdentityRequest profileIdentityRequestModel = new ProfileIdentityRequest.Builder()
+      .identifier("testString")
+      .type("user")
+      .accounts(java.util.Arrays.asList("testString"))
+      .description("testString")
+      .build();
+    assertEquals(profileIdentityRequestModel.identifier(), "testString");
+    assertEquals(profileIdentityRequestModel.type(), "user");
+    assertEquals(profileIdentityRequestModel.accounts(), java.util.Arrays.asList("testString"));
+    assertEquals(profileIdentityRequestModel.description(), "testString");
+
+    TemplateProfileComponentRequest templateProfileComponentRequestModel = new TemplateProfileComponentRequest.Builder()
+      .name("testString")
+      .description("testString")
+      .rules(java.util.Arrays.asList(trustedProfileTemplateClaimRuleModel))
+      .identities(java.util.Arrays.asList(profileIdentityRequestModel))
+      .build();
+    assertEquals(templateProfileComponentRequestModel.name(), "testString");
+    assertEquals(templateProfileComponentRequestModel.description(), "testString");
+    assertEquals(templateProfileComponentRequestModel.rules(), java.util.Arrays.asList(trustedProfileTemplateClaimRuleModel));
+    assertEquals(templateProfileComponentRequestModel.identities(), java.util.Arrays.asList(profileIdentityRequestModel));
+
+    PolicyTemplateReference policyTemplateReferenceModel = new PolicyTemplateReference.Builder()
+      .id("testString")
+      .version("testString")
+      .build();
+    assertEquals(policyTemplateReferenceModel.id(), "testString");
+    assertEquals(policyTemplateReferenceModel.version(), "testString");
+
+    CreateProfileTemplateVersionOptions createProfileTemplateVersionOptionsModel = new CreateProfileTemplateVersionOptions.Builder()
+      .templateId("testString")
+      .accountId("testString")
+      .name("testString")
+      .description("testString")
+      .profile(templateProfileComponentRequestModel)
+      .policyTemplateReferences(java.util.Arrays.asList(policyTemplateReferenceModel))
+      .build();
+    assertEquals(createProfileTemplateVersionOptionsModel.templateId(), "testString");
+    assertEquals(createProfileTemplateVersionOptionsModel.accountId(), "testString");
+    assertEquals(createProfileTemplateVersionOptionsModel.name(), "testString");
+    assertEquals(createProfileTemplateVersionOptionsModel.description(), "testString");
+    assertEquals(createProfileTemplateVersionOptionsModel.profile(), templateProfileComponentRequestModel);
+    assertEquals(createProfileTemplateVersionOptionsModel.policyTemplateReferences(), java.util.Arrays.asList(policyTemplateReferenceModel));
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testCreateProfileTemplateVersionOptionsError() throws Throwable {
+    new CreateProfileTemplateVersionOptions.Builder().build();
+  }
+
+}

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/CreateReportOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/CreateReportOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/CreateServiceIdOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/CreateServiceIdOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/CreateTrustedProfileAssignmentOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/CreateTrustedProfileAssignmentOptionsTest.java
@@ -1,0 +1,51 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import com.ibm.cloud.platform_services.iam_identity.v1.model.CreateTrustedProfileAssignmentOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.utils.TestUtilities;
+import com.ibm.cloud.sdk.core.service.model.FileWithMetadata;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.List;
+import org.testng.annotations.Test;
+import static org.testng.Assert.*;
+
+/**
+ * Unit test class for the CreateTrustedProfileAssignmentOptions model.
+ */
+public class CreateTrustedProfileAssignmentOptionsTest {
+  final HashMap<String, InputStream> mockStreamMap = TestUtilities.createMockStreamMap();
+  final List<FileWithMetadata> mockListFileWithMetadata = TestUtilities.creatMockListFileWithMetadata();
+
+  @Test
+  public void testCreateTrustedProfileAssignmentOptions() throws Throwable {
+    CreateTrustedProfileAssignmentOptions createTrustedProfileAssignmentOptionsModel = new CreateTrustedProfileAssignmentOptions.Builder()
+      .templateId("testString")
+      .templateVersion(Long.valueOf("1"))
+      .targetType("Account")
+      .target("testString")
+      .build();
+    assertEquals(createTrustedProfileAssignmentOptionsModel.templateId(), "testString");
+    assertEquals(createTrustedProfileAssignmentOptionsModel.templateVersion(), Long.valueOf("1"));
+    assertEquals(createTrustedProfileAssignmentOptionsModel.targetType(), "Account");
+    assertEquals(createTrustedProfileAssignmentOptionsModel.target(), "testString");
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testCreateTrustedProfileAssignmentOptionsError() throws Throwable {
+    new CreateTrustedProfileAssignmentOptions.Builder().build();
+  }
+
+}

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/DeleteAccountSettingsAssignmentOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/DeleteAccountSettingsAssignmentOptionsTest.java
@@ -1,0 +1,45 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import com.ibm.cloud.platform_services.iam_identity.v1.model.DeleteAccountSettingsAssignmentOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.utils.TestUtilities;
+import com.ibm.cloud.sdk.core.service.model.FileWithMetadata;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.List;
+import org.testng.annotations.Test;
+import static org.testng.Assert.*;
+
+/**
+ * Unit test class for the DeleteAccountSettingsAssignmentOptions model.
+ */
+public class DeleteAccountSettingsAssignmentOptionsTest {
+  final HashMap<String, InputStream> mockStreamMap = TestUtilities.createMockStreamMap();
+  final List<FileWithMetadata> mockListFileWithMetadata = TestUtilities.creatMockListFileWithMetadata();
+
+  @Test
+  public void testDeleteAccountSettingsAssignmentOptions() throws Throwable {
+    DeleteAccountSettingsAssignmentOptions deleteAccountSettingsAssignmentOptionsModel = new DeleteAccountSettingsAssignmentOptions.Builder()
+      .assignmentId("testString")
+      .build();
+    assertEquals(deleteAccountSettingsAssignmentOptionsModel.assignmentId(), "testString");
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testDeleteAccountSettingsAssignmentOptionsError() throws Throwable {
+    new DeleteAccountSettingsAssignmentOptions.Builder().build();
+  }
+
+}

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/DeleteAccountSettingsTemplateVersionOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/DeleteAccountSettingsTemplateVersionOptionsTest.java
@@ -1,0 +1,47 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import com.ibm.cloud.platform_services.iam_identity.v1.model.DeleteAccountSettingsTemplateVersionOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.utils.TestUtilities;
+import com.ibm.cloud.sdk.core.service.model.FileWithMetadata;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.List;
+import org.testng.annotations.Test;
+import static org.testng.Assert.*;
+
+/**
+ * Unit test class for the DeleteAccountSettingsTemplateVersionOptions model.
+ */
+public class DeleteAccountSettingsTemplateVersionOptionsTest {
+  final HashMap<String, InputStream> mockStreamMap = TestUtilities.createMockStreamMap();
+  final List<FileWithMetadata> mockListFileWithMetadata = TestUtilities.creatMockListFileWithMetadata();
+
+  @Test
+  public void testDeleteAccountSettingsTemplateVersionOptions() throws Throwable {
+    DeleteAccountSettingsTemplateVersionOptions deleteAccountSettingsTemplateVersionOptionsModel = new DeleteAccountSettingsTemplateVersionOptions.Builder()
+      .templateId("testString")
+      .version("testString")
+      .build();
+    assertEquals(deleteAccountSettingsTemplateVersionOptionsModel.templateId(), "testString");
+    assertEquals(deleteAccountSettingsTemplateVersionOptionsModel.version(), "testString");
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testDeleteAccountSettingsTemplateVersionOptionsError() throws Throwable {
+    new DeleteAccountSettingsTemplateVersionOptions.Builder().build();
+  }
+
+}

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/DeleteAllVersionsOfAccountSettingsTemplateOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/DeleteAllVersionsOfAccountSettingsTemplateOptionsTest.java
@@ -1,0 +1,45 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import com.ibm.cloud.platform_services.iam_identity.v1.model.DeleteAllVersionsOfAccountSettingsTemplateOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.utils.TestUtilities;
+import com.ibm.cloud.sdk.core.service.model.FileWithMetadata;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.List;
+import org.testng.annotations.Test;
+import static org.testng.Assert.*;
+
+/**
+ * Unit test class for the DeleteAllVersionsOfAccountSettingsTemplateOptions model.
+ */
+public class DeleteAllVersionsOfAccountSettingsTemplateOptionsTest {
+  final HashMap<String, InputStream> mockStreamMap = TestUtilities.createMockStreamMap();
+  final List<FileWithMetadata> mockListFileWithMetadata = TestUtilities.creatMockListFileWithMetadata();
+
+  @Test
+  public void testDeleteAllVersionsOfAccountSettingsTemplateOptions() throws Throwable {
+    DeleteAllVersionsOfAccountSettingsTemplateOptions deleteAllVersionsOfAccountSettingsTemplateOptionsModel = new DeleteAllVersionsOfAccountSettingsTemplateOptions.Builder()
+      .templateId("testString")
+      .build();
+    assertEquals(deleteAllVersionsOfAccountSettingsTemplateOptionsModel.templateId(), "testString");
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testDeleteAllVersionsOfAccountSettingsTemplateOptionsError() throws Throwable {
+    new DeleteAllVersionsOfAccountSettingsTemplateOptions.Builder().build();
+  }
+
+}

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/DeleteAllVersionsOfProfileTemplateOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/DeleteAllVersionsOfProfileTemplateOptionsTest.java
@@ -1,0 +1,45 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import com.ibm.cloud.platform_services.iam_identity.v1.model.DeleteAllVersionsOfProfileTemplateOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.utils.TestUtilities;
+import com.ibm.cloud.sdk.core.service.model.FileWithMetadata;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.List;
+import org.testng.annotations.Test;
+import static org.testng.Assert.*;
+
+/**
+ * Unit test class for the DeleteAllVersionsOfProfileTemplateOptions model.
+ */
+public class DeleteAllVersionsOfProfileTemplateOptionsTest {
+  final HashMap<String, InputStream> mockStreamMap = TestUtilities.createMockStreamMap();
+  final List<FileWithMetadata> mockListFileWithMetadata = TestUtilities.creatMockListFileWithMetadata();
+
+  @Test
+  public void testDeleteAllVersionsOfProfileTemplateOptions() throws Throwable {
+    DeleteAllVersionsOfProfileTemplateOptions deleteAllVersionsOfProfileTemplateOptionsModel = new DeleteAllVersionsOfProfileTemplateOptions.Builder()
+      .templateId("testString")
+      .build();
+    assertEquals(deleteAllVersionsOfProfileTemplateOptionsModel.templateId(), "testString");
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testDeleteAllVersionsOfProfileTemplateOptionsError() throws Throwable {
+    new DeleteAllVersionsOfProfileTemplateOptions.Builder().build();
+  }
+
+}

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/DeleteApiKeyOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/DeleteApiKeyOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/DeleteClaimRuleOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/DeleteClaimRuleOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/DeleteLinkOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/DeleteLinkOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/DeleteProfileOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/DeleteProfileOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/DeleteProfileTemplateVersionOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/DeleteProfileTemplateVersionOptionsTest.java
@@ -1,0 +1,47 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import com.ibm.cloud.platform_services.iam_identity.v1.model.DeleteProfileTemplateVersionOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.utils.TestUtilities;
+import com.ibm.cloud.sdk.core.service.model.FileWithMetadata;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.List;
+import org.testng.annotations.Test;
+import static org.testng.Assert.*;
+
+/**
+ * Unit test class for the DeleteProfileTemplateVersionOptions model.
+ */
+public class DeleteProfileTemplateVersionOptionsTest {
+  final HashMap<String, InputStream> mockStreamMap = TestUtilities.createMockStreamMap();
+  final List<FileWithMetadata> mockListFileWithMetadata = TestUtilities.creatMockListFileWithMetadata();
+
+  @Test
+  public void testDeleteProfileTemplateVersionOptions() throws Throwable {
+    DeleteProfileTemplateVersionOptions deleteProfileTemplateVersionOptionsModel = new DeleteProfileTemplateVersionOptions.Builder()
+      .templateId("testString")
+      .version("testString")
+      .build();
+    assertEquals(deleteProfileTemplateVersionOptionsModel.templateId(), "testString");
+    assertEquals(deleteProfileTemplateVersionOptionsModel.version(), "testString");
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testDeleteProfileTemplateVersionOptionsError() throws Throwable {
+    new DeleteProfileTemplateVersionOptions.Builder().build();
+  }
+
+}

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/DeleteServiceIdOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/DeleteServiceIdOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/DeleteTrustedProfileAssignmentOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/DeleteTrustedProfileAssignmentOptionsTest.java
@@ -1,0 +1,45 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import com.ibm.cloud.platform_services.iam_identity.v1.model.DeleteTrustedProfileAssignmentOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.utils.TestUtilities;
+import com.ibm.cloud.sdk.core.service.model.FileWithMetadata;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.List;
+import org.testng.annotations.Test;
+import static org.testng.Assert.*;
+
+/**
+ * Unit test class for the DeleteTrustedProfileAssignmentOptions model.
+ */
+public class DeleteTrustedProfileAssignmentOptionsTest {
+  final HashMap<String, InputStream> mockStreamMap = TestUtilities.createMockStreamMap();
+  final List<FileWithMetadata> mockListFileWithMetadata = TestUtilities.creatMockListFileWithMetadata();
+
+  @Test
+  public void testDeleteTrustedProfileAssignmentOptions() throws Throwable {
+    DeleteTrustedProfileAssignmentOptions deleteTrustedProfileAssignmentOptionsModel = new DeleteTrustedProfileAssignmentOptions.Builder()
+      .assignmentId("testString")
+      .build();
+    assertEquals(deleteTrustedProfileAssignmentOptionsModel.assignmentId(), "testString");
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testDeleteTrustedProfileAssignmentOptionsError() throws Throwable {
+    new DeleteTrustedProfileAssignmentOptions.Builder().build();
+  }
+
+}

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/EnityHistoryRecordTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/EnityHistoryRecordTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/EntityActivityTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/EntityActivityTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ErrorTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ErrorTest.java
@@ -1,0 +1,40 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import com.ibm.cloud.platform_services.iam_identity.v1.model.Error;
+import com.ibm.cloud.platform_services.iam_identity.v1.utils.TestUtilities;
+import com.ibm.cloud.sdk.core.service.model.FileWithMetadata;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.List;
+import org.testng.annotations.Test;
+import static org.testng.Assert.*;
+
+/**
+ * Unit test class for the Error model.
+ */
+public class ErrorTest {
+  final HashMap<String, InputStream> mockStreamMap = TestUtilities.createMockStreamMap();
+  final List<FileWithMetadata> mockListFileWithMetadata = TestUtilities.creatMockListFileWithMetadata();
+
+  @Test
+  public void testError() throws Throwable {
+    Error errorModel = new Error();
+    assertNull(errorModel.getCode());
+    assertNull(errorModel.getMessageCode());
+    assertNull(errorModel.getMessage());
+    assertNull(errorModel.getDetails());
+  }
+}

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ExceptionResponseTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ExceptionResponseTest.java
@@ -1,0 +1,42 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import com.ibm.cloud.platform_services.iam_identity.v1.model.Error;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.ExceptionResponse;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.ResponseContext;
+import com.ibm.cloud.platform_services.iam_identity.v1.utils.TestUtilities;
+import com.ibm.cloud.sdk.core.service.model.FileWithMetadata;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.List;
+import org.testng.annotations.Test;
+import static org.testng.Assert.*;
+
+/**
+ * Unit test class for the ExceptionResponse model.
+ */
+public class ExceptionResponseTest {
+  final HashMap<String, InputStream> mockStreamMap = TestUtilities.createMockStreamMap();
+  final List<FileWithMetadata> mockListFileWithMetadata = TestUtilities.creatMockListFileWithMetadata();
+
+  @Test
+  public void testExceptionResponse() throws Throwable {
+    ExceptionResponse exceptionResponseModel = new ExceptionResponse();
+    assertNull(exceptionResponseModel.getContext());
+    assertNull(exceptionResponseModel.getStatusCode());
+    assertNull(exceptionResponseModel.getErrors());
+    assertNull(exceptionResponseModel.getTrace());
+  }
+}

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/GetAccountSettingsAssignmentOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/GetAccountSettingsAssignmentOptionsTest.java
@@ -1,0 +1,47 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import com.ibm.cloud.platform_services.iam_identity.v1.model.GetAccountSettingsAssignmentOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.utils.TestUtilities;
+import com.ibm.cloud.sdk.core.service.model.FileWithMetadata;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.List;
+import org.testng.annotations.Test;
+import static org.testng.Assert.*;
+
+/**
+ * Unit test class for the GetAccountSettingsAssignmentOptions model.
+ */
+public class GetAccountSettingsAssignmentOptionsTest {
+  final HashMap<String, InputStream> mockStreamMap = TestUtilities.createMockStreamMap();
+  final List<FileWithMetadata> mockListFileWithMetadata = TestUtilities.creatMockListFileWithMetadata();
+
+  @Test
+  public void testGetAccountSettingsAssignmentOptions() throws Throwable {
+    GetAccountSettingsAssignmentOptions getAccountSettingsAssignmentOptionsModel = new GetAccountSettingsAssignmentOptions.Builder()
+      .assignmentId("testString")
+      .includeHistory(false)
+      .build();
+    assertEquals(getAccountSettingsAssignmentOptionsModel.assignmentId(), "testString");
+    assertEquals(getAccountSettingsAssignmentOptionsModel.includeHistory(), Boolean.valueOf(false));
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testGetAccountSettingsAssignmentOptionsError() throws Throwable {
+    new GetAccountSettingsAssignmentOptions.Builder().build();
+  }
+
+}

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/GetAccountSettingsOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/GetAccountSettingsOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/GetAccountSettingsTemplateVersionOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/GetAccountSettingsTemplateVersionOptionsTest.java
@@ -1,0 +1,49 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import com.ibm.cloud.platform_services.iam_identity.v1.model.GetAccountSettingsTemplateVersionOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.utils.TestUtilities;
+import com.ibm.cloud.sdk.core.service.model.FileWithMetadata;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.List;
+import org.testng.annotations.Test;
+import static org.testng.Assert.*;
+
+/**
+ * Unit test class for the GetAccountSettingsTemplateVersionOptions model.
+ */
+public class GetAccountSettingsTemplateVersionOptionsTest {
+  final HashMap<String, InputStream> mockStreamMap = TestUtilities.createMockStreamMap();
+  final List<FileWithMetadata> mockListFileWithMetadata = TestUtilities.creatMockListFileWithMetadata();
+
+  @Test
+  public void testGetAccountSettingsTemplateVersionOptions() throws Throwable {
+    GetAccountSettingsTemplateVersionOptions getAccountSettingsTemplateVersionOptionsModel = new GetAccountSettingsTemplateVersionOptions.Builder()
+      .templateId("testString")
+      .version("testString")
+      .includeHistory(false)
+      .build();
+    assertEquals(getAccountSettingsTemplateVersionOptionsModel.templateId(), "testString");
+    assertEquals(getAccountSettingsTemplateVersionOptionsModel.version(), "testString");
+    assertEquals(getAccountSettingsTemplateVersionOptionsModel.includeHistory(), Boolean.valueOf(false));
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testGetAccountSettingsTemplateVersionOptionsError() throws Throwable {
+    new GetAccountSettingsTemplateVersionOptions.Builder().build();
+  }
+
+}

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/GetApiKeyOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/GetApiKeyOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/GetApiKeysDetailsOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/GetApiKeysDetailsOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/GetClaimRuleOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/GetClaimRuleOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/GetLatestAccountSettingsTemplateVersionOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/GetLatestAccountSettingsTemplateVersionOptionsTest.java
@@ -1,0 +1,47 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import com.ibm.cloud.platform_services.iam_identity.v1.model.GetLatestAccountSettingsTemplateVersionOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.utils.TestUtilities;
+import com.ibm.cloud.sdk.core.service.model.FileWithMetadata;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.List;
+import org.testng.annotations.Test;
+import static org.testng.Assert.*;
+
+/**
+ * Unit test class for the GetLatestAccountSettingsTemplateVersionOptions model.
+ */
+public class GetLatestAccountSettingsTemplateVersionOptionsTest {
+  final HashMap<String, InputStream> mockStreamMap = TestUtilities.createMockStreamMap();
+  final List<FileWithMetadata> mockListFileWithMetadata = TestUtilities.creatMockListFileWithMetadata();
+
+  @Test
+  public void testGetLatestAccountSettingsTemplateVersionOptions() throws Throwable {
+    GetLatestAccountSettingsTemplateVersionOptions getLatestAccountSettingsTemplateVersionOptionsModel = new GetLatestAccountSettingsTemplateVersionOptions.Builder()
+      .templateId("testString")
+      .includeHistory(false)
+      .build();
+    assertEquals(getLatestAccountSettingsTemplateVersionOptionsModel.templateId(), "testString");
+    assertEquals(getLatestAccountSettingsTemplateVersionOptionsModel.includeHistory(), Boolean.valueOf(false));
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testGetLatestAccountSettingsTemplateVersionOptionsError() throws Throwable {
+    new GetLatestAccountSettingsTemplateVersionOptions.Builder().build();
+  }
+
+}

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/GetLatestProfileTemplateVersionOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/GetLatestProfileTemplateVersionOptionsTest.java
@@ -1,0 +1,47 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import com.ibm.cloud.platform_services.iam_identity.v1.model.GetLatestProfileTemplateVersionOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.utils.TestUtilities;
+import com.ibm.cloud.sdk.core.service.model.FileWithMetadata;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.List;
+import org.testng.annotations.Test;
+import static org.testng.Assert.*;
+
+/**
+ * Unit test class for the GetLatestProfileTemplateVersionOptions model.
+ */
+public class GetLatestProfileTemplateVersionOptionsTest {
+  final HashMap<String, InputStream> mockStreamMap = TestUtilities.createMockStreamMap();
+  final List<FileWithMetadata> mockListFileWithMetadata = TestUtilities.creatMockListFileWithMetadata();
+
+  @Test
+  public void testGetLatestProfileTemplateVersionOptions() throws Throwable {
+    GetLatestProfileTemplateVersionOptions getLatestProfileTemplateVersionOptionsModel = new GetLatestProfileTemplateVersionOptions.Builder()
+      .templateId("testString")
+      .includeHistory(false)
+      .build();
+    assertEquals(getLatestProfileTemplateVersionOptionsModel.templateId(), "testString");
+    assertEquals(getLatestProfileTemplateVersionOptionsModel.includeHistory(), Boolean.valueOf(false));
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testGetLatestProfileTemplateVersionOptionsError() throws Throwable {
+    new GetLatestProfileTemplateVersionOptions.Builder().build();
+  }
+
+}

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/GetLatestTemplateVersionOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/GetLatestTemplateVersionOptionsTest.java
@@ -1,0 +1,47 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import com.ibm.cloud.platform_services.iam_identity.v1.model.GetLatestTemplateVersionOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.utils.TestUtilities;
+import com.ibm.cloud.sdk.core.service.model.FileWithMetadata;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.List;
+import org.testng.annotations.Test;
+import static org.testng.Assert.*;
+
+/**
+ * Unit test class for the GetLatestTemplateVersionOptions model.
+ */
+public class GetLatestTemplateVersionOptionsTest {
+  final HashMap<String, InputStream> mockStreamMap = TestUtilities.createMockStreamMap();
+  final List<FileWithMetadata> mockListFileWithMetadata = TestUtilities.creatMockListFileWithMetadata();
+
+  @Test
+  public void testGetLatestTemplateVersionOptions() throws Throwable {
+    GetLatestTemplateVersionOptions getLatestTemplateVersionOptionsModel = new GetLatestTemplateVersionOptions.Builder()
+      .templateId("testString")
+      .includeHistory(false)
+      .build();
+    assertEquals(getLatestTemplateVersionOptionsModel.templateId(), "testString");
+    assertEquals(getLatestTemplateVersionOptionsModel.includeHistory(), Boolean.valueOf(false));
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testGetLatestTemplateVersionOptionsError() throws Throwable {
+    new GetLatestTemplateVersionOptions.Builder().build();
+  }
+
+}

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/GetLinkOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/GetLinkOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/GetProfileOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/GetProfileOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/GetProfileTemplateVersionOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/GetProfileTemplateVersionOptionsTest.java
@@ -1,0 +1,49 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import com.ibm.cloud.platform_services.iam_identity.v1.model.GetProfileTemplateVersionOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.utils.TestUtilities;
+import com.ibm.cloud.sdk.core.service.model.FileWithMetadata;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.List;
+import org.testng.annotations.Test;
+import static org.testng.Assert.*;
+
+/**
+ * Unit test class for the GetProfileTemplateVersionOptions model.
+ */
+public class GetProfileTemplateVersionOptionsTest {
+  final HashMap<String, InputStream> mockStreamMap = TestUtilities.createMockStreamMap();
+  final List<FileWithMetadata> mockListFileWithMetadata = TestUtilities.creatMockListFileWithMetadata();
+
+  @Test
+  public void testGetProfileTemplateVersionOptions() throws Throwable {
+    GetProfileTemplateVersionOptions getProfileTemplateVersionOptionsModel = new GetProfileTemplateVersionOptions.Builder()
+      .templateId("testString")
+      .version("testString")
+      .includeHistory(false)
+      .build();
+    assertEquals(getProfileTemplateVersionOptionsModel.templateId(), "testString");
+    assertEquals(getProfileTemplateVersionOptionsModel.version(), "testString");
+    assertEquals(getProfileTemplateVersionOptionsModel.includeHistory(), Boolean.valueOf(false));
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testGetProfileTemplateVersionOptionsError() throws Throwable {
+    new GetProfileTemplateVersionOptions.Builder().build();
+  }
+
+}

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/GetReportOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/GetReportOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/GetServiceIdOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/GetServiceIdOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/GetTrustedProfileAssignmentOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/GetTrustedProfileAssignmentOptionsTest.java
@@ -1,0 +1,47 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import com.ibm.cloud.platform_services.iam_identity.v1.model.GetTrustedProfileAssignmentOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.utils.TestUtilities;
+import com.ibm.cloud.sdk.core.service.model.FileWithMetadata;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.List;
+import org.testng.annotations.Test;
+import static org.testng.Assert.*;
+
+/**
+ * Unit test class for the GetTrustedProfileAssignmentOptions model.
+ */
+public class GetTrustedProfileAssignmentOptionsTest {
+  final HashMap<String, InputStream> mockStreamMap = TestUtilities.createMockStreamMap();
+  final List<FileWithMetadata> mockListFileWithMetadata = TestUtilities.creatMockListFileWithMetadata();
+
+  @Test
+  public void testGetTrustedProfileAssignmentOptions() throws Throwable {
+    GetTrustedProfileAssignmentOptions getTrustedProfileAssignmentOptionsModel = new GetTrustedProfileAssignmentOptions.Builder()
+      .assignmentId("testString")
+      .includeHistory(false)
+      .build();
+    assertEquals(getTrustedProfileAssignmentOptionsModel.assignmentId(), "testString");
+    assertEquals(getTrustedProfileAssignmentOptionsModel.includeHistory(), Boolean.valueOf(false));
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testGetTrustedProfileAssignmentOptionsError() throws Throwable {
+    new GetTrustedProfileAssignmentOptions.Builder().build();
+  }
+
+}

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ListAccountSettingsAssignmentsOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ListAccountSettingsAssignmentsOptionsTest.java
@@ -1,0 +1,57 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import com.ibm.cloud.platform_services.iam_identity.v1.model.ListAccountSettingsAssignmentsOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.utils.TestUtilities;
+import com.ibm.cloud.sdk.core.service.model.FileWithMetadata;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.List;
+import org.testng.annotations.Test;
+import static org.testng.Assert.*;
+
+/**
+ * Unit test class for the ListAccountSettingsAssignmentsOptions model.
+ */
+public class ListAccountSettingsAssignmentsOptionsTest {
+  final HashMap<String, InputStream> mockStreamMap = TestUtilities.createMockStreamMap();
+  final List<FileWithMetadata> mockListFileWithMetadata = TestUtilities.creatMockListFileWithMetadata();
+
+  @Test
+  public void testListAccountSettingsAssignmentsOptions() throws Throwable {
+    ListAccountSettingsAssignmentsOptions listAccountSettingsAssignmentsOptionsModel = new ListAccountSettingsAssignmentsOptions.Builder()
+      .accountId("testString")
+      .templateId("testString")
+      .templateVersion("testString")
+      .target("testString")
+      .targetType("Account")
+      .limit(Long.valueOf("20"))
+      .pagetoken("testString")
+      .sort("created_at")
+      .order("asc")
+      .includeHistory(false)
+      .build();
+    assertEquals(listAccountSettingsAssignmentsOptionsModel.accountId(), "testString");
+    assertEquals(listAccountSettingsAssignmentsOptionsModel.templateId(), "testString");
+    assertEquals(listAccountSettingsAssignmentsOptionsModel.templateVersion(), "testString");
+    assertEquals(listAccountSettingsAssignmentsOptionsModel.target(), "testString");
+    assertEquals(listAccountSettingsAssignmentsOptionsModel.targetType(), "Account");
+    assertEquals(listAccountSettingsAssignmentsOptionsModel.limit(), Long.valueOf("20"));
+    assertEquals(listAccountSettingsAssignmentsOptionsModel.pagetoken(), "testString");
+    assertEquals(listAccountSettingsAssignmentsOptionsModel.sort(), "created_at");
+    assertEquals(listAccountSettingsAssignmentsOptionsModel.order(), "asc");
+    assertEquals(listAccountSettingsAssignmentsOptionsModel.includeHistory(), Boolean.valueOf(false));
+  }
+}

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ListAccountSettingsTemplatesOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ListAccountSettingsTemplatesOptionsTest.java
@@ -1,0 +1,49 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import com.ibm.cloud.platform_services.iam_identity.v1.model.ListAccountSettingsTemplatesOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.utils.TestUtilities;
+import com.ibm.cloud.sdk.core.service.model.FileWithMetadata;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.List;
+import org.testng.annotations.Test;
+import static org.testng.Assert.*;
+
+/**
+ * Unit test class for the ListAccountSettingsTemplatesOptions model.
+ */
+public class ListAccountSettingsTemplatesOptionsTest {
+  final HashMap<String, InputStream> mockStreamMap = TestUtilities.createMockStreamMap();
+  final List<FileWithMetadata> mockListFileWithMetadata = TestUtilities.creatMockListFileWithMetadata();
+
+  @Test
+  public void testListAccountSettingsTemplatesOptions() throws Throwable {
+    ListAccountSettingsTemplatesOptions listAccountSettingsTemplatesOptionsModel = new ListAccountSettingsTemplatesOptions.Builder()
+      .accountId("testString")
+      .limit("20")
+      .pagetoken("testString")
+      .sort("created_at")
+      .order("asc")
+      .includeHistory("false")
+      .build();
+    assertEquals(listAccountSettingsTemplatesOptionsModel.accountId(), "testString");
+    assertEquals(listAccountSettingsTemplatesOptionsModel.limit(), "20");
+    assertEquals(listAccountSettingsTemplatesOptionsModel.pagetoken(), "testString");
+    assertEquals(listAccountSettingsTemplatesOptionsModel.sort(), "created_at");
+    assertEquals(listAccountSettingsTemplatesOptionsModel.order(), "asc");
+    assertEquals(listAccountSettingsTemplatesOptionsModel.includeHistory(), "false");
+  }
+}

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ListApiKeysOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ListApiKeysOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ListClaimRulesOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ListClaimRulesOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ListLinksOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ListLinksOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ListProfileTemplatesOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ListProfileTemplatesOptionsTest.java
@@ -1,0 +1,49 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import com.ibm.cloud.platform_services.iam_identity.v1.model.ListProfileTemplatesOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.utils.TestUtilities;
+import com.ibm.cloud.sdk.core.service.model.FileWithMetadata;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.List;
+import org.testng.annotations.Test;
+import static org.testng.Assert.*;
+
+/**
+ * Unit test class for the ListProfileTemplatesOptions model.
+ */
+public class ListProfileTemplatesOptionsTest {
+  final HashMap<String, InputStream> mockStreamMap = TestUtilities.createMockStreamMap();
+  final List<FileWithMetadata> mockListFileWithMetadata = TestUtilities.creatMockListFileWithMetadata();
+
+  @Test
+  public void testListProfileTemplatesOptions() throws Throwable {
+    ListProfileTemplatesOptions listProfileTemplatesOptionsModel = new ListProfileTemplatesOptions.Builder()
+      .accountId("testString")
+      .limit("20")
+      .pagetoken("testString")
+      .sort("created_at")
+      .order("asc")
+      .includeHistory("false")
+      .build();
+    assertEquals(listProfileTemplatesOptionsModel.accountId(), "testString");
+    assertEquals(listProfileTemplatesOptionsModel.limit(), "20");
+    assertEquals(listProfileTemplatesOptionsModel.pagetoken(), "testString");
+    assertEquals(listProfileTemplatesOptionsModel.sort(), "created_at");
+    assertEquals(listProfileTemplatesOptionsModel.order(), "asc");
+    assertEquals(listProfileTemplatesOptionsModel.includeHistory(), "false");
+  }
+}

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ListProfilesOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ListProfilesOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ListServiceIdsOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ListServiceIdsOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ListTrustedProfileAssignmentsOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ListTrustedProfileAssignmentsOptionsTest.java
@@ -1,0 +1,57 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import com.ibm.cloud.platform_services.iam_identity.v1.model.ListTrustedProfileAssignmentsOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.utils.TestUtilities;
+import com.ibm.cloud.sdk.core.service.model.FileWithMetadata;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.List;
+import org.testng.annotations.Test;
+import static org.testng.Assert.*;
+
+/**
+ * Unit test class for the ListTrustedProfileAssignmentsOptions model.
+ */
+public class ListTrustedProfileAssignmentsOptionsTest {
+  final HashMap<String, InputStream> mockStreamMap = TestUtilities.createMockStreamMap();
+  final List<FileWithMetadata> mockListFileWithMetadata = TestUtilities.creatMockListFileWithMetadata();
+
+  @Test
+  public void testListTrustedProfileAssignmentsOptions() throws Throwable {
+    ListTrustedProfileAssignmentsOptions listTrustedProfileAssignmentsOptionsModel = new ListTrustedProfileAssignmentsOptions.Builder()
+      .accountId("testString")
+      .templateId("testString")
+      .templateVersion("testString")
+      .target("testString")
+      .targetType("Account")
+      .limit(Long.valueOf("20"))
+      .pagetoken("testString")
+      .sort("created_at")
+      .order("asc")
+      .includeHistory(false)
+      .build();
+    assertEquals(listTrustedProfileAssignmentsOptionsModel.accountId(), "testString");
+    assertEquals(listTrustedProfileAssignmentsOptionsModel.templateId(), "testString");
+    assertEquals(listTrustedProfileAssignmentsOptionsModel.templateVersion(), "testString");
+    assertEquals(listTrustedProfileAssignmentsOptionsModel.target(), "testString");
+    assertEquals(listTrustedProfileAssignmentsOptionsModel.targetType(), "Account");
+    assertEquals(listTrustedProfileAssignmentsOptionsModel.limit(), Long.valueOf("20"));
+    assertEquals(listTrustedProfileAssignmentsOptionsModel.pagetoken(), "testString");
+    assertEquals(listTrustedProfileAssignmentsOptionsModel.sort(), "created_at");
+    assertEquals(listTrustedProfileAssignmentsOptionsModel.order(), "asc");
+    assertEquals(listTrustedProfileAssignmentsOptionsModel.includeHistory(), Boolean.valueOf(false));
+  }
+}

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ListVersionsOfAccountSettingsTemplateOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ListVersionsOfAccountSettingsTemplateOptionsTest.java
@@ -1,0 +1,55 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import com.ibm.cloud.platform_services.iam_identity.v1.model.ListVersionsOfAccountSettingsTemplateOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.utils.TestUtilities;
+import com.ibm.cloud.sdk.core.service.model.FileWithMetadata;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.List;
+import org.testng.annotations.Test;
+import static org.testng.Assert.*;
+
+/**
+ * Unit test class for the ListVersionsOfAccountSettingsTemplateOptions model.
+ */
+public class ListVersionsOfAccountSettingsTemplateOptionsTest {
+  final HashMap<String, InputStream> mockStreamMap = TestUtilities.createMockStreamMap();
+  final List<FileWithMetadata> mockListFileWithMetadata = TestUtilities.creatMockListFileWithMetadata();
+
+  @Test
+  public void testListVersionsOfAccountSettingsTemplateOptions() throws Throwable {
+    ListVersionsOfAccountSettingsTemplateOptions listVersionsOfAccountSettingsTemplateOptionsModel = new ListVersionsOfAccountSettingsTemplateOptions.Builder()
+      .templateId("testString")
+      .limit("20")
+      .pagetoken("testString")
+      .sort("created_at")
+      .order("asc")
+      .includeHistory("false")
+      .build();
+    assertEquals(listVersionsOfAccountSettingsTemplateOptionsModel.templateId(), "testString");
+    assertEquals(listVersionsOfAccountSettingsTemplateOptionsModel.limit(), "20");
+    assertEquals(listVersionsOfAccountSettingsTemplateOptionsModel.pagetoken(), "testString");
+    assertEquals(listVersionsOfAccountSettingsTemplateOptionsModel.sort(), "created_at");
+    assertEquals(listVersionsOfAccountSettingsTemplateOptionsModel.order(), "asc");
+    assertEquals(listVersionsOfAccountSettingsTemplateOptionsModel.includeHistory(), "false");
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testListVersionsOfAccountSettingsTemplateOptionsError() throws Throwable {
+    new ListVersionsOfAccountSettingsTemplateOptions.Builder().build();
+  }
+
+}

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ListVersionsOfProfileTemplateOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ListVersionsOfProfileTemplateOptionsTest.java
@@ -1,0 +1,55 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import com.ibm.cloud.platform_services.iam_identity.v1.model.ListVersionsOfProfileTemplateOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.utils.TestUtilities;
+import com.ibm.cloud.sdk.core.service.model.FileWithMetadata;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.List;
+import org.testng.annotations.Test;
+import static org.testng.Assert.*;
+
+/**
+ * Unit test class for the ListVersionsOfProfileTemplateOptions model.
+ */
+public class ListVersionsOfProfileTemplateOptionsTest {
+  final HashMap<String, InputStream> mockStreamMap = TestUtilities.createMockStreamMap();
+  final List<FileWithMetadata> mockListFileWithMetadata = TestUtilities.creatMockListFileWithMetadata();
+
+  @Test
+  public void testListVersionsOfProfileTemplateOptions() throws Throwable {
+    ListVersionsOfProfileTemplateOptions listVersionsOfProfileTemplateOptionsModel = new ListVersionsOfProfileTemplateOptions.Builder()
+      .templateId("testString")
+      .limit("20")
+      .pagetoken("testString")
+      .sort("created_at")
+      .order("asc")
+      .includeHistory("false")
+      .build();
+    assertEquals(listVersionsOfProfileTemplateOptionsModel.templateId(), "testString");
+    assertEquals(listVersionsOfProfileTemplateOptionsModel.limit(), "20");
+    assertEquals(listVersionsOfProfileTemplateOptionsModel.pagetoken(), "testString");
+    assertEquals(listVersionsOfProfileTemplateOptionsModel.sort(), "created_at");
+    assertEquals(listVersionsOfProfileTemplateOptionsModel.order(), "asc");
+    assertEquals(listVersionsOfProfileTemplateOptionsModel.includeHistory(), "false");
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testListVersionsOfProfileTemplateOptionsError() throws Throwable {
+    new ListVersionsOfProfileTemplateOptions.Builder().build();
+  }
+
+}

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/LockApiKeyOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/LockApiKeyOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/LockServiceIdOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/LockServiceIdOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/PolicyTemplateReferenceTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/PolicyTemplateReferenceTest.java
@@ -1,0 +1,54 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import com.ibm.cloud.platform_services.iam_identity.v1.model.PolicyTemplateReference;
+import com.ibm.cloud.platform_services.iam_identity.v1.utils.TestUtilities;
+import com.ibm.cloud.sdk.core.service.model.FileWithMetadata;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.List;
+import org.testng.annotations.Test;
+import static org.testng.Assert.*;
+
+/**
+ * Unit test class for the PolicyTemplateReference model.
+ */
+public class PolicyTemplateReferenceTest {
+  final HashMap<String, InputStream> mockStreamMap = TestUtilities.createMockStreamMap();
+  final List<FileWithMetadata> mockListFileWithMetadata = TestUtilities.creatMockListFileWithMetadata();
+
+  @Test
+  public void testPolicyTemplateReference() throws Throwable {
+    PolicyTemplateReference policyTemplateReferenceModel = new PolicyTemplateReference.Builder()
+      .id("testString")
+      .version("testString")
+      .build();
+    assertEquals(policyTemplateReferenceModel.id(), "testString");
+    assertEquals(policyTemplateReferenceModel.version(), "testString");
+
+    String json = TestUtilities.serialize(policyTemplateReferenceModel);
+
+    PolicyTemplateReference policyTemplateReferenceModelNew = TestUtilities.deserialize(json, PolicyTemplateReference.class);
+    assertTrue(policyTemplateReferenceModelNew instanceof PolicyTemplateReference);
+    assertEquals(policyTemplateReferenceModelNew.id(), "testString");
+    assertEquals(policyTemplateReferenceModelNew.version(), "testString");
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testPolicyTemplateReferenceError() throws Throwable {
+    new PolicyTemplateReference.Builder().build();
+  }
+
+}

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ProfileClaimRuleConditionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ProfileClaimRuleConditionsTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ProfileClaimRuleListTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ProfileClaimRuleListTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ProfileClaimRuleTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ProfileClaimRuleTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ProfileIdentitiesResponseTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ProfileIdentitiesResponseTest.java
@@ -14,7 +14,7 @@
 package com.ibm.cloud.platform_services.iam_identity.v1.model;
 
 import com.ibm.cloud.platform_services.iam_identity.v1.model.ProfileIdentitiesResponse;
-import com.ibm.cloud.platform_services.iam_identity.v1.model.ProfileIdentity;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.ProfileIdentityResponse;
 import com.ibm.cloud.platform_services.iam_identity.v1.utils.TestUtilities;
 import com.ibm.cloud.sdk.core.service.model.FileWithMetadata;
 import java.io.InputStream;

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ProfileIdentityRequestTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ProfileIdentityRequestTest.java
@@ -13,7 +13,7 @@
 
 package com.ibm.cloud.platform_services.iam_identity.v1.model;
 
-import com.ibm.cloud.platform_services.iam_identity.v1.model.ProfileIdentity;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.ProfileIdentityRequest;
 import com.ibm.cloud.platform_services.iam_identity.v1.utils.TestUtilities;
 import com.ibm.cloud.sdk.core.service.model.FileWithMetadata;
 import java.io.InputStream;
@@ -23,40 +23,37 @@ import org.testng.annotations.Test;
 import static org.testng.Assert.*;
 
 /**
- * Unit test class for the ProfileIdentity model.
+ * Unit test class for the ProfileIdentityRequest model.
  */
-public class ProfileIdentityTest {
+public class ProfileIdentityRequestTest {
   final HashMap<String, InputStream> mockStreamMap = TestUtilities.createMockStreamMap();
   final List<FileWithMetadata> mockListFileWithMetadata = TestUtilities.creatMockListFileWithMetadata();
 
   @Test
-  public void testProfileIdentity() throws Throwable {
-    ProfileIdentity profileIdentityModel = new ProfileIdentity.Builder()
-      .iamId("testString")
+  public void testProfileIdentityRequest() throws Throwable {
+    ProfileIdentityRequest profileIdentityRequestModel = new ProfileIdentityRequest.Builder()
       .identifier("testString")
       .type("user")
       .accounts(java.util.Arrays.asList("testString"))
       .description("testString")
       .build();
-    assertEquals(profileIdentityModel.iamId(), "testString");
-    assertEquals(profileIdentityModel.identifier(), "testString");
-    assertEquals(profileIdentityModel.type(), "user");
-    assertEquals(profileIdentityModel.accounts(), java.util.Arrays.asList("testString"));
-    assertEquals(profileIdentityModel.description(), "testString");
+    assertEquals(profileIdentityRequestModel.identifier(), "testString");
+    assertEquals(profileIdentityRequestModel.type(), "user");
+    assertEquals(profileIdentityRequestModel.accounts(), java.util.Arrays.asList("testString"));
+    assertEquals(profileIdentityRequestModel.description(), "testString");
 
-    String json = TestUtilities.serialize(profileIdentityModel);
+    String json = TestUtilities.serialize(profileIdentityRequestModel);
 
-    ProfileIdentity profileIdentityModelNew = TestUtilities.deserialize(json, ProfileIdentity.class);
-    assertTrue(profileIdentityModelNew instanceof ProfileIdentity);
-    assertEquals(profileIdentityModelNew.iamId(), "testString");
-    assertEquals(profileIdentityModelNew.identifier(), "testString");
-    assertEquals(profileIdentityModelNew.type(), "user");
-    assertEquals(profileIdentityModelNew.description(), "testString");
+    ProfileIdentityRequest profileIdentityRequestModelNew = TestUtilities.deserialize(json, ProfileIdentityRequest.class);
+    assertTrue(profileIdentityRequestModelNew instanceof ProfileIdentityRequest);
+    assertEquals(profileIdentityRequestModelNew.identifier(), "testString");
+    assertEquals(profileIdentityRequestModelNew.type(), "user");
+    assertEquals(profileIdentityRequestModelNew.description(), "testString");
   }
 
   @Test(expectedExceptions = IllegalArgumentException.class)
-  public void testProfileIdentityError() throws Throwable {
-    new ProfileIdentity.Builder().build();
+  public void testProfileIdentityRequestError() throws Throwable {
+    new ProfileIdentityRequest.Builder().build();
   }
 
 }

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ProfileIdentityResponseTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ProfileIdentityResponseTest.java
@@ -1,0 +1,41 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import com.ibm.cloud.platform_services.iam_identity.v1.model.ProfileIdentityResponse;
+import com.ibm.cloud.platform_services.iam_identity.v1.utils.TestUtilities;
+import com.ibm.cloud.sdk.core.service.model.FileWithMetadata;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.List;
+import org.testng.annotations.Test;
+import static org.testng.Assert.*;
+
+/**
+ * Unit test class for the ProfileIdentityResponse model.
+ */
+public class ProfileIdentityResponseTest {
+  final HashMap<String, InputStream> mockStreamMap = TestUtilities.createMockStreamMap();
+  final List<FileWithMetadata> mockListFileWithMetadata = TestUtilities.creatMockListFileWithMetadata();
+
+  @Test
+  public void testProfileIdentityResponse() throws Throwable {
+    ProfileIdentityResponse profileIdentityResponseModel = new ProfileIdentityResponse();
+    assertNull(profileIdentityResponseModel.getIamId());
+    assertNull(profileIdentityResponseModel.getIdentifier());
+    assertNull(profileIdentityResponseModel.getType());
+    assertNull(profileIdentityResponseModel.getAccounts());
+    assertNull(profileIdentityResponseModel.getDescription());
+  }
+}

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ProfileLinkLinkTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ProfileLinkLinkTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ProfileLinkListTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ProfileLinkListTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ProfileLinkTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ProfileLinkTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ReportReferenceTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ReportReferenceTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ReportTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ReportTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ResponseContextTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ResponseContextTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ServiceIdListTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ServiceIdListTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ServiceIdTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/ServiceIdTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/SetProfileIdentitiesOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/SetProfileIdentitiesOptionsTest.java
@@ -13,7 +13,7 @@
 
 package com.ibm.cloud.platform_services.iam_identity.v1.model;
 
-import com.ibm.cloud.platform_services.iam_identity.v1.model.ProfileIdentity;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.ProfileIdentityRequest;
 import com.ibm.cloud.platform_services.iam_identity.v1.model.SetProfileIdentitiesOptions;
 import com.ibm.cloud.platform_services.iam_identity.v1.utils.TestUtilities;
 import com.ibm.cloud.sdk.core.service.model.FileWithMetadata;
@@ -32,27 +32,25 @@ public class SetProfileIdentitiesOptionsTest {
 
   @Test
   public void testSetProfileIdentitiesOptions() throws Throwable {
-    ProfileIdentity profileIdentityModel = new ProfileIdentity.Builder()
-      .iamId("testString")
+    ProfileIdentityRequest profileIdentityRequestModel = new ProfileIdentityRequest.Builder()
       .identifier("testString")
       .type("user")
       .accounts(java.util.Arrays.asList("testString"))
       .description("testString")
       .build();
-    assertEquals(profileIdentityModel.iamId(), "testString");
-    assertEquals(profileIdentityModel.identifier(), "testString");
-    assertEquals(profileIdentityModel.type(), "user");
-    assertEquals(profileIdentityModel.accounts(), java.util.Arrays.asList("testString"));
-    assertEquals(profileIdentityModel.description(), "testString");
+    assertEquals(profileIdentityRequestModel.identifier(), "testString");
+    assertEquals(profileIdentityRequestModel.type(), "user");
+    assertEquals(profileIdentityRequestModel.accounts(), java.util.Arrays.asList("testString"));
+    assertEquals(profileIdentityRequestModel.description(), "testString");
 
     SetProfileIdentitiesOptions setProfileIdentitiesOptionsModel = new SetProfileIdentitiesOptions.Builder()
       .profileId("testString")
       .ifMatch("testString")
-      .identities(java.util.Arrays.asList(profileIdentityModel))
+      .identities(java.util.Arrays.asList(profileIdentityRequestModel))
       .build();
     assertEquals(setProfileIdentitiesOptionsModel.profileId(), "testString");
     assertEquals(setProfileIdentitiesOptionsModel.ifMatch(), "testString");
-    assertEquals(setProfileIdentitiesOptionsModel.identities(), java.util.Arrays.asList(profileIdentityModel));
+    assertEquals(setProfileIdentitiesOptionsModel.identities(), java.util.Arrays.asList(profileIdentityRequestModel));
   }
 
   @Test(expectedExceptions = IllegalArgumentException.class)

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/SetProfileIdentityOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/SetProfileIdentityOptionsTest.java
@@ -36,7 +36,6 @@ public class SetProfileIdentityOptionsTest {
       .identityType("user")
       .identifier("testString")
       .type("user")
-      .iamId("testString")
       .accounts(java.util.Arrays.asList("testString"))
       .description("testString")
       .build();
@@ -44,7 +43,6 @@ public class SetProfileIdentityOptionsTest {
     assertEquals(setProfileIdentityOptionsModel.identityType(), "user");
     assertEquals(setProfileIdentityOptionsModel.identifier(), "testString");
     assertEquals(setProfileIdentityOptionsModel.type(), "user");
-    assertEquals(setProfileIdentityOptionsModel.iamId(), "testString");
     assertEquals(setProfileIdentityOptionsModel.accounts(), java.util.Arrays.asList("testString"));
     assertEquals(setProfileIdentityOptionsModel.description(), "testString");
   }

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/TemplateAssignmentListResponseTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/TemplateAssignmentListResponseTest.java
@@ -1,0 +1,50 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import com.ibm.cloud.platform_services.iam_identity.v1.model.EnityHistoryRecord;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.ResponseContext;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.TemplateAssignmentListResponse;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.TemplateAssignmentResource;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.TemplateAssignmentResourceError;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.TemplateAssignmentResponse;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.TemplateAssignmentResponseResource;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.TemplateAssignmentResponseResourceDetail;
+import com.ibm.cloud.platform_services.iam_identity.v1.utils.TestUtilities;
+import com.ibm.cloud.sdk.core.service.model.FileWithMetadata;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.List;
+import org.testng.annotations.Test;
+import static org.testng.Assert.*;
+
+/**
+ * Unit test class for the TemplateAssignmentListResponse model.
+ */
+public class TemplateAssignmentListResponseTest {
+  final HashMap<String, InputStream> mockStreamMap = TestUtilities.createMockStreamMap();
+  final List<FileWithMetadata> mockListFileWithMetadata = TestUtilities.creatMockListFileWithMetadata();
+
+  @Test
+  public void testTemplateAssignmentListResponse() throws Throwable {
+    TemplateAssignmentListResponse templateAssignmentListResponseModel = new TemplateAssignmentListResponse();
+    assertNull(templateAssignmentListResponseModel.getContext());
+    assertNull(templateAssignmentListResponseModel.getOffset());
+    assertNull(templateAssignmentListResponseModel.getLimit());
+    assertNull(templateAssignmentListResponseModel.getFirst());
+    assertNull(templateAssignmentListResponseModel.getPrevious());
+    assertNull(templateAssignmentListResponseModel.getNext());
+    assertNull(templateAssignmentListResponseModel.getAssignments());
+  }
+}

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/TemplateAssignmentResourceErrorTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/TemplateAssignmentResourceErrorTest.java
@@ -1,0 +1,40 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import com.ibm.cloud.platform_services.iam_identity.v1.model.TemplateAssignmentResourceError;
+import com.ibm.cloud.platform_services.iam_identity.v1.utils.TestUtilities;
+import com.ibm.cloud.sdk.core.service.model.FileWithMetadata;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.List;
+import org.testng.annotations.Test;
+import static org.testng.Assert.*;
+
+/**
+ * Unit test class for the TemplateAssignmentResourceError model.
+ */
+public class TemplateAssignmentResourceErrorTest {
+  final HashMap<String, InputStream> mockStreamMap = TestUtilities.createMockStreamMap();
+  final List<FileWithMetadata> mockListFileWithMetadata = TestUtilities.creatMockListFileWithMetadata();
+
+  @Test
+  public void testTemplateAssignmentResourceError() throws Throwable {
+    TemplateAssignmentResourceError templateAssignmentResourceErrorModel = new TemplateAssignmentResourceError();
+    assertNull(templateAssignmentResourceErrorModel.getName());
+    assertNull(templateAssignmentResourceErrorModel.getErrorCode());
+    assertNull(templateAssignmentResourceErrorModel.getMessage());
+    assertNull(templateAssignmentResourceErrorModel.getStatusCode());
+  }
+}

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/TemplateAssignmentResourceTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/TemplateAssignmentResourceTest.java
@@ -1,0 +1,37 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import com.ibm.cloud.platform_services.iam_identity.v1.model.TemplateAssignmentResource;
+import com.ibm.cloud.platform_services.iam_identity.v1.utils.TestUtilities;
+import com.ibm.cloud.sdk.core.service.model.FileWithMetadata;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.List;
+import org.testng.annotations.Test;
+import static org.testng.Assert.*;
+
+/**
+ * Unit test class for the TemplateAssignmentResource model.
+ */
+public class TemplateAssignmentResourceTest {
+  final HashMap<String, InputStream> mockStreamMap = TestUtilities.createMockStreamMap();
+  final List<FileWithMetadata> mockListFileWithMetadata = TestUtilities.creatMockListFileWithMetadata();
+
+  @Test
+  public void testTemplateAssignmentResource() throws Throwable {
+    TemplateAssignmentResource templateAssignmentResourceModel = new TemplateAssignmentResource();
+    assertNull(templateAssignmentResourceModel.getId());
+  }
+}

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/TemplateAssignmentResponseResourceDetailTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/TemplateAssignmentResponseResourceDetailTest.java
@@ -1,0 +1,43 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import com.ibm.cloud.platform_services.iam_identity.v1.model.TemplateAssignmentResource;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.TemplateAssignmentResourceError;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.TemplateAssignmentResponseResourceDetail;
+import com.ibm.cloud.platform_services.iam_identity.v1.utils.TestUtilities;
+import com.ibm.cloud.sdk.core.service.model.FileWithMetadata;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.List;
+import org.testng.annotations.Test;
+import static org.testng.Assert.*;
+
+/**
+ * Unit test class for the TemplateAssignmentResponseResourceDetail model.
+ */
+public class TemplateAssignmentResponseResourceDetailTest {
+  final HashMap<String, InputStream> mockStreamMap = TestUtilities.createMockStreamMap();
+  final List<FileWithMetadata> mockListFileWithMetadata = TestUtilities.creatMockListFileWithMetadata();
+
+  @Test
+  public void testTemplateAssignmentResponseResourceDetail() throws Throwable {
+    TemplateAssignmentResponseResourceDetail templateAssignmentResponseResourceDetailModel = new TemplateAssignmentResponseResourceDetail();
+    assertNull(templateAssignmentResponseResourceDetailModel.getId());
+    assertNull(templateAssignmentResponseResourceDetailModel.getVersion());
+    assertNull(templateAssignmentResponseResourceDetailModel.getResourceCreated());
+    assertNull(templateAssignmentResponseResourceDetailModel.getErrorMessage());
+    assertNull(templateAssignmentResponseResourceDetailModel.getStatus());
+  }
+}

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/TemplateAssignmentResponseResourceTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/TemplateAssignmentResponseResourceTest.java
@@ -1,0 +1,43 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import com.ibm.cloud.platform_services.iam_identity.v1.model.TemplateAssignmentResource;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.TemplateAssignmentResourceError;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.TemplateAssignmentResponseResource;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.TemplateAssignmentResponseResourceDetail;
+import com.ibm.cloud.platform_services.iam_identity.v1.utils.TestUtilities;
+import com.ibm.cloud.sdk.core.service.model.FileWithMetadata;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.List;
+import org.testng.annotations.Test;
+import static org.testng.Assert.*;
+
+/**
+ * Unit test class for the TemplateAssignmentResponseResource model.
+ */
+public class TemplateAssignmentResponseResourceTest {
+  final HashMap<String, InputStream> mockStreamMap = TestUtilities.createMockStreamMap();
+  final List<FileWithMetadata> mockListFileWithMetadata = TestUtilities.creatMockListFileWithMetadata();
+
+  @Test
+  public void testTemplateAssignmentResponseResource() throws Throwable {
+    TemplateAssignmentResponseResource templateAssignmentResponseResourceModel = new TemplateAssignmentResponseResource();
+    assertNull(templateAssignmentResponseResourceModel.getTarget());
+    assertNull(templateAssignmentResponseResourceModel.getProfile());
+    assertNull(templateAssignmentResponseResourceModel.getAccountSettings());
+    assertNull(templateAssignmentResponseResourceModel.getPolicyTemplateRefs());
+  }
+}

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/TemplateAssignmentResponseTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/TemplateAssignmentResponseTest.java
@@ -1,0 +1,58 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import com.ibm.cloud.platform_services.iam_identity.v1.model.EnityHistoryRecord;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.ResponseContext;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.TemplateAssignmentResource;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.TemplateAssignmentResourceError;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.TemplateAssignmentResponse;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.TemplateAssignmentResponseResource;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.TemplateAssignmentResponseResourceDetail;
+import com.ibm.cloud.platform_services.iam_identity.v1.utils.TestUtilities;
+import com.ibm.cloud.sdk.core.service.model.FileWithMetadata;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.List;
+import org.testng.annotations.Test;
+import static org.testng.Assert.*;
+
+/**
+ * Unit test class for the TemplateAssignmentResponse model.
+ */
+public class TemplateAssignmentResponseTest {
+  final HashMap<String, InputStream> mockStreamMap = TestUtilities.createMockStreamMap();
+  final List<FileWithMetadata> mockListFileWithMetadata = TestUtilities.creatMockListFileWithMetadata();
+
+  @Test
+  public void testTemplateAssignmentResponse() throws Throwable {
+    TemplateAssignmentResponse templateAssignmentResponseModel = new TemplateAssignmentResponse();
+    assertNull(templateAssignmentResponseModel.getContext());
+    assertNull(templateAssignmentResponseModel.getId());
+    assertNull(templateAssignmentResponseModel.getAccountId());
+    assertNull(templateAssignmentResponseModel.getTemplateId());
+    assertNull(templateAssignmentResponseModel.getTemplateVersion());
+    assertNull(templateAssignmentResponseModel.getTargetType());
+    assertNull(templateAssignmentResponseModel.getTarget());
+    assertNull(templateAssignmentResponseModel.getStatus());
+    assertNull(templateAssignmentResponseModel.getResources());
+    assertNull(templateAssignmentResponseModel.getHistory());
+    assertNull(templateAssignmentResponseModel.getHref());
+    assertNull(templateAssignmentResponseModel.getCreatedAt());
+    assertNull(templateAssignmentResponseModel.getCreatedById());
+    assertNull(templateAssignmentResponseModel.getLastModifiedAt());
+    assertNull(templateAssignmentResponseModel.getLastModifiedById());
+    assertNull(templateAssignmentResponseModel.getEntityTag());
+  }
+}

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/TemplateProfileComponentRequestTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/TemplateProfileComponentRequestTest.java
@@ -1,0 +1,94 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import com.ibm.cloud.platform_services.iam_identity.v1.model.ProfileClaimRuleConditions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.ProfileIdentityRequest;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.TemplateProfileComponentRequest;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.TrustedProfileTemplateClaimRule;
+import com.ibm.cloud.platform_services.iam_identity.v1.utils.TestUtilities;
+import com.ibm.cloud.sdk.core.service.model.FileWithMetadata;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.List;
+import org.testng.annotations.Test;
+import static org.testng.Assert.*;
+
+/**
+ * Unit test class for the TemplateProfileComponentRequest model.
+ */
+public class TemplateProfileComponentRequestTest {
+  final HashMap<String, InputStream> mockStreamMap = TestUtilities.createMockStreamMap();
+  final List<FileWithMetadata> mockListFileWithMetadata = TestUtilities.creatMockListFileWithMetadata();
+
+  @Test
+  public void testTemplateProfileComponentRequest() throws Throwable {
+    ProfileClaimRuleConditions profileClaimRuleConditionsModel = new ProfileClaimRuleConditions.Builder()
+      .claim("testString")
+      .operator("testString")
+      .value("testString")
+      .build();
+    assertEquals(profileClaimRuleConditionsModel.claim(), "testString");
+    assertEquals(profileClaimRuleConditionsModel.operator(), "testString");
+    assertEquals(profileClaimRuleConditionsModel.value(), "testString");
+
+    TrustedProfileTemplateClaimRule trustedProfileTemplateClaimRuleModel = new TrustedProfileTemplateClaimRule.Builder()
+      .name("testString")
+      .type("Profile-SAML")
+      .realmName("testString")
+      .expiration(Long.valueOf("26"))
+      .conditions(java.util.Arrays.asList(profileClaimRuleConditionsModel))
+      .build();
+    assertEquals(trustedProfileTemplateClaimRuleModel.name(), "testString");
+    assertEquals(trustedProfileTemplateClaimRuleModel.type(), "Profile-SAML");
+    assertEquals(trustedProfileTemplateClaimRuleModel.realmName(), "testString");
+    assertEquals(trustedProfileTemplateClaimRuleModel.expiration(), Long.valueOf("26"));
+    assertEquals(trustedProfileTemplateClaimRuleModel.conditions(), java.util.Arrays.asList(profileClaimRuleConditionsModel));
+
+    ProfileIdentityRequest profileIdentityRequestModel = new ProfileIdentityRequest.Builder()
+      .identifier("testString")
+      .type("user")
+      .accounts(java.util.Arrays.asList("testString"))
+      .description("testString")
+      .build();
+    assertEquals(profileIdentityRequestModel.identifier(), "testString");
+    assertEquals(profileIdentityRequestModel.type(), "user");
+    assertEquals(profileIdentityRequestModel.accounts(), java.util.Arrays.asList("testString"));
+    assertEquals(profileIdentityRequestModel.description(), "testString");
+
+    TemplateProfileComponentRequest templateProfileComponentRequestModel = new TemplateProfileComponentRequest.Builder()
+      .name("testString")
+      .description("testString")
+      .rules(java.util.Arrays.asList(trustedProfileTemplateClaimRuleModel))
+      .identities(java.util.Arrays.asList(profileIdentityRequestModel))
+      .build();
+    assertEquals(templateProfileComponentRequestModel.name(), "testString");
+    assertEquals(templateProfileComponentRequestModel.description(), "testString");
+    assertEquals(templateProfileComponentRequestModel.rules(), java.util.Arrays.asList(trustedProfileTemplateClaimRuleModel));
+    assertEquals(templateProfileComponentRequestModel.identities(), java.util.Arrays.asList(profileIdentityRequestModel));
+
+    String json = TestUtilities.serialize(templateProfileComponentRequestModel);
+
+    TemplateProfileComponentRequest templateProfileComponentRequestModelNew = TestUtilities.deserialize(json, TemplateProfileComponentRequest.class);
+    assertTrue(templateProfileComponentRequestModelNew instanceof TemplateProfileComponentRequest);
+    assertEquals(templateProfileComponentRequestModelNew.name(), "testString");
+    assertEquals(templateProfileComponentRequestModelNew.description(), "testString");
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testTemplateProfileComponentRequestError() throws Throwable {
+    new TemplateProfileComponentRequest.Builder().build();
+  }
+
+}

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/TemplateProfileComponentResponseTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/TemplateProfileComponentResponseTest.java
@@ -1,0 +1,43 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import com.ibm.cloud.platform_services.iam_identity.v1.model.ProfileClaimRuleConditions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.ProfileIdentityResponse;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.TemplateProfileComponentResponse;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.TrustedProfileTemplateClaimRule;
+import com.ibm.cloud.platform_services.iam_identity.v1.utils.TestUtilities;
+import com.ibm.cloud.sdk.core.service.model.FileWithMetadata;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.List;
+import org.testng.annotations.Test;
+import static org.testng.Assert.*;
+
+/**
+ * Unit test class for the TemplateProfileComponentResponse model.
+ */
+public class TemplateProfileComponentResponseTest {
+  final HashMap<String, InputStream> mockStreamMap = TestUtilities.createMockStreamMap();
+  final List<FileWithMetadata> mockListFileWithMetadata = TestUtilities.creatMockListFileWithMetadata();
+
+  @Test
+  public void testTemplateProfileComponentResponse() throws Throwable {
+    TemplateProfileComponentResponse templateProfileComponentResponseModel = new TemplateProfileComponentResponse();
+    assertNull(templateProfileComponentResponseModel.getName());
+    assertNull(templateProfileComponentResponseModel.getDescription());
+    assertNull(templateProfileComponentResponseModel.getRules());
+    assertNull(templateProfileComponentResponseModel.getIdentities());
+  }
+}

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/TrustedProfileTemplateClaimRuleTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/TrustedProfileTemplateClaimRuleTest.java
@@ -1,0 +1,72 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import com.ibm.cloud.platform_services.iam_identity.v1.model.ProfileClaimRuleConditions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.TrustedProfileTemplateClaimRule;
+import com.ibm.cloud.platform_services.iam_identity.v1.utils.TestUtilities;
+import com.ibm.cloud.sdk.core.service.model.FileWithMetadata;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.List;
+import org.testng.annotations.Test;
+import static org.testng.Assert.*;
+
+/**
+ * Unit test class for the TrustedProfileTemplateClaimRule model.
+ */
+public class TrustedProfileTemplateClaimRuleTest {
+  final HashMap<String, InputStream> mockStreamMap = TestUtilities.createMockStreamMap();
+  final List<FileWithMetadata> mockListFileWithMetadata = TestUtilities.creatMockListFileWithMetadata();
+
+  @Test
+  public void testTrustedProfileTemplateClaimRule() throws Throwable {
+    ProfileClaimRuleConditions profileClaimRuleConditionsModel = new ProfileClaimRuleConditions.Builder()
+      .claim("testString")
+      .operator("testString")
+      .value("testString")
+      .build();
+    assertEquals(profileClaimRuleConditionsModel.claim(), "testString");
+    assertEquals(profileClaimRuleConditionsModel.operator(), "testString");
+    assertEquals(profileClaimRuleConditionsModel.value(), "testString");
+
+    TrustedProfileTemplateClaimRule trustedProfileTemplateClaimRuleModel = new TrustedProfileTemplateClaimRule.Builder()
+      .name("testString")
+      .type("Profile-SAML")
+      .realmName("testString")
+      .expiration(Long.valueOf("26"))
+      .conditions(java.util.Arrays.asList(profileClaimRuleConditionsModel))
+      .build();
+    assertEquals(trustedProfileTemplateClaimRuleModel.name(), "testString");
+    assertEquals(trustedProfileTemplateClaimRuleModel.type(), "Profile-SAML");
+    assertEquals(trustedProfileTemplateClaimRuleModel.realmName(), "testString");
+    assertEquals(trustedProfileTemplateClaimRuleModel.expiration(), Long.valueOf("26"));
+    assertEquals(trustedProfileTemplateClaimRuleModel.conditions(), java.util.Arrays.asList(profileClaimRuleConditionsModel));
+
+    String json = TestUtilities.serialize(trustedProfileTemplateClaimRuleModel);
+
+    TrustedProfileTemplateClaimRule trustedProfileTemplateClaimRuleModelNew = TestUtilities.deserialize(json, TrustedProfileTemplateClaimRule.class);
+    assertTrue(trustedProfileTemplateClaimRuleModelNew instanceof TrustedProfileTemplateClaimRule);
+    assertEquals(trustedProfileTemplateClaimRuleModelNew.name(), "testString");
+    assertEquals(trustedProfileTemplateClaimRuleModelNew.type(), "Profile-SAML");
+    assertEquals(trustedProfileTemplateClaimRuleModelNew.realmName(), "testString");
+    assertEquals(trustedProfileTemplateClaimRuleModelNew.expiration(), Long.valueOf("26"));
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testTrustedProfileTemplateClaimRuleError() throws Throwable {
+    new TrustedProfileTemplateClaimRule.Builder().build();
+  }
+
+}

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/TrustedProfileTemplateListTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/TrustedProfileTemplateListTest.java
@@ -1,0 +1,51 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import com.ibm.cloud.platform_services.iam_identity.v1.model.EnityHistoryRecord;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.PolicyTemplateReference;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.ProfileClaimRuleConditions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.ProfileIdentityResponse;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.ResponseContext;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.TemplateProfileComponentResponse;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.TrustedProfileTemplateClaimRule;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.TrustedProfileTemplateList;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.TrustedProfileTemplateResponse;
+import com.ibm.cloud.platform_services.iam_identity.v1.utils.TestUtilities;
+import com.ibm.cloud.sdk.core.service.model.FileWithMetadata;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.List;
+import org.testng.annotations.Test;
+import static org.testng.Assert.*;
+
+/**
+ * Unit test class for the TrustedProfileTemplateList model.
+ */
+public class TrustedProfileTemplateListTest {
+  final HashMap<String, InputStream> mockStreamMap = TestUtilities.createMockStreamMap();
+  final List<FileWithMetadata> mockListFileWithMetadata = TestUtilities.creatMockListFileWithMetadata();
+
+  @Test
+  public void testTrustedProfileTemplateList() throws Throwable {
+    TrustedProfileTemplateList trustedProfileTemplateListModel = new TrustedProfileTemplateList();
+    assertNull(trustedProfileTemplateListModel.getContext());
+    assertNull(trustedProfileTemplateListModel.getOffset());
+    assertNull(trustedProfileTemplateListModel.getLimit());
+    assertNull(trustedProfileTemplateListModel.getFirst());
+    assertNull(trustedProfileTemplateListModel.getPrevious());
+    assertNull(trustedProfileTemplateListModel.getNext());
+    assertNull(trustedProfileTemplateListModel.getProfileTemplates());
+  }
+}

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/TrustedProfileTemplateResponseTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/TrustedProfileTemplateResponseTest.java
@@ -1,0 +1,57 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import com.ibm.cloud.platform_services.iam_identity.v1.model.EnityHistoryRecord;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.PolicyTemplateReference;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.ProfileClaimRuleConditions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.ProfileIdentityResponse;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.TemplateProfileComponentResponse;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.TrustedProfileTemplateClaimRule;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.TrustedProfileTemplateResponse;
+import com.ibm.cloud.platform_services.iam_identity.v1.utils.TestUtilities;
+import com.ibm.cloud.sdk.core.service.model.FileWithMetadata;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.List;
+import org.testng.annotations.Test;
+import static org.testng.Assert.*;
+
+/**
+ * Unit test class for the TrustedProfileTemplateResponse model.
+ */
+public class TrustedProfileTemplateResponseTest {
+  final HashMap<String, InputStream> mockStreamMap = TestUtilities.createMockStreamMap();
+  final List<FileWithMetadata> mockListFileWithMetadata = TestUtilities.creatMockListFileWithMetadata();
+
+  @Test
+  public void testTrustedProfileTemplateResponse() throws Throwable {
+    TrustedProfileTemplateResponse trustedProfileTemplateResponseModel = new TrustedProfileTemplateResponse();
+    assertNull(trustedProfileTemplateResponseModel.getId());
+    assertNull(trustedProfileTemplateResponseModel.getVersion());
+    assertNull(trustedProfileTemplateResponseModel.getAccountId());
+    assertNull(trustedProfileTemplateResponseModel.getName());
+    assertNull(trustedProfileTemplateResponseModel.getDescription());
+    assertNull(trustedProfileTemplateResponseModel.isCommitted());
+    assertNull(trustedProfileTemplateResponseModel.getProfile());
+    assertNull(trustedProfileTemplateResponseModel.getPolicyTemplateReferences());
+    assertNull(trustedProfileTemplateResponseModel.getHistory());
+    assertNull(trustedProfileTemplateResponseModel.getEntityTag());
+    assertNull(trustedProfileTemplateResponseModel.getCrn());
+    assertNull(trustedProfileTemplateResponseModel.getCreatedAt());
+    assertNull(trustedProfileTemplateResponseModel.getCreatedById());
+    assertNull(trustedProfileTemplateResponseModel.getLastModifiedAt());
+    assertNull(trustedProfileTemplateResponseModel.getLastModifiedById());
+  }
+}

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/TrustedProfileTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/TrustedProfileTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -45,6 +45,8 @@ public class TrustedProfileTest {
     assertNull(trustedProfileModel.getModifiedAt());
     assertNull(trustedProfileModel.getIamId());
     assertNull(trustedProfileModel.getAccountId());
+    assertNull(trustedProfileModel.getTemplateId());
+    assertNull(trustedProfileModel.getAssignmentId());
     assertNull(trustedProfileModel.getImsAccountId());
     assertNull(trustedProfileModel.getImsUserId());
     assertNull(trustedProfileModel.getHistory());

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/TrustedProfilesListTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/TrustedProfilesListTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/UnlockApiKeyOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/UnlockApiKeyOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/UnlockServiceIdOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/UnlockServiceIdOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/UpdateAccountSettingsAssignmentOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/UpdateAccountSettingsAssignmentOptionsTest.java
@@ -1,0 +1,49 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import com.ibm.cloud.platform_services.iam_identity.v1.model.UpdateAccountSettingsAssignmentOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.utils.TestUtilities;
+import com.ibm.cloud.sdk.core.service.model.FileWithMetadata;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.List;
+import org.testng.annotations.Test;
+import static org.testng.Assert.*;
+
+/**
+ * Unit test class for the UpdateAccountSettingsAssignmentOptions model.
+ */
+public class UpdateAccountSettingsAssignmentOptionsTest {
+  final HashMap<String, InputStream> mockStreamMap = TestUtilities.createMockStreamMap();
+  final List<FileWithMetadata> mockListFileWithMetadata = TestUtilities.creatMockListFileWithMetadata();
+
+  @Test
+  public void testUpdateAccountSettingsAssignmentOptions() throws Throwable {
+    UpdateAccountSettingsAssignmentOptions updateAccountSettingsAssignmentOptionsModel = new UpdateAccountSettingsAssignmentOptions.Builder()
+      .assignmentId("testString")
+      .ifMatch("testString")
+      .templateVersion(Long.valueOf("1"))
+      .build();
+    assertEquals(updateAccountSettingsAssignmentOptionsModel.assignmentId(), "testString");
+    assertEquals(updateAccountSettingsAssignmentOptionsModel.ifMatch(), "testString");
+    assertEquals(updateAccountSettingsAssignmentOptionsModel.templateVersion(), Long.valueOf("1"));
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testUpdateAccountSettingsAssignmentOptionsError() throws Throwable {
+    new UpdateAccountSettingsAssignmentOptions.Builder().build();
+  }
+
+}

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/UpdateAccountSettingsTemplateVersionOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/UpdateAccountSettingsTemplateVersionOptionsTest.java
@@ -1,0 +1,89 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import com.ibm.cloud.platform_services.iam_identity.v1.model.AccountSettingsComponent;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.AccountSettingsUserMFA;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.UpdateAccountSettingsTemplateVersionOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.utils.TestUtilities;
+import com.ibm.cloud.sdk.core.service.model.FileWithMetadata;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.List;
+import org.testng.annotations.Test;
+import static org.testng.Assert.*;
+
+/**
+ * Unit test class for the UpdateAccountSettingsTemplateVersionOptions model.
+ */
+public class UpdateAccountSettingsTemplateVersionOptionsTest {
+  final HashMap<String, InputStream> mockStreamMap = TestUtilities.createMockStreamMap();
+  final List<FileWithMetadata> mockListFileWithMetadata = TestUtilities.creatMockListFileWithMetadata();
+
+  @Test
+  public void testUpdateAccountSettingsTemplateVersionOptions() throws Throwable {
+    AccountSettingsUserMFA accountSettingsUserMfaModel = new AccountSettingsUserMFA.Builder()
+      .iamId("testString")
+      .mfa("NONE")
+      .build();
+    assertEquals(accountSettingsUserMfaModel.iamId(), "testString");
+    assertEquals(accountSettingsUserMfaModel.mfa(), "NONE");
+
+    AccountSettingsComponent accountSettingsComponentModel = new AccountSettingsComponent.Builder()
+      .restrictCreateServiceId("NOT_SET")
+      .restrictCreatePlatformApikey("NOT_SET")
+      .allowedIpAddresses("testString")
+      .mfa("NONE")
+      .userMfa(java.util.Arrays.asList(accountSettingsUserMfaModel))
+      .sessionExpirationInSeconds("86400")
+      .sessionInvalidationInSeconds("7200")
+      .maxSessionsPerIdentity("testString")
+      .systemAccessTokenExpirationInSeconds("3600")
+      .systemRefreshTokenExpirationInSeconds("259200")
+      .build();
+    assertEquals(accountSettingsComponentModel.restrictCreateServiceId(), "NOT_SET");
+    assertEquals(accountSettingsComponentModel.restrictCreatePlatformApikey(), "NOT_SET");
+    assertEquals(accountSettingsComponentModel.allowedIpAddresses(), "testString");
+    assertEquals(accountSettingsComponentModel.mfa(), "NONE");
+    assertEquals(accountSettingsComponentModel.userMfa(), java.util.Arrays.asList(accountSettingsUserMfaModel));
+    assertEquals(accountSettingsComponentModel.sessionExpirationInSeconds(), "86400");
+    assertEquals(accountSettingsComponentModel.sessionInvalidationInSeconds(), "7200");
+    assertEquals(accountSettingsComponentModel.maxSessionsPerIdentity(), "testString");
+    assertEquals(accountSettingsComponentModel.systemAccessTokenExpirationInSeconds(), "3600");
+    assertEquals(accountSettingsComponentModel.systemRefreshTokenExpirationInSeconds(), "259200");
+
+    UpdateAccountSettingsTemplateVersionOptions updateAccountSettingsTemplateVersionOptionsModel = new UpdateAccountSettingsTemplateVersionOptions.Builder()
+      .ifMatch("testString")
+      .templateId("testString")
+      .version("testString")
+      .accountId("testString")
+      .name("testString")
+      .description("testString")
+      .accountSettings(accountSettingsComponentModel)
+      .build();
+    assertEquals(updateAccountSettingsTemplateVersionOptionsModel.ifMatch(), "testString");
+    assertEquals(updateAccountSettingsTemplateVersionOptionsModel.templateId(), "testString");
+    assertEquals(updateAccountSettingsTemplateVersionOptionsModel.version(), "testString");
+    assertEquals(updateAccountSettingsTemplateVersionOptionsModel.accountId(), "testString");
+    assertEquals(updateAccountSettingsTemplateVersionOptionsModel.name(), "testString");
+    assertEquals(updateAccountSettingsTemplateVersionOptionsModel.description(), "testString");
+    assertEquals(updateAccountSettingsTemplateVersionOptionsModel.accountSettings(), accountSettingsComponentModel);
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testUpdateAccountSettingsTemplateVersionOptionsError() throws Throwable {
+    new UpdateAccountSettingsTemplateVersionOptions.Builder().build();
+  }
+
+}

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/UpdateApiKeyOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/UpdateApiKeyOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/UpdateClaimRuleOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/UpdateClaimRuleOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/UpdateProfileOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/UpdateProfileOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/UpdateProfileTemplateVersionOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/UpdateProfileTemplateVersionOptionsTest.java
@@ -1,0 +1,115 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import com.ibm.cloud.platform_services.iam_identity.v1.model.PolicyTemplateReference;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.ProfileClaimRuleConditions;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.ProfileIdentityRequest;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.TemplateProfileComponentRequest;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.TrustedProfileTemplateClaimRule;
+import com.ibm.cloud.platform_services.iam_identity.v1.model.UpdateProfileTemplateVersionOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.utils.TestUtilities;
+import com.ibm.cloud.sdk.core.service.model.FileWithMetadata;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.List;
+import org.testng.annotations.Test;
+import static org.testng.Assert.*;
+
+/**
+ * Unit test class for the UpdateProfileTemplateVersionOptions model.
+ */
+public class UpdateProfileTemplateVersionOptionsTest {
+  final HashMap<String, InputStream> mockStreamMap = TestUtilities.createMockStreamMap();
+  final List<FileWithMetadata> mockListFileWithMetadata = TestUtilities.creatMockListFileWithMetadata();
+
+  @Test
+  public void testUpdateProfileTemplateVersionOptions() throws Throwable {
+    ProfileClaimRuleConditions profileClaimRuleConditionsModel = new ProfileClaimRuleConditions.Builder()
+      .claim("testString")
+      .operator("testString")
+      .value("testString")
+      .build();
+    assertEquals(profileClaimRuleConditionsModel.claim(), "testString");
+    assertEquals(profileClaimRuleConditionsModel.operator(), "testString");
+    assertEquals(profileClaimRuleConditionsModel.value(), "testString");
+
+    TrustedProfileTemplateClaimRule trustedProfileTemplateClaimRuleModel = new TrustedProfileTemplateClaimRule.Builder()
+      .name("testString")
+      .type("Profile-SAML")
+      .realmName("testString")
+      .expiration(Long.valueOf("26"))
+      .conditions(java.util.Arrays.asList(profileClaimRuleConditionsModel))
+      .build();
+    assertEquals(trustedProfileTemplateClaimRuleModel.name(), "testString");
+    assertEquals(trustedProfileTemplateClaimRuleModel.type(), "Profile-SAML");
+    assertEquals(trustedProfileTemplateClaimRuleModel.realmName(), "testString");
+    assertEquals(trustedProfileTemplateClaimRuleModel.expiration(), Long.valueOf("26"));
+    assertEquals(trustedProfileTemplateClaimRuleModel.conditions(), java.util.Arrays.asList(profileClaimRuleConditionsModel));
+
+    ProfileIdentityRequest profileIdentityRequestModel = new ProfileIdentityRequest.Builder()
+      .identifier("testString")
+      .type("user")
+      .accounts(java.util.Arrays.asList("testString"))
+      .description("testString")
+      .build();
+    assertEquals(profileIdentityRequestModel.identifier(), "testString");
+    assertEquals(profileIdentityRequestModel.type(), "user");
+    assertEquals(profileIdentityRequestModel.accounts(), java.util.Arrays.asList("testString"));
+    assertEquals(profileIdentityRequestModel.description(), "testString");
+
+    TemplateProfileComponentRequest templateProfileComponentRequestModel = new TemplateProfileComponentRequest.Builder()
+      .name("testString")
+      .description("testString")
+      .rules(java.util.Arrays.asList(trustedProfileTemplateClaimRuleModel))
+      .identities(java.util.Arrays.asList(profileIdentityRequestModel))
+      .build();
+    assertEquals(templateProfileComponentRequestModel.name(), "testString");
+    assertEquals(templateProfileComponentRequestModel.description(), "testString");
+    assertEquals(templateProfileComponentRequestModel.rules(), java.util.Arrays.asList(trustedProfileTemplateClaimRuleModel));
+    assertEquals(templateProfileComponentRequestModel.identities(), java.util.Arrays.asList(profileIdentityRequestModel));
+
+    PolicyTemplateReference policyTemplateReferenceModel = new PolicyTemplateReference.Builder()
+      .id("testString")
+      .version("testString")
+      .build();
+    assertEquals(policyTemplateReferenceModel.id(), "testString");
+    assertEquals(policyTemplateReferenceModel.version(), "testString");
+
+    UpdateProfileTemplateVersionOptions updateProfileTemplateVersionOptionsModel = new UpdateProfileTemplateVersionOptions.Builder()
+      .ifMatch("testString")
+      .templateId("testString")
+      .version("testString")
+      .accountId("testString")
+      .name("testString")
+      .description("testString")
+      .profile(templateProfileComponentRequestModel)
+      .policyTemplateReferences(java.util.Arrays.asList(policyTemplateReferenceModel))
+      .build();
+    assertEquals(updateProfileTemplateVersionOptionsModel.ifMatch(), "testString");
+    assertEquals(updateProfileTemplateVersionOptionsModel.templateId(), "testString");
+    assertEquals(updateProfileTemplateVersionOptionsModel.version(), "testString");
+    assertEquals(updateProfileTemplateVersionOptionsModel.accountId(), "testString");
+    assertEquals(updateProfileTemplateVersionOptionsModel.name(), "testString");
+    assertEquals(updateProfileTemplateVersionOptionsModel.description(), "testString");
+    assertEquals(updateProfileTemplateVersionOptionsModel.profile(), templateProfileComponentRequestModel);
+    assertEquals(updateProfileTemplateVersionOptionsModel.policyTemplateReferences(), java.util.Arrays.asList(policyTemplateReferenceModel));
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testUpdateProfileTemplateVersionOptionsError() throws Throwable {
+    new UpdateProfileTemplateVersionOptions.Builder().build();
+  }
+
+}

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/UpdateServiceIdOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/UpdateServiceIdOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/UpdateTrustedProfileAssignmentOptionsTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/UpdateTrustedProfileAssignmentOptionsTest.java
@@ -1,0 +1,49 @@
+/*
+ * (C) Copyright IBM Corp. 2023.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.ibm.cloud.platform_services.iam_identity.v1.model;
+
+import com.ibm.cloud.platform_services.iam_identity.v1.model.UpdateTrustedProfileAssignmentOptions;
+import com.ibm.cloud.platform_services.iam_identity.v1.utils.TestUtilities;
+import com.ibm.cloud.sdk.core.service.model.FileWithMetadata;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.List;
+import org.testng.annotations.Test;
+import static org.testng.Assert.*;
+
+/**
+ * Unit test class for the UpdateTrustedProfileAssignmentOptions model.
+ */
+public class UpdateTrustedProfileAssignmentOptionsTest {
+  final HashMap<String, InputStream> mockStreamMap = TestUtilities.createMockStreamMap();
+  final List<FileWithMetadata> mockListFileWithMetadata = TestUtilities.creatMockListFileWithMetadata();
+
+  @Test
+  public void testUpdateTrustedProfileAssignmentOptions() throws Throwable {
+    UpdateTrustedProfileAssignmentOptions updateTrustedProfileAssignmentOptionsModel = new UpdateTrustedProfileAssignmentOptions.Builder()
+      .assignmentId("testString")
+      .ifMatch("testString")
+      .templateVersion(Long.valueOf("1"))
+      .build();
+    assertEquals(updateTrustedProfileAssignmentOptionsModel.assignmentId(), "testString");
+    assertEquals(updateTrustedProfileAssignmentOptionsModel.ifMatch(), "testString");
+    assertEquals(updateTrustedProfileAssignmentOptionsModel.templateVersion(), Long.valueOf("1"));
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testUpdateTrustedProfileAssignmentOptionsError() throws Throwable {
+    new UpdateTrustedProfileAssignmentOptions.Builder().build();
+  }
+
+}

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/UserActivityTest.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/model/UserActivityTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/utils/TestUtilities.java
+++ b/modules/iam-identity/src/test/java/com/ibm/cloud/platform_services/iam_identity/v1/utils/TestUtilities.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2023.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at


### PR DESCRIPTION
## PR summary
Added support for IAM enterprise feature. Enterprise admins can create templates for account settings and trusted profiles and assign them to accounts and account groups in the enterprise.

## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## Current vs new behavior  
SDK adopters will be able to work with IAM enterprise feature.

## Does this PR introduce a breaking change?    
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
API definition: [Staging](https://test.cloud.ibm.com/apidocs/iam-identity-token-api#list-profile-templates)

Test information:

Integration Tests:
```
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running com.ibm.cloud.platform_services.iam_identity.v1.IamIdentityIT
[INFO] Tests run: 92, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 536.386 s - in com.ibm.cloud.platform_services.iam_identity.v1.IamIdentityIT
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 92, Failures: 0, Errors: 0, Skipped: 0
[INFO]
```

Examples:
[examples_java_sdk_2023-07-20.log](https://github.com/IBM/platform-services-java-sdk/files/12104727/examples_java_sdk_2023-07-20.log)
