### PR TITLE
fix(Global Search/Tagging): regen services with latest API definitions

### DIFF
--- a/modules/global-search/src/main/java/com/ibm/cloud/platform_services/global_search/v2/GlobalSearch.java
+++ b/modules/global-search/src/main/java/com/ibm/cloud/platform_services/global_search/v2/GlobalSearch.java
@@ -12,7 +12,7 @@
  */
 
 /*
- * IBM OpenAPI SDK Code Generator Version: 3.70.0-7df966bf-20230419-195904
+ * IBM OpenAPI SDK Code Generator Version: 3.79.0-2eb6af3d-20230905-174838
  */
 
 package com.ibm.cloud.platform_services.global_search.v2;
@@ -37,7 +37,7 @@ import java.util.Map.Entry;
  * platform. The search repository stores and searches cloud resources attributes, which categorize or classify
  * resources. A resource is a physical or logical component that can be created or reserved for an application or
  * service instance. They are owned by resource providers, such as Cloud Foundry, IBM Kubernetes Service, or resource
- * controller in IBM Cloud. Resources are uniquely identified by a Cloud Resource Name (CRN)  or by an IMS ID. The
+ * controller in IBM Cloud. Resources are uniquely identified by a Cloud Resource Name (CRN) or by an IMS ID. The
  * properties of a resource include tags and system properties. Both properties are defined in an IBM Cloud billing
  * account, and span across many regions.
  *
@@ -120,6 +120,12 @@ public class GlobalSearch extends BaseService {
       builder.header(header.getKey(), header.getValue());
     }
     builder.header("Accept", "application/json");
+    if (searchOptions.xRequestId() != null) {
+      builder.header("x-request-id", searchOptions.xRequestId());
+    }
+    if (searchOptions.xCorrelationId() != null) {
+      builder.header("x-correlation-id", searchOptions.xCorrelationId());
+    }
     if (searchOptions.transactionId() != null) {
       builder.header("transaction-id", searchOptions.transactionId());
     }

