### PR TITLE
build: bump java core to 9.20.0

### DIFF
--- a/build/generateJavadocIndex.sh
+++ b/build/generateJavadocIndex.sh
@@ -23,7 +23,7 @@ echo '<!DOCTYPE html>
 
     <p>Javadoc by release:</p>
     <ul>'
-echo ${TRAVIS_BRANCH} | sed 's/^.*/        <li><a href="docs\/&">Latest release<\/a><\/li>/'
+echo ${TRAVIS_TAG} | sed 's/^.*/        <li><a href="docs\/&">Latest release<\/a><\/li>/'
 ls docs | grep --invert-match index.html | sed 's/^.*/        <li><a href="docs\/&">&<\/a><\/li>/'
 echo '    </ul>
 </div>

--- a/build/publishJavadoc.sh
+++ b/build/publishJavadoc.sh
@@ -3,7 +3,7 @@
 # Publish javadocs only for a tagged-release.
 if [[ -n "${TRAVIS_TAG}" ]]; then
 
-    printf "\n>>>>> Publishing javadoc for release build: repo=%s branch=%s build_num=%s job_num=%s\n" ${TRAVIS_REPO_SLUG} ${TRAVIS_BRANCH} ${TRAVIS_BUILD_NUMBER} ${TRAVIS_JOB_NUMBER} 
+    printf "\n>>>>> Publishing javadoc for release build: repo=%s release=%s build_num=%s job_num=%s\n" ${TRAVIS_REPO_SLUG} ${TRAVIS_TAG} ${TRAVIS_BUILD_NUMBER} ${TRAVIS_JOB_NUMBER} 
 
     printf "\n>>>>> Cloning repository's gh-pages branch into directory 'gh-pages'\n"
     rm -fr ./gh-pages
@@ -14,22 +14,22 @@ if [[ -n "${TRAVIS_TAG}" ]]; then
     pushd gh-pages
     
     # Create a new directory for this branch/tag and copy the javadocs there.
-    printf "\n>>>>> Copying javadocs to new directory: docs/%s\n" ${TRAVIS_BRANCH}
-    rm -rf docs/${TRAVIS_BRANCH}
-    mkdir -p docs/${TRAVIS_BRANCH}
-    cp -rf ../target/site/apidocs/* docs/${TRAVIS_BRANCH}
+    printf "\n>>>>> Copying javadocs to new directory: docs/%s\n" ${TRAVIS_TAG}
+    rm -rf docs/${TRAVIS_TAG}
+    mkdir -p docs/${TRAVIS_TAG}
+    cp -rf ../target/site/apidocs/* docs/${TRAVIS_TAG}
 
     printf "\n>>>>> Generating gh-pages index.html...\n"
     ../build/generateJavadocIndex.sh > index.html
 
     printf "\n>>>>> Committing new javadoc...\n"
     git add -f .
-    git commit -m "docs: latest javadoc for ${TRAVIS_BRANCH} (${TRAVIS_COMMIT})"
+    git commit -m "docs: latest javadoc for ${TRAVIS_TAG} (${TRAVIS_COMMIT})"
     git push -f origin gh-pages
 
     popd
 
-    printf "\n>>>>> Published javadoc for release build: repo=%s branch=%s build_num=%s job_num=%s\n"  ${TRAVIS_REPO_SLUG} ${TRAVIS_BRANCH} ${TRAVIS_BUILD_NUMBER} ${TRAVIS_JOB_NUMBER} 
+    printf "\n>>>>> Published javadoc for release build: repo=%s release=%s build_num=%s job_num=%s\n"  ${TRAVIS_REPO_SLUG} ${TRAVIS_TAG} ${TRAVIS_BUILD_NUMBER} ${TRAVIS_JOB_NUMBER} 
 
 else
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <!-- This is the version associated with the Java core. -->
-    <sdk-core-version>9.18.7</sdk-core-version>
+    <sdk-core-version>9.20.0</sdk-core-version>
 
     <testng-version>7.8.0</testng-version>
     <okhttp3-version>4.12.0</okhttp3-version>


### PR DESCRIPTION
## PR summary
Bumps the java core version to 9.20.0, and tweaks the scripts used to publish javadocs slightly so that they consistently use the TRAVIS_TAG environment variable instead of a combination of TRAVIS_TAG and TRAVIS_BRANCH.

## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [ ] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## Current vs new behavior  
<!-- Please describe the current behavior that you are modifying and the new behavior. -->

## Does this PR introduce a breaking change?    
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->