### PR TITLE
build: add dependecy cooldown logic to renovate config

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 package-lock=false
+minimummin-release-age=3

--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
   "prConcurrentLimit": 4,
-  "reviewers": ["Norbert-Biczo", "Lidia-Tarcza", "Andras-Felleg"],
+  "reviewers": ["pyrooka", "diatrcz", "Andris28"],
   "packageRules": [
     {
       "matchManagers": ["maven"],

--- a/renovate.json
+++ b/renovate.json
@@ -6,12 +6,13 @@
   "packageRules": [
     {
       "matchManagers": ["maven"],
-      "groupName": "Java dependencies",
-      "minimumReleaseAge": "3 days"
+      "minimumReleaseAge": "3 days",
+      "description": "Wait 3 days before updating Java dependencies"
     },
     {
       "matchManagers": ["npm"],
-      "extends": ["security:minimumReleaseAgeNpm"]
+      "extends": ["security:minimumReleaseAgeNpm"],
+      "description": "Wait 3 days before updating semantic release dependencies"
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,17 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"]
+  "extends": ["config:recommended"],
+  "prConcurrentLimit": 4,
+  "reviewers": ["Norbert-Biczo", "Lidia-Tarcza", "Andras-Felleg"],
+  "packageRules": [
+    {
+      "matchManagers": ["maven"],
+      "groupName": "Java dependencies",
+      "minimumReleaseAge": "3 days"
+    },
+    {
+      "matchManagers": ["npm"],
+      "extends": ["security:minimumReleaseAgeNpm"]
+    }
+  ]
 }


### PR DESCRIPTION
In this commit we add dependency cooldown logic
that enables us to update more frequently and worry
less about compromised packages.