### PR TITLE
fix: add javadoc publish script

### DIFF
--- a/build/publishJavadoc-gha.sh
+++ b/build/publishJavadoc-gha.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Required environment variables:
+# GH_TOKEN
+# GH_REPO_SLUG
+# GH_TAG
+
+printf "\n>>>>> Publishing javadoc for release build: repo=%s tag=%s\n" ${GH_REPO_SLUG} ${GH_TAG}
+
+printf "\n>>>>> Cloning repository's gh-pages branch into directory 'gh-pages'\n"
+rm -fr ./gh-pages
+git config --global user.email "devxsdk@us.ibm.com"
+git config --global user.name "ibm-devx-sdk"
+git clone --branch=gh-pages https://${GH_TOKEN}@github.com/IBM/platform-services-java-sdk.git gh-pages
+
+printf "\n>>>>> Finished cloning...\n"
+
+pushd gh-pages
+
+# Create a new directory for this branch/tag and copy the javadocs there.
+printf "\n>>>>> Copying javadocs to new directory: docs/%s\n" ${GH_TAG}
+rm -rf docs/${GH_TAG}
+mkdir -p docs/${GH_TAG}
+cp -rf ../target/site/apidocs/* docs/${GH_TAG}
+
+printf "\n>>>>> Generating gh-pages index.html...\n"
+../build/generateJavadocIndex.sh > index.html
+
+printf "\n>>>>> Committing new javadoc...\n"
+git add -f .
+git commit -m "docs: latest javadoc for ${GH_TAG}"
+git push -f origin gh-pages
+
+popd
+
+printf "\n>>>>> Published javadoc for release build: repo=%s tag=%s\n"  ${GH_REPO_SLUG} ${GH_TAG}
+


### PR DESCRIPTION
## PR summary
When I introduced GH actions to the project, I forgot to include the new script to publish javadocs.  This PR adds it.

## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [ ] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## Current vs new behavior  
<!-- Please describe the current behavior that you are modifying and the new behavior. -->

## Does this PR introduce a breaking change?    
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->