--- a/modules/global-search/src/main/java/com/ibm/cloud/platform_services/global_search/v2/model/SearchOptions.java
+++ b/modules/global-search/src/main/java/com/ibm/cloud/platform_services/global_search/v2/model/SearchOptions.java
@@ -79,6 +79,8 @@ public class SearchOptions extends GenericModel {
   protected String query;
   protected List<String> fields;
   protected String searchCursor;
+  protected String xRequestId;
+  protected String xCorrelationId;
   protected String transactionId;
   protected String accountId;
   protected Long limit;
@@ -97,6 +99,8 @@ public class SearchOptions extends GenericModel {
     private String query;
     private List<String> fields;
     private String searchCursor;
+    private String xRequestId;
+    private String xCorrelationId;
     private String transactionId;
     private String accountId;
     private Long limit;
@@ -117,6 +121,8 @@ public class SearchOptions extends GenericModel {
       this.query = searchOptions.query;
       this.fields = searchOptions.fields;
       this.searchCursor = searchOptions.searchCursor;
+      this.xRequestId = searchOptions.xRequestId;
+      this.xCorrelationId = searchOptions.xCorrelationId;
       this.transactionId = searchOptions.transactionId;
       this.accountId = searchOptions.accountId;
       this.limit = searchOptions.limit;
@@ -211,11 +217,35 @@ public class SearchOptions extends GenericModel {
     }
 
     /**
+     * Set the xRequestId.
+     *
+     * @param xRequestId the xRequestId
+     * @return the SearchOptions builder
+     */
+    public Builder xRequestId(String xRequestId) {
+      this.xRequestId = xRequestId;
+      return this;
+    }
+
+    /**
+     * Set the xCorrelationId.
+     *
+     * @param xCorrelationId the xCorrelationId
+     * @return the SearchOptions builder
+     */
+    public Builder xCorrelationId(String xCorrelationId) {
+      this.xCorrelationId = xCorrelationId;
+      return this;
+    }
+
+    /**
      * Set the transactionId.
      *
      * @param transactionId the transactionId
      * @return the SearchOptions builder
+     * @deprecated this method is deprecated and may be removed in a future release
      */
+    @Deprecated
     public Builder transactionId(String transactionId) {
       this.transactionId = transactionId;
       return this;
@@ -328,6 +358,8 @@ public class SearchOptions extends GenericModel {
     query = builder.query;
     fields = builder.fields;
     searchCursor = builder.searchCursor;
+    xRequestId = builder.xRequestId;
+    xCorrelationId = builder.xCorrelationId;
     transactionId = builder.transactionId;
     accountId = builder.accountId;
     limit = builder.limit;
@@ -385,13 +417,46 @@ public class SearchOptions extends GenericModel {
   }
 
   /**
+   * Gets the xRequestId.
+   *
+   * An alphanumeric string that is used to trace the request. The value  may include ASCII alphanumerics and any of
+   * following segment separators: space ( ), comma (,), hyphen, (-), and underscore (_) and may have a length up to
+   * 1024 bytes. The value is considered invalid and must be ignored if that value includes any other character or is
+   * longer than 1024 bytes or is fewer than 8 characters. If not specified or invalid, it is automatically replaced by
+   * a random (version 4) UUID.
+   *
+   * @return the xRequestId
+   */
+  public String xRequestId() {
+    return xRequestId;
+  }
+
+  /**
+   * Gets the xCorrelationId.
+   *
+   * An alphanumeric string that is used to trace the request as a part of a larger context: the same value is used for
+   * downstream requests and retries of those requests. The value may include ASCII alphanumerics and any of following
+   * segment separators: space ( ), comma (,), hyphen, (-), and underscore (_) and may have a length up to 1024 bytes.
+   * The value is considered invalid and must be ignored if that value includes any other character or is longer than
+   * 1024 bytes or is fewer than 8 characters. If not specified or invalid, it is automatically replaced by a random
+   * (version 4) UUID.
+   *
+   * @return the xCorrelationId
+   */
+  public String xCorrelationId() {
+    return xCorrelationId;
+  }
+
+  /**
    * Gets the transactionId.
    *
    * An alphanumeric string that can be used to trace a request across services. If not specified, it automatically
    * generated with the prefix "gst-".
    *
    * @return the transactionId
+   * @deprecated this method is deprecated and may be removed in a future release
    */
+  @Deprecated
   public String transactionId() {
     return transactionId;
   }

--- a/modules/global-search/src/test/java/com/ibm/cloud/platform_services/global_search/v2/GlobalSearchTest.java
+++ b/modules/global-search/src/test/java/com/ibm/cloud/platform_services/global_search/v2/GlobalSearchTest.java
@@ -69,9 +69,11 @@ public class GlobalSearchTest {
       .query("testString")
       .fields(java.util.Arrays.asList("testString"))
       .searchCursor("testString")
+      .xRequestId("testString")
+      .xCorrelationId("testString")
       .transactionId("testString")
       .accountId("testString")
-      .limit(Long.valueOf("1"))
+      .limit(Long.valueOf("10"))
       .timeout(Long.valueOf("0"))
       .sort(java.util.Arrays.asList("testString"))
       .isDeleted("false")
@@ -98,7 +100,7 @@ public class GlobalSearchTest {
     Map<String, String> query = TestUtilities.parseQueryString(request);
     assertNotNull(query);
     assertEquals(query.get("account_id"), "testString");
-    assertEquals(Long.valueOf(query.get("limit")), Long.valueOf("1"));
+    assertEquals(Long.valueOf(query.get("limit")), Long.valueOf("10"));
     assertEquals(Long.valueOf(query.get("timeout")), Long.valueOf("0"));
     assertEquals(query.get("sort"), RequestUtils.join(java.util.Arrays.asList("testString"), ","));
     assertEquals(query.get("is_deleted"), "false");

--- a/modules/global-search/src/test/java/com/ibm/cloud/platform_services/global_search/v2/model/SearchOptionsTest.java
+++ b/modules/global-search/src/test/java/com/ibm/cloud/platform_services/global_search/v2/model/SearchOptionsTest.java
@@ -35,9 +35,11 @@ public class SearchOptionsTest {
       .query("testString")
       .fields(java.util.Arrays.asList("testString"))
       .searchCursor("testString")
+      .xRequestId("testString")
+      .xCorrelationId("testString")
       .transactionId("testString")
       .accountId("testString")
-      .limit(Long.valueOf("1"))
+      .limit(Long.valueOf("10"))
       .timeout(Long.valueOf("0"))
       .sort(java.util.Arrays.asList("testString"))
       .isDeleted("false")
@@ -49,9 +51,11 @@ public class SearchOptionsTest {
     assertEquals(searchOptionsModel.query(), "testString");
     assertEquals(searchOptionsModel.fields(), java.util.Arrays.asList("testString"));
     assertEquals(searchOptionsModel.searchCursor(), "testString");
+    assertEquals(searchOptionsModel.xRequestId(), "testString");
+    assertEquals(searchOptionsModel.xCorrelationId(), "testString");
     assertEquals(searchOptionsModel.transactionId(), "testString");
     assertEquals(searchOptionsModel.accountId(), "testString");
-    assertEquals(searchOptionsModel.limit(), Long.valueOf("1"));
+    assertEquals(searchOptionsModel.limit(), Long.valueOf("10"));
     assertEquals(searchOptionsModel.timeout(), Long.valueOf("0"));
     assertEquals(searchOptionsModel.sort(), java.util.Arrays.asList("testString"));
     assertEquals(searchOptionsModel.isDeleted(), "false");

--- a/modules/global-tagging/src/main/java/com/ibm/cloud/platform_services/global_tagging/v1/GlobalTagging.java
+++ b/modules/global-tagging/src/main/java/com/ibm/cloud/platform_services/global_tagging/v1/GlobalTagging.java
@@ -12,7 +12,7 @@
  */
 
 /*
- * IBM OpenAPI SDK Code Generator Version: 3.64.0-959a5845-20230112-195144
+ * IBM OpenAPI SDK Code Generator Version: 3.79.0-2eb6af3d-20230905-174838
  */
 
 package com.ibm.cloud.platform_services.global_tagging.v1;
@@ -119,6 +119,12 @@ public class GlobalTagging extends BaseService {
       builder.header(header.getKey(), header.getValue());
     }
     builder.header("Accept", "application/json");
+    if (listTagsOptions.xRequestId() != null) {
+      builder.header("x-request-id", listTagsOptions.xRequestId());
+    }
+    if (listTagsOptions.xCorrelationId() != null) {
+      builder.header("x-correlation-id", listTagsOptions.xCorrelationId());
+    }
     if (listTagsOptions.transactionId() != null) {
       builder.header("transaction-id", listTagsOptions.transactionId());
     }
@@ -191,6 +197,12 @@ public class GlobalTagging extends BaseService {
       builder.header(header.getKey(), header.getValue());
     }
     builder.header("Accept", "application/json");
+    if (createTagOptions.xRequestId() != null) {
+      builder.header("x-request-id", createTagOptions.xRequestId());
+    }
+    if (createTagOptions.xCorrelationId() != null) {
+      builder.header("x-correlation-id", createTagOptions.xCorrelationId());
+    }
     if (createTagOptions.transactionId() != null) {
       builder.header("transaction-id", createTagOptions.transactionId());
     }
@@ -229,6 +241,12 @@ public class GlobalTagging extends BaseService {
       builder.header(header.getKey(), header.getValue());
     }
     builder.header("Accept", "application/json");
+    if (deleteTagAllOptions.xRequestId() != null) {
+      builder.header("x-request-id", deleteTagAllOptions.xRequestId());
+    }
+    if (deleteTagAllOptions.xCorrelationId() != null) {
+      builder.header("x-correlation-id", deleteTagAllOptions.xCorrelationId());
+    }
     if (deleteTagAllOptions.transactionId() != null) {
       builder.header("transaction-id", deleteTagAllOptions.transactionId());
     }
@@ -279,6 +297,12 @@ public class GlobalTagging extends BaseService {
       builder.header(header.getKey(), header.getValue());
     }
     builder.header("Accept", "application/json");
+    if (deleteTagOptions.xRequestId() != null) {
+      builder.header("x-request-id", deleteTagOptions.xRequestId());
+    }
+    if (deleteTagOptions.xCorrelationId() != null) {
+      builder.header("x-correlation-id", deleteTagOptions.xCorrelationId());
+    }
     if (deleteTagOptions.transactionId() != null) {
       builder.header("transaction-id", deleteTagOptions.transactionId());
     }
@@ -317,6 +341,12 @@ public class GlobalTagging extends BaseService {
       builder.header(header.getKey(), header.getValue());
     }
     builder.header("Accept", "application/json");
+    if (attachTagOptions.xRequestId() != null) {
+      builder.header("x-request-id", attachTagOptions.xRequestId());
+    }
+    if (attachTagOptions.xCorrelationId() != null) {
+      builder.header("x-correlation-id", attachTagOptions.xCorrelationId());
+    }
     if (attachTagOptions.transactionId() != null) {
       builder.header("transaction-id", attachTagOptions.transactionId());
     }
@@ -360,6 +390,12 @@ public class GlobalTagging extends BaseService {
       builder.header(header.getKey(), header.getValue());
     }
     builder.header("Accept", "application/json");
+    if (detachTagOptions.xRequestId() != null) {
+      builder.header("x-request-id", detachTagOptions.xRequestId());
+    }
+    if (detachTagOptions.xCorrelationId() != null) {
+      builder.header("x-correlation-id", detachTagOptions.xCorrelationId());
+    }
     if (detachTagOptions.transactionId() != null) {
       builder.header("transaction-id", detachTagOptions.transactionId());
     }

--- a/modules/global-tagging/src/main/java/com/ibm/cloud/platform_services/global_tagging/v1/model/AttachTagOptions.java
+++ b/modules/global-tagging/src/main/java/com/ibm/cloud/platform_services/global_tagging/v1/model/AttachTagOptions.java
@@ -38,6 +38,8 @@ public class AttachTagOptions extends GenericModel {
   protected List<Resource> resources;
   protected String tagName;
   protected List<String> tagNames;
+  protected String xRequestId;
+  protected String xCorrelationId;
   protected String transactionId;
   protected String impersonateUser;
   protected String accountId;
@@ -50,6 +52,8 @@ public class AttachTagOptions extends GenericModel {
     private List<Resource> resources;
     private String tagName;
     private List<String> tagNames;
+    private String xRequestId;
+    private String xCorrelationId;
     private String transactionId;
     private String impersonateUser;
     private String accountId;
@@ -64,6 +68,8 @@ public class AttachTagOptions extends GenericModel {
       this.resources = attachTagOptions.resources;
       this.tagName = attachTagOptions.tagName;
       this.tagNames = attachTagOptions.tagNames;
+      this.xRequestId = attachTagOptions.xRequestId;
+      this.xCorrelationId = attachTagOptions.xCorrelationId;
       this.transactionId = attachTagOptions.transactionId;
       this.impersonateUser = attachTagOptions.impersonateUser;
       this.accountId = attachTagOptions.accountId;
@@ -162,11 +168,35 @@ public class AttachTagOptions extends GenericModel {
     }
 
     /**
+     * Set the xRequestId.
+     *
+     * @param xRequestId the xRequestId
+     * @return the AttachTagOptions builder
+     */
+    public Builder xRequestId(String xRequestId) {
+      this.xRequestId = xRequestId;
+      return this;
+    }
+
+    /**
+     * Set the xCorrelationId.
+     *
+     * @param xCorrelationId the xCorrelationId
+     * @return the AttachTagOptions builder
+     */
+    public Builder xCorrelationId(String xCorrelationId) {
+      this.xCorrelationId = xCorrelationId;
+      return this;
+    }
+
+    /**
      * Set the transactionId.
      *
      * @param transactionId the transactionId
      * @return the AttachTagOptions builder
+     * @deprecated this method is deprecated and may be removed in a future release
      */
+    @Deprecated
     public Builder transactionId(String transactionId) {
       this.transactionId = transactionId;
       return this;
@@ -214,6 +244,8 @@ public class AttachTagOptions extends GenericModel {
     resources = builder.resources;
     tagName = builder.tagName;
     tagNames = builder.tagNames;
+    xRequestId = builder.xRequestId;
+    xCorrelationId = builder.xCorrelationId;
     transactionId = builder.transactionId;
     impersonateUser = builder.impersonateUser;
     accountId = builder.accountId;
@@ -263,13 +295,46 @@ public class AttachTagOptions extends GenericModel {
   }
 
   /**
+   * Gets the xRequestId.
+   *
+   * An alphanumeric string that is used to trace the request. The value  may include ASCII alphanumerics and any of
+   * following segment separators: space ( ), comma (,), hyphen, (-), and underscore (_) and may have a length up to
+   * 1024 bytes. The value is considered invalid and must be ignored if that value includes any other character or is
+   * longer than 1024 bytes or is fewer than 8 characters. If not specified or invalid, it is automatically replaced by
+   * a random (version 4) UUID.
+   *
+   * @return the xRequestId
+   */
+  public String xRequestId() {
+    return xRequestId;
+  }
+
+  /**
+   * Gets the xCorrelationId.
+   *
+   * An alphanumeric string that is used to trace the request as a part of a larger context: the same value is used for
+   * downstream requests and retries of those requests. The value may include ASCII alphanumerics and any of following
+   * segment separators: space ( ), comma (,), hyphen, (-), and underscore (_) and may have a length up to 1024 bytes.
+   * The value is considered invalid and must be ignored if that value includes any other character or is longer than
+   * 1024 bytes or is fewer than 8 characters. If not specified or invalid, it is automatically replaced by a random
+   * (version 4) UUID.
+   *
+   * @return the xCorrelationId
+   */
+  public String xCorrelationId() {
+    return xCorrelationId;
+  }
+
+  /**
    * Gets the transactionId.
    *
    * An alphanumeric string that can be used to trace a request across services. If not specified, it automatically
    * generated with the prefix "gst-".
    *
    * @return the transactionId
+   * @deprecated this method is deprecated and may be removed in a future release
    */
+  @Deprecated
   public String transactionId() {
     return transactionId;
   }

--- a/modules/global-tagging/src/main/java/com/ibm/cloud/platform_services/global_tagging/v1/model/CreateTagOptions.java
+++ b/modules/global-tagging/src/main/java/com/ibm/cloud/platform_services/global_tagging/v1/model/CreateTagOptions.java
@@ -32,6 +32,8 @@ public class CreateTagOptions extends GenericModel {
 
   protected List<String> tagNames;
   protected String impersonateUser;
+  protected String xRequestId;
+  protected String xCorrelationId;
   protected String transactionId;
   protected String accountId;
   protected String tagType;
@@ -42,6 +44,8 @@ public class CreateTagOptions extends GenericModel {
   public static class Builder {
     private List<String> tagNames;
     private String impersonateUser;
+    private String xRequestId;
+    private String xCorrelationId;
     private String transactionId;
     private String accountId;
     private String tagType;
@@ -54,6 +58,8 @@ public class CreateTagOptions extends GenericModel {
     private Builder(CreateTagOptions createTagOptions) {
       this.tagNames = createTagOptions.tagNames;
       this.impersonateUser = createTagOptions.impersonateUser;
+      this.xRequestId = createTagOptions.xRequestId;
+      this.xCorrelationId = createTagOptions.xCorrelationId;
       this.transactionId = createTagOptions.transactionId;
       this.accountId = createTagOptions.accountId;
       this.tagType = createTagOptions.tagType;
@@ -123,11 +129,35 @@ public class CreateTagOptions extends GenericModel {
     }
 
     /**
+     * Set the xRequestId.
+     *
+     * @param xRequestId the xRequestId
+     * @return the CreateTagOptions builder
+     */
+    public Builder xRequestId(String xRequestId) {
+      this.xRequestId = xRequestId;
+      return this;
+    }
+
+    /**
+     * Set the xCorrelationId.
+     *
+     * @param xCorrelationId the xCorrelationId
+     * @return the CreateTagOptions builder
+     */
+    public Builder xCorrelationId(String xCorrelationId) {
+      this.xCorrelationId = xCorrelationId;
+      return this;
+    }
+
+    /**
      * Set the transactionId.
      *
      * @param transactionId the transactionId
      * @return the CreateTagOptions builder
+     * @deprecated this method is deprecated and may be removed in a future release
      */
+    @Deprecated
     public Builder transactionId(String transactionId) {
       this.transactionId = transactionId;
       return this;
@@ -163,6 +193,8 @@ public class CreateTagOptions extends GenericModel {
       "tagNames cannot be null");
     tagNames = builder.tagNames;
     impersonateUser = builder.impersonateUser;
+    xRequestId = builder.xRequestId;
+    xCorrelationId = builder.xCorrelationId;
     transactionId = builder.transactionId;
     accountId = builder.accountId;
     tagType = builder.tagType;
@@ -200,13 +232,46 @@ public class CreateTagOptions extends GenericModel {
   }
 
   /**
+   * Gets the xRequestId.
+   *
+   * An alphanumeric string that is used to trace the request. The value  may include ASCII alphanumerics and any of
+   * following segment separators: space ( ), comma (,), hyphen, (-), and underscore (_) and may have a length up to
+   * 1024 bytes. The value is considered invalid and must be ignored if that value includes any other character or is
+   * longer than 1024 bytes or is fewer than 8 characters. If not specified or invalid, it is automatically replaced by
+   * a random (version 4) UUID.
+   *
+   * @return the xRequestId
+   */
+  public String xRequestId() {
+    return xRequestId;
+  }
+
+  /**
+   * Gets the xCorrelationId.
+   *
+   * An alphanumeric string that is used to trace the request as a part of a larger context: the same value is used for
+   * downstream requests and retries of those requests. The value may include ASCII alphanumerics and any of following
+   * segment separators: space ( ), comma (,), hyphen, (-), and underscore (_) and may have a length up to 1024 bytes.
+   * The value is considered invalid and must be ignored if that value includes any other character or is longer than
+   * 1024 bytes or is fewer than 8 characters. If not specified or invalid, it is automatically replaced by a random
+   * (version 4) UUID.
+   *
+   * @return the xCorrelationId
+   */
+  public String xCorrelationId() {
+    return xCorrelationId;
+  }
+
+  /**
    * Gets the transactionId.
    *
    * An alphanumeric string that can be used to trace a request across services. If not specified, it automatically
    * generated with the prefix "gst-".
    *
    * @return the transactionId
+   * @deprecated this method is deprecated and may be removed in a future release
    */
+  @Deprecated
   public String transactionId() {
     return transactionId;
   }

--- a/modules/global-tagging/src/main/java/com/ibm/cloud/platform_services/global_tagging/v1/model/DeleteTagAllOptions.java
+++ b/modules/global-tagging/src/main/java/com/ibm/cloud/platform_services/global_tagging/v1/model/DeleteTagAllOptions.java
@@ -42,6 +42,8 @@ public class DeleteTagAllOptions extends GenericModel {
     String ACCESS = "access";
   }
 
+  protected String xRequestId;
+  protected String xCorrelationId;
   protected String transactionId;
   protected String providers;
   protected String impersonateUser;
@@ -52,6 +54,8 @@ public class DeleteTagAllOptions extends GenericModel {
    * Builder.
    */
   public static class Builder {
+    private String xRequestId;
+    private String xCorrelationId;
     private String transactionId;
     private String providers;
     private String impersonateUser;
@@ -64,6 +68,8 @@ public class DeleteTagAllOptions extends GenericModel {
      * @param deleteTagAllOptions the instance to initialize the Builder with
      */
     private Builder(DeleteTagAllOptions deleteTagAllOptions) {
+      this.xRequestId = deleteTagAllOptions.xRequestId;
+      this.xCorrelationId = deleteTagAllOptions.xCorrelationId;
       this.transactionId = deleteTagAllOptions.transactionId;
       this.providers = deleteTagAllOptions.providers;
       this.impersonateUser = deleteTagAllOptions.impersonateUser;
@@ -87,11 +93,35 @@ public class DeleteTagAllOptions extends GenericModel {
     }
 
     /**
+     * Set the xRequestId.
+     *
+     * @param xRequestId the xRequestId
+     * @return the DeleteTagAllOptions builder
+     */
+    public Builder xRequestId(String xRequestId) {
+      this.xRequestId = xRequestId;
+      return this;
+    }
+
+    /**
+     * Set the xCorrelationId.
+     *
+     * @param xCorrelationId the xCorrelationId
+     * @return the DeleteTagAllOptions builder
+     */
+    public Builder xCorrelationId(String xCorrelationId) {
+      this.xCorrelationId = xCorrelationId;
+      return this;
+    }
+
+    /**
      * Set the transactionId.
      *
      * @param transactionId the transactionId
      * @return the DeleteTagAllOptions builder
+     * @deprecated this method is deprecated and may be removed in a future release
      */
+    @Deprecated
     public Builder transactionId(String transactionId) {
       this.transactionId = transactionId;
       return this;
@@ -145,6 +175,8 @@ public class DeleteTagAllOptions extends GenericModel {
   protected DeleteTagAllOptions() { }
 
   protected DeleteTagAllOptions(Builder builder) {
+    xRequestId = builder.xRequestId;
+    xCorrelationId = builder.xCorrelationId;
     transactionId = builder.transactionId;
     providers = builder.providers;
     impersonateUser = builder.impersonateUser;
@@ -162,13 +194,46 @@ public class DeleteTagAllOptions extends GenericModel {
   }
 
   /**
+   * Gets the xRequestId.
+   *
+   * An alphanumeric string that is used to trace the request. The value  may include ASCII alphanumerics and any of
+   * following segment separators: space ( ), comma (,), hyphen, (-), and underscore (_) and may have a length up to
+   * 1024 bytes. The value is considered invalid and must be ignored if that value includes any other character or is
+   * longer than 1024 bytes or is fewer than 8 characters. If not specified or invalid, it is automatically replaced by
+   * a random (version 4) UUID.
+   *
+   * @return the xRequestId
+   */
+  public String xRequestId() {
+    return xRequestId;
+  }
+
+  /**
+   * Gets the xCorrelationId.
+   *
+   * An alphanumeric string that is used to trace the request as a part of a larger context: the same value is used for
+   * downstream requests and retries of those requests. The value may include ASCII alphanumerics and any of following
+   * segment separators: space ( ), comma (,), hyphen, (-), and underscore (_) and may have a length up to 1024 bytes.
+   * The value is considered invalid and must be ignored if that value includes any other character or is longer than
+   * 1024 bytes or is fewer than 8 characters. If not specified or invalid, it is automatically replaced by a random
+   * (version 4) UUID.
+   *
+   * @return the xCorrelationId
+   */
+  public String xCorrelationId() {
+    return xCorrelationId;
+  }
+
+  /**
    * Gets the transactionId.
    *
    * An alphanumeric string that can be used to trace a request across services. If not specified, it automatically
    * generated with the prefix "gst-".
    *
    * @return the transactionId
+   * @deprecated this method is deprecated and may be removed in a future release
    */
+  @Deprecated
   public String transactionId() {
     return transactionId;
   }

--- a/modules/global-tagging/src/main/java/com/ibm/cloud/platform_services/global_tagging/v1/model/DeleteTagOptions.java
+++ b/modules/global-tagging/src/main/java/com/ibm/cloud/platform_services/global_tagging/v1/model/DeleteTagOptions.java
@@ -43,6 +43,8 @@ public class DeleteTagOptions extends GenericModel {
   }
 
   protected String tagName;
+  protected String xRequestId;
+  protected String xCorrelationId;
   protected String transactionId;
   protected List<String> providers;
   protected String impersonateUser;
@@ -54,6 +56,8 @@ public class DeleteTagOptions extends GenericModel {
    */
   public static class Builder {
     private String tagName;
+    private String xRequestId;
+    private String xCorrelationId;
     private String transactionId;
     private List<String> providers;
     private String impersonateUser;
@@ -67,6 +71,8 @@ public class DeleteTagOptions extends GenericModel {
      */
     private Builder(DeleteTagOptions deleteTagOptions) {
       this.tagName = deleteTagOptions.tagName;
+      this.xRequestId = deleteTagOptions.xRequestId;
+      this.xCorrelationId = deleteTagOptions.xCorrelationId;
       this.transactionId = deleteTagOptions.transactionId;
       this.providers = deleteTagOptions.providers;
       this.impersonateUser = deleteTagOptions.impersonateUser;
@@ -126,11 +132,35 @@ public class DeleteTagOptions extends GenericModel {
     }
 
     /**
+     * Set the xRequestId.
+     *
+     * @param xRequestId the xRequestId
+     * @return the DeleteTagOptions builder
+     */
+    public Builder xRequestId(String xRequestId) {
+      this.xRequestId = xRequestId;
+      return this;
+    }
+
+    /**
+     * Set the xCorrelationId.
+     *
+     * @param xCorrelationId the xCorrelationId
+     * @return the DeleteTagOptions builder
+     */
+    public Builder xCorrelationId(String xCorrelationId) {
+      this.xCorrelationId = xCorrelationId;
+      return this;
+    }
+
+    /**
      * Set the transactionId.
      *
      * @param transactionId the transactionId
      * @return the DeleteTagOptions builder
+     * @deprecated this method is deprecated and may be removed in a future release
      */
+    @Deprecated
     public Builder transactionId(String transactionId) {
       this.transactionId = transactionId;
       return this;
@@ -188,6 +218,8 @@ public class DeleteTagOptions extends GenericModel {
     com.ibm.cloud.sdk.core.util.Validator.notEmpty(builder.tagName,
       "tagName cannot be empty");
     tagName = builder.tagName;
+    xRequestId = builder.xRequestId;
+    xCorrelationId = builder.xCorrelationId;
     transactionId = builder.transactionId;
     providers = builder.providers;
     impersonateUser = builder.impersonateUser;
@@ -216,13 +248,46 @@ public class DeleteTagOptions extends GenericModel {
   }
 
   /**
+   * Gets the xRequestId.
+   *
+   * An alphanumeric string that is used to trace the request. The value  may include ASCII alphanumerics and any of
+   * following segment separators: space ( ), comma (,), hyphen, (-), and underscore (_) and may have a length up to
+   * 1024 bytes. The value is considered invalid and must be ignored if that value includes any other character or is
+   * longer than 1024 bytes or is fewer than 8 characters. If not specified or invalid, it is automatically replaced by
+   * a random (version 4) UUID.
+   *
+   * @return the xRequestId
+   */
+  public String xRequestId() {
+    return xRequestId;
+  }
+
+  /**
+   * Gets the xCorrelationId.
+   *
+   * An alphanumeric string that is used to trace the request as a part of a larger context: the same value is used for
+   * downstream requests and retries of those requests. The value may include ASCII alphanumerics and any of following
+   * segment separators: space ( ), comma (,), hyphen, (-), and underscore (_) and may have a length up to 1024 bytes.
+   * The value is considered invalid and must be ignored if that value includes any other character or is longer than
+   * 1024 bytes or is fewer than 8 characters. If not specified or invalid, it is automatically replaced by a random
+   * (version 4) UUID.
+   *
+   * @return the xCorrelationId
+   */
+  public String xCorrelationId() {
+    return xCorrelationId;
+  }
+
+  /**
    * Gets the transactionId.
    *
    * An alphanumeric string that can be used to trace a request across services. If not specified, it automatically
    * generated with the prefix "gst-".
    *
    * @return the transactionId
+   * @deprecated this method is deprecated and may be removed in a future release
    */
+  @Deprecated
   public String transactionId() {
     return transactionId;
   }

--- a/modules/global-tagging/src/main/java/com/ibm/cloud/platform_services/global_tagging/v1/model/DetachTagOptions.java
+++ b/modules/global-tagging/src/main/java/com/ibm/cloud/platform_services/global_tagging/v1/model/DetachTagOptions.java
@@ -38,6 +38,8 @@ public class DetachTagOptions extends GenericModel {
   protected List<Resource> resources;
   protected String tagName;
   protected List<String> tagNames;
+  protected String xRequestId;
+  protected String xCorrelationId;
   protected String transactionId;
   protected String impersonateUser;
   protected String accountId;
@@ -50,6 +52,8 @@ public class DetachTagOptions extends GenericModel {
     private List<Resource> resources;
     private String tagName;
     private List<String> tagNames;
+    private String xRequestId;
+    private String xCorrelationId;
     private String transactionId;
     private String impersonateUser;
     private String accountId;
@@ -64,6 +68,8 @@ public class DetachTagOptions extends GenericModel {
       this.resources = detachTagOptions.resources;
       this.tagName = detachTagOptions.tagName;
       this.tagNames = detachTagOptions.tagNames;
+      this.xRequestId = detachTagOptions.xRequestId;
+      this.xCorrelationId = detachTagOptions.xCorrelationId;
       this.transactionId = detachTagOptions.transactionId;
       this.impersonateUser = detachTagOptions.impersonateUser;
       this.accountId = detachTagOptions.accountId;
@@ -162,11 +168,35 @@ public class DetachTagOptions extends GenericModel {
     }
 
     /**
+     * Set the xRequestId.
+     *
+     * @param xRequestId the xRequestId
+     * @return the DetachTagOptions builder
+     */
+    public Builder xRequestId(String xRequestId) {
+      this.xRequestId = xRequestId;
+      return this;
+    }
+
+    /**
+     * Set the xCorrelationId.
+     *
+     * @param xCorrelationId the xCorrelationId
+     * @return the DetachTagOptions builder
+     */
+    public Builder xCorrelationId(String xCorrelationId) {
+      this.xCorrelationId = xCorrelationId;
+      return this;
+    }
+
+    /**
      * Set the transactionId.
      *
      * @param transactionId the transactionId
      * @return the DetachTagOptions builder
+     * @deprecated this method is deprecated and may be removed in a future release
      */
+    @Deprecated
     public Builder transactionId(String transactionId) {
       this.transactionId = transactionId;
       return this;
@@ -214,6 +244,8 @@ public class DetachTagOptions extends GenericModel {
     resources = builder.resources;
     tagName = builder.tagName;
     tagNames = builder.tagNames;
+    xRequestId = builder.xRequestId;
+    xCorrelationId = builder.xCorrelationId;
     transactionId = builder.transactionId;
     impersonateUser = builder.impersonateUser;
     accountId = builder.accountId;
@@ -263,13 +295,46 @@ public class DetachTagOptions extends GenericModel {
   }
 
   /**
+   * Gets the xRequestId.
+   *
+   * An alphanumeric string that is used to trace the request. The value  may include ASCII alphanumerics and any of
+   * following segment separators: space ( ), comma (,), hyphen, (-), and underscore (_) and may have a length up to
+   * 1024 bytes. The value is considered invalid and must be ignored if that value includes any other character or is
+   * longer than 1024 bytes or is fewer than 8 characters. If not specified or invalid, it is automatically replaced by
+   * a random (version 4) UUID.
+   *
+   * @return the xRequestId
+   */
+  public String xRequestId() {
+    return xRequestId;
+  }
+
+  /**
+   * Gets the xCorrelationId.
+   *
+   * An alphanumeric string that is used to trace the request as a part of a larger context: the same value is used for
+   * downstream requests and retries of those requests. The value may include ASCII alphanumerics and any of following
+   * segment separators: space ( ), comma (,), hyphen, (-), and underscore (_) and may have a length up to 1024 bytes.
+   * The value is considered invalid and must be ignored if that value includes any other character or is longer than
+   * 1024 bytes or is fewer than 8 characters. If not specified or invalid, it is automatically replaced by a random
+   * (version 4) UUID.
+   *
+   * @return the xCorrelationId
+   */
+  public String xCorrelationId() {
+    return xCorrelationId;
+  }
+
+  /**
    * Gets the transactionId.
    *
    * An alphanumeric string that can be used to trace a request across services. If not specified, it automatically
    * generated with the prefix "gst-".
    *
    * @return the transactionId
+   * @deprecated this method is deprecated and may be removed in a future release
    */
+  @Deprecated
   public String transactionId() {
     return transactionId;
   }
@@ -288,7 +353,7 @@ public class DetachTagOptions extends GenericModel {
   /**
    * Gets the accountId.
    *
-   * The ID of the billing account of the untagged resource.  It is a required parameter if `tag_type` is set to
+   * The ID of the billing account of the untagged resource. It is a required parameter if `tag_type` is set to
    * `service`, otherwise it is inferred from the authorization IAM token.
    *
    * @return the accountId

--- a/modules/global-tagging/src/main/java/com/ibm/cloud/platform_services/global_tagging/v1/model/ListTagsOptions.java
+++ b/modules/global-tagging/src/main/java/com/ibm/cloud/platform_services/global_tagging/v1/model/ListTagsOptions.java
@@ -51,6 +51,8 @@ public class ListTagsOptions extends GenericModel {
     String DESC = "desc";
   }
 
+  protected String xRequestId;
+  protected String xCorrelationId;
   protected String transactionId;
   protected String impersonateUser;
   protected String accountId;
@@ -68,6 +70,8 @@ public class ListTagsOptions extends GenericModel {
    * Builder.
    */
   public static class Builder {
+    private String xRequestId;
+    private String xCorrelationId;
     private String transactionId;
     private String impersonateUser;
     private String accountId;
@@ -87,6 +91,8 @@ public class ListTagsOptions extends GenericModel {
      * @param listTagsOptions the instance to initialize the Builder with
      */
     private Builder(ListTagsOptions listTagsOptions) {
+      this.xRequestId = listTagsOptions.xRequestId;
+      this.xCorrelationId = listTagsOptions.xCorrelationId;
       this.transactionId = listTagsOptions.transactionId;
       this.impersonateUser = listTagsOptions.impersonateUser;
       this.accountId = listTagsOptions.accountId;
@@ -133,11 +139,35 @@ public class ListTagsOptions extends GenericModel {
     }
 
     /**
+     * Set the xRequestId.
+     *
+     * @param xRequestId the xRequestId
+     * @return the ListTagsOptions builder
+     */
+    public Builder xRequestId(String xRequestId) {
+      this.xRequestId = xRequestId;
+      return this;
+    }
+
+    /**
+     * Set the xCorrelationId.
+     *
+     * @param xCorrelationId the xCorrelationId
+     * @return the ListTagsOptions builder
+     */
+    public Builder xCorrelationId(String xCorrelationId) {
+      this.xCorrelationId = xCorrelationId;
+      return this;
+    }
+
+    /**
      * Set the transactionId.
      *
      * @param transactionId the transactionId
      * @return the ListTagsOptions builder
+     * @deprecated this method is deprecated and may be removed in a future release
      */
+    @Deprecated
     public Builder transactionId(String transactionId) {
       this.transactionId = transactionId;
       return this;
@@ -269,6 +299,8 @@ public class ListTagsOptions extends GenericModel {
   protected ListTagsOptions() { }
 
   protected ListTagsOptions(Builder builder) {
+    xRequestId = builder.xRequestId;
+    xCorrelationId = builder.xCorrelationId;
     transactionId = builder.transactionId;
     impersonateUser = builder.impersonateUser;
     accountId = builder.accountId;
@@ -293,13 +325,46 @@ public class ListTagsOptions extends GenericModel {
   }
 
   /**
+   * Gets the xRequestId.
+   *
+   * An alphanumeric string that is used to trace the request. The value  may include ASCII alphanumerics and any of
+   * following segment separators: space ( ), comma (,), hyphen, (-), and underscore (_) and may have a length up to
+   * 1024 bytes. The value is considered invalid and must be ignored if that value includes any other character or is
+   * longer than 1024 bytes or is fewer than 8 characters. If not specified or invalid, it is automatically replaced by
+   * a random (version 4) UUID.
+   *
+   * @return the xRequestId
+   */
+  public String xRequestId() {
+    return xRequestId;
+  }
+
+  /**
+   * Gets the xCorrelationId.
+   *
+   * An alphanumeric string that is used to trace the request as a part of a larger context: the same value is used for
+   * downstream requests and retries of those requests. The value may include ASCII alphanumerics and any of following
+   * segment separators: space ( ), comma (,), hyphen, (-), and underscore (_) and may have a length up to 1024 bytes.
+   * The value is considered invalid and must be ignored if that value includes any other character or is longer than
+   * 1024 bytes or is fewer than 8 characters. If not specified or invalid, it is automatically replaced by a random
+   * (version 4) UUID.
+   *
+   * @return the xCorrelationId
+   */
+  public String xCorrelationId() {
+    return xCorrelationId;
+  }
+
+  /**
    * Gets the transactionId.
    *
    * An alphanumeric string that can be used to trace a request across services. If not specified, it automatically
    * generated with the prefix "gst-".
    *
    * @return the transactionId
+   * @deprecated this method is deprecated and may be removed in a future release
    */
+  @Deprecated
   public String transactionId() {
     return transactionId;
   }

--- a/modules/global-tagging/src/test/java/com/ibm/cloud/platform_services/global_tagging/v1/GlobalTaggingTest.java
+++ b/modules/global-tagging/src/test/java/com/ibm/cloud/platform_services/global_tagging/v1/GlobalTaggingTest.java
@@ -80,6 +80,8 @@ public class GlobalTaggingTest {
 
     // Construct an instance of the ListTagsOptions model
     ListTagsOptions listTagsOptionsModel = new ListTagsOptions.Builder()
+      .xRequestId("testString")
+      .xCorrelationId("testString")
       .transactionId("testString")
       .impersonateUser("testString")
       .accountId("testString")
@@ -88,7 +90,7 @@ public class GlobalTaggingTest {
       .providers(java.util.Arrays.asList("ghost"))
       .attachedTo("testString")
       .offset(Long.valueOf("0"))
-      .limit(Long.valueOf("1"))
+      .limit(Long.valueOf("100"))
       .timeout(Long.valueOf("0"))
       .orderByName("asc")
       .attachedOnly(false)
@@ -117,7 +119,7 @@ public class GlobalTaggingTest {
     assertEquals(query.get("providers"), RequestUtils.join(java.util.Arrays.asList("ghost"), ","));
     assertEquals(query.get("attached_to"), "testString");
     assertEquals(Long.valueOf(query.get("offset")), Long.valueOf("0"));
-    assertEquals(Long.valueOf(query.get("limit")), Long.valueOf("1"));
+    assertEquals(Long.valueOf(query.get("limit")), Long.valueOf("100"));
     assertEquals(Long.valueOf(query.get("timeout")), Long.valueOf("0"));
     assertEquals(query.get("order_by_name"), "asc");
     assertEquals(Boolean.valueOf(query.get("attached_only")), Boolean.valueOf(false));
@@ -148,6 +150,8 @@ public class GlobalTaggingTest {
     CreateTagOptions createTagOptionsModel = new CreateTagOptions.Builder()
       .tagNames(java.util.Arrays.asList("testString"))
       .impersonateUser("testString")
+      .xRequestId("testString")
+      .xCorrelationId("testString")
       .transactionId("testString")
       .accountId("testString")
       .tagType("access")
@@ -204,6 +208,8 @@ public class GlobalTaggingTest {
 
     // Construct an instance of the DeleteTagAllOptions model
     DeleteTagAllOptions deleteTagAllOptionsModel = new DeleteTagAllOptions.Builder()
+      .xRequestId("testString")
+      .xCorrelationId("testString")
       .transactionId("testString")
       .providers("ghost")
       .impersonateUser("testString")
@@ -257,6 +263,8 @@ public class GlobalTaggingTest {
     // Construct an instance of the DeleteTagOptions model
     DeleteTagOptions deleteTagOptionsModel = new DeleteTagOptions.Builder()
       .tagName("testString")
+      .xRequestId("testString")
+      .xCorrelationId("testString")
       .transactionId("testString")
       .providers(java.util.Arrays.asList("ghost"))
       .impersonateUser("testString")
@@ -325,6 +333,8 @@ public class GlobalTaggingTest {
       .resources(java.util.Arrays.asList(resourceModel))
       .tagName("testString")
       .tagNames(java.util.Arrays.asList("testString"))
+      .xRequestId("testString")
+      .xCorrelationId("testString")
       .transactionId("testString")
       .impersonateUser("testString")
       .accountId("testString")
@@ -391,6 +401,8 @@ public class GlobalTaggingTest {
       .resources(java.util.Arrays.asList(resourceModel))
       .tagName("testString")
       .tagNames(java.util.Arrays.asList("testString"))
+      .xRequestId("testString")
+      .xCorrelationId("testString")
       .transactionId("testString")
       .impersonateUser("testString")
       .accountId("testString")

--- a/modules/global-tagging/src/test/java/com/ibm/cloud/platform_services/global_tagging/v1/model/AttachTagOptionsTest.java
+++ b/modules/global-tagging/src/test/java/com/ibm/cloud/platform_services/global_tagging/v1/model/AttachTagOptionsTest.java
@@ -43,6 +43,8 @@ public class AttachTagOptionsTest {
       .resources(java.util.Arrays.asList(resourceModel))
       .tagName("testString")
       .tagNames(java.util.Arrays.asList("testString"))
+      .xRequestId("testString")
+      .xCorrelationId("testString")
       .transactionId("testString")
       .impersonateUser("testString")
       .accountId("testString")
@@ -51,6 +53,8 @@ public class AttachTagOptionsTest {
     assertEquals(attachTagOptionsModel.resources(), java.util.Arrays.asList(resourceModel));
     assertEquals(attachTagOptionsModel.tagName(), "testString");
     assertEquals(attachTagOptionsModel.tagNames(), java.util.Arrays.asList("testString"));
+    assertEquals(attachTagOptionsModel.xRequestId(), "testString");
+    assertEquals(attachTagOptionsModel.xCorrelationId(), "testString");
     assertEquals(attachTagOptionsModel.transactionId(), "testString");
     assertEquals(attachTagOptionsModel.impersonateUser(), "testString");
     assertEquals(attachTagOptionsModel.accountId(), "testString");

--- a/modules/global-tagging/src/test/java/com/ibm/cloud/platform_services/global_tagging/v1/model/CreateTagOptionsTest.java
+++ b/modules/global-tagging/src/test/java/com/ibm/cloud/platform_services/global_tagging/v1/model/CreateTagOptionsTest.java
@@ -34,12 +34,16 @@ public class CreateTagOptionsTest {
     CreateTagOptions createTagOptionsModel = new CreateTagOptions.Builder()
       .tagNames(java.util.Arrays.asList("testString"))
       .impersonateUser("testString")
+      .xRequestId("testString")
+      .xCorrelationId("testString")
       .transactionId("testString")
       .accountId("testString")
       .tagType("access")
       .build();
     assertEquals(createTagOptionsModel.tagNames(), java.util.Arrays.asList("testString"));
     assertEquals(createTagOptionsModel.impersonateUser(), "testString");
+    assertEquals(createTagOptionsModel.xRequestId(), "testString");
+    assertEquals(createTagOptionsModel.xCorrelationId(), "testString");
     assertEquals(createTagOptionsModel.transactionId(), "testString");
     assertEquals(createTagOptionsModel.accountId(), "testString");
     assertEquals(createTagOptionsModel.tagType(), "access");

--- a/modules/global-tagging/src/test/java/com/ibm/cloud/platform_services/global_tagging/v1/model/DeleteTagAllOptionsTest.java
+++ b/modules/global-tagging/src/test/java/com/ibm/cloud/platform_services/global_tagging/v1/model/DeleteTagAllOptionsTest.java
@@ -32,12 +32,16 @@ public class DeleteTagAllOptionsTest {
   @Test
   public void testDeleteTagAllOptions() throws Throwable {
     DeleteTagAllOptions deleteTagAllOptionsModel = new DeleteTagAllOptions.Builder()
+      .xRequestId("testString")
+      .xCorrelationId("testString")
       .transactionId("testString")
       .providers("ghost")
       .impersonateUser("testString")
       .accountId("testString")
       .tagType("user")
       .build();
+    assertEquals(deleteTagAllOptionsModel.xRequestId(), "testString");
+    assertEquals(deleteTagAllOptionsModel.xCorrelationId(), "testString");
     assertEquals(deleteTagAllOptionsModel.transactionId(), "testString");
     assertEquals(deleteTagAllOptionsModel.providers(), "ghost");
     assertEquals(deleteTagAllOptionsModel.impersonateUser(), "testString");

--- a/modules/global-tagging/src/test/java/com/ibm/cloud/platform_services/global_tagging/v1/model/DeleteTagOptionsTest.java
+++ b/modules/global-tagging/src/test/java/com/ibm/cloud/platform_services/global_tagging/v1/model/DeleteTagOptionsTest.java
@@ -33,6 +33,8 @@ public class DeleteTagOptionsTest {
   public void testDeleteTagOptions() throws Throwable {
     DeleteTagOptions deleteTagOptionsModel = new DeleteTagOptions.Builder()
       .tagName("testString")
+      .xRequestId("testString")
+      .xCorrelationId("testString")
       .transactionId("testString")
       .providers(java.util.Arrays.asList("ghost"))
       .impersonateUser("testString")
@@ -40,6 +42,8 @@ public class DeleteTagOptionsTest {
       .tagType("user")
       .build();
     assertEquals(deleteTagOptionsModel.tagName(), "testString");
+    assertEquals(deleteTagOptionsModel.xRequestId(), "testString");
+    assertEquals(deleteTagOptionsModel.xCorrelationId(), "testString");
     assertEquals(deleteTagOptionsModel.transactionId(), "testString");
     assertEquals(deleteTagOptionsModel.providers(), java.util.Arrays.asList("ghost"));
     assertEquals(deleteTagOptionsModel.impersonateUser(), "testString");

--- a/modules/global-tagging/src/test/java/com/ibm/cloud/platform_services/global_tagging/v1/model/DetachTagOptionsTest.java
+++ b/modules/global-tagging/src/test/java/com/ibm/cloud/platform_services/global_tagging/v1/model/DetachTagOptionsTest.java
@@ -43,6 +43,8 @@ public class DetachTagOptionsTest {
       .resources(java.util.Arrays.asList(resourceModel))
       .tagName("testString")
       .tagNames(java.util.Arrays.asList("testString"))
+      .xRequestId("testString")
+      .xCorrelationId("testString")
       .transactionId("testString")
       .impersonateUser("testString")
       .accountId("testString")
@@ -51,6 +53,8 @@ public class DetachTagOptionsTest {
     assertEquals(detachTagOptionsModel.resources(), java.util.Arrays.asList(resourceModel));
     assertEquals(detachTagOptionsModel.tagName(), "testString");
     assertEquals(detachTagOptionsModel.tagNames(), java.util.Arrays.asList("testString"));
+    assertEquals(detachTagOptionsModel.xRequestId(), "testString");
+    assertEquals(detachTagOptionsModel.xCorrelationId(), "testString");
     assertEquals(detachTagOptionsModel.transactionId(), "testString");
     assertEquals(detachTagOptionsModel.impersonateUser(), "testString");
     assertEquals(detachTagOptionsModel.accountId(), "testString");

--- a/modules/global-tagging/src/test/java/com/ibm/cloud/platform_services/global_tagging/v1/model/ListTagsOptionsTest.java
+++ b/modules/global-tagging/src/test/java/com/ibm/cloud/platform_services/global_tagging/v1/model/ListTagsOptionsTest.java
@@ -32,6 +32,8 @@ public class ListTagsOptionsTest {
   @Test
   public void testListTagsOptions() throws Throwable {
     ListTagsOptions listTagsOptionsModel = new ListTagsOptions.Builder()
+      .xRequestId("testString")
+      .xCorrelationId("testString")
       .transactionId("testString")
       .impersonateUser("testString")
       .accountId("testString")
@@ -40,11 +42,13 @@ public class ListTagsOptionsTest {
       .providers(java.util.Arrays.asList("ghost"))
       .attachedTo("testString")
       .offset(Long.valueOf("0"))
-      .limit(Long.valueOf("1"))
+      .limit(Long.valueOf("100"))
       .timeout(Long.valueOf("0"))
       .orderByName("asc")
       .attachedOnly(false)
       .build();
+    assertEquals(listTagsOptionsModel.xRequestId(), "testString");
+    assertEquals(listTagsOptionsModel.xCorrelationId(), "testString");
     assertEquals(listTagsOptionsModel.transactionId(), "testString");
     assertEquals(listTagsOptionsModel.impersonateUser(), "testString");
     assertEquals(listTagsOptionsModel.accountId(), "testString");
@@ -53,7 +57,7 @@ public class ListTagsOptionsTest {
     assertEquals(listTagsOptionsModel.providers(), java.util.Arrays.asList("ghost"));
     assertEquals(listTagsOptionsModel.attachedTo(), "testString");
     assertEquals(listTagsOptionsModel.offset(), Long.valueOf("0"));
-    assertEquals(listTagsOptionsModel.limit(), Long.valueOf("1"));
+    assertEquals(listTagsOptionsModel.limit(), Long.valueOf("100"));
     assertEquals(listTagsOptionsModel.timeout(), Long.valueOf("0"));
     assertEquals(listTagsOptionsModel.orderByName(), "asc");
     assertEquals(listTagsOptionsModel.attachedOnly(), Boolean.valueOf(false));


### PR DESCRIPTION
fix(Global Search/Tagging): regenerated services with latest API definition

## PR summary
defined tracing headers for GhoST search and tagging apis.
deprecated transaction-id header parameter



<img width="727" alt="Screenshot 2023-09-20 at 12 06 59" src="https://github.com/IBM/platform-services-java-sdk/assets/55192611/645edcda-a068-4a02-bd75-58f72a8fd312">



## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [ ] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## Current vs new behavior  
<!-- Please describe the current behavior that you are modifying and the new behavior. -->

## Does this PR introduce a breaking change?    
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->