### PR TITLE
fix: bump java-sdk-core to 9.18.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,10 +14,10 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <!-- This is the version associated with the Java core. -->
-    <sdk-core-version>9.18.6</sdk-core-version>
+    <sdk-core-version>9.18.7</sdk-core-version>
 
     <testng-version>7.8.0</testng-version>
-    <okhttp3-version>4.11.0</okhttp3-version>
+    <okhttp3-version>4.12.0</okhttp3-version>
     <surefire-version>3.1.2</surefire-version>
     <jacoco-plugin-version>0.8.10</jacoco-plugin-version>
     <maven-deploy-plugin-version>3.1.1</maven-deploy-plugin-version>


### PR DESCRIPTION
## PR summary
This PR bumps the java core version to 9.18.7 and also bumps the okhttp version to 4.12.0

## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## Current vs new behavior  
<!-- Please describe the current behavior that you are modifying and the new behavior. -->

## Does this PR introduce a breaking change?    
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